### PR TITLE
Add WebAssembly (Emscripten) port of the 65C02 emulator

### DIFF
--- a/emulator/Badger6502VMLib/badgervmpal.cpp
+++ b/emulator/Badger6502VMLib/badgervmpal.cpp
@@ -9,8 +9,10 @@
 #elif defined(PLATFORM_WINDOWS)
 #include <chrono>
 #include <thread>
+#elif defined(PLATFORM_WEB)
+#include <cstring>
 #else
-#error Must define either PLATFORM_PICO or PLATFORM_WINDOWS
+#error Must define either PLATFORM_PICO, PLATFORM_WINDOWS or PLATFORM_WEB
 #endif
 
 
@@ -20,6 +22,9 @@ void pal_sleep(uint32_t milliseconds)
     sleep_ms(milliseconds);
 #elif defined(PLATFORM_WINDOWS)
     this_thread::sleep_for(chrono::milliseconds(milliseconds));
+#elif defined(PLATFORM_WEB)
+    // The browser drives timing via requestAnimationFrame; blocking would freeze the tab.
+    (void)milliseconds;
 #endif
 }
 
@@ -38,6 +43,8 @@ void pal_sprintf(char *dest, const char *fmt, ...)
 #pragma warning (restore : 4996)
 #elif defined(PLATFORM_PICO)
     vsprintf(dest, fmt, ap);
+#elif defined(PLATFORM_WEB)
+    vsprintf(dest, fmt, ap);
 #endif
     va_end(ap);
 }
@@ -48,6 +55,8 @@ void pal_debugbreak()
     __debugbreak();
 #elif defined(PLATFORM_PICO)
     
+#elif defined(PLATFORM_WEB)
+
 #endif
 }
 
@@ -56,6 +65,8 @@ void pal_strncpy(char *dest, const char *src, int cch)
 #if defined(PLATFORM_WINDOWS)
     strncpy_s(dest, _pal_countof(dest), src, cch);
 #elif defined(PLATFORM_PICO)
+    strncpy(dest, src, cch);
+#elif defined(PLATFORM_WEB)
     strncpy(dest, src, cch);
 #endif
 }
@@ -92,6 +103,12 @@ bool pal_loadbinary(const char *szFileName, uint8_t *dest)
         memcpy(&dest[0x8000], pFile, dataSize);
         return true;  
 
+    #elif defined(PLATFORM_WEB)
+
+        // The web bridge loads ROM bytes directly into VM::GetData(); no filesystem.
+        (void)szFileName; (void)dest;
+        return false;
+
     #endif
 }
 
@@ -123,6 +140,12 @@ bool pal_loadromdisk(const char *szFileName, uint8_t *dest)
 
         return false;
 
+    #elif defined(PLATFORM_WEB)
+
+        // The web bridge loads the romdisk image directly into VM::GetRomDisk().
+        (void)szFileName; (void)dest;
+        return false;
+
     #endif
 }
 
@@ -134,6 +157,9 @@ void pal_initromdisk(uint8_t **romdisk)
         memset(*romdisk, 0, sizeof(int8_t) * _pal_countof(*romdisk));
     #elif defined(PLATFORM_PICO)
         *romdisk = (uint8_t *) find_embedded_file("data/loderun.bin", nullptr);
+    #elif defined(PLATFORM_WEB)
+        *romdisk = new uint8_t[0x80000];
+        memset(*romdisk, 0, 0x80000);
     #endif
 }
 
@@ -142,5 +168,7 @@ void pal_freeromdisk(uint8_t **romdisk)
     #if defined(PLATFORM_WINDOWS)
         delete [] *romdisk;
     #elif defined(PLATFORM_PICO)
+    #elif defined(PLATFORM_WEB)
+        delete [] *romdisk;
     #endif
 }

--- a/emulator/Badger6502VMLib/badgervmpal.h
+++ b/emulator/Badger6502VMLib/badgervmpal.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#if defined(__EMSCRIPTEN__) && !defined(PLATFORM_WEB)
+#define PLATFORM_WEB
+#endif
+
 #include "vm.h"
 
 

--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -1,4 +1,6 @@
+#if defined(PLATFORM_WINDOWS)
 #include "windows.h"
+#endif
 
 #include "vm.h"
 #include "badgervmpal.h"
@@ -124,6 +126,12 @@ void VM::DoSoftSwitches(uint16_t address, bool write)
 	{
 	case MM_SS_KEYBD_STROBE:
 		_via1->SignalPin(VIA::CB1);
+#if defined(PLATFORM_WEB)
+		// Apple II semantics: any access to $C010 clears the keyboard strobe
+		// (bit 7 of $C000). The Windows/Pico hosts manage this differently, so
+		// this is web-only and additive.
+		_data[MM_SS_KEYBOARD] &= 0x7F;
+#endif
 		break;
 
 	case MM_SS_JOYSTICK:

--- a/emulator/MockMicroSD/MappedFile.cpp
+++ b/emulator/MockMicroSD/MappedFile.cpp
@@ -1,6 +1,90 @@
 #include "pch.h"
 #include "MappedFile.h"
 
+#if defined(__EMSCRIPTEN__)
+
+void MMappedFile::InitLogical(uint32_t fileSizeBytes)
+{
+	_fileSize = fileSizeBytes;
+	_sectors.clear();
+	_cacheSector = 0xFFFFFFFF;
+	_cacheBuf = nullptr;
+	_initialized = true;
+}
+
+void MMappedFile::LoadSector(uint32_t sectorIndex, const uint8_t* data, uint32_t len)
+{
+	if (len > kSectorSize)
+	{
+		len = kSectorSize;
+	}
+
+	std::vector<uint8_t>& sec = _sectors[sectorIndex];
+	sec.assign(kSectorSize, 0);
+	memcpy(sec.data(), data, len);
+}
+
+bool MMappedFile::IsInitialized()
+{
+	return _initialized;
+}
+
+uint8_t MMappedFile::GetData(uint32_t address)
+{
+	if (!_initialized)
+	{
+		return 0;
+	}
+
+	uint32_t sector = address / kSectorSize;
+	uint32_t offset = address % kSectorSize;
+
+	if (sector != _cacheSector)
+	{
+		auto it = _sectors.find(sector);
+		_cacheBuf = (it == _sectors.end()) ? nullptr : &it->second;
+		_cacheSector = sector;
+	}
+
+	if (_cacheBuf == nullptr)
+	{
+		// Never-written sector reads back as zero (the image is mostly zeros).
+		return 0;
+	}
+
+	return (*_cacheBuf)[offset];
+}
+
+bool MMappedFile::SetData(uint32_t address, uint8_t byte)
+{
+	if (!_initialized)
+	{
+		return false;
+	}
+
+	uint32_t sector = address / kSectorSize;
+	uint32_t offset = address % kSectorSize;
+
+	std::vector<uint8_t>& sec = _sectors[sector];
+	if (sec.empty())
+	{
+		sec.assign(kSectorSize, 0);
+	}
+	sec[offset] = byte;
+
+	// Keep the read cache coherent with a fresh write.
+	_cacheSector = sector;
+	_cacheBuf = &sec;
+	return true;
+}
+
+uint32_t MMappedFile::GetFileSize()
+{
+	return _fileSize;
+}
+
+#else
+
 MMappedFile::~MMappedFile()
 {
 	UnmapViewOfFile(_pBuf);
@@ -79,3 +163,5 @@ DWORD MMappedFile::GetFileSize()
 {
 	return _dwFileSize;
 }
+
+#endif

--- a/emulator/MockMicroSD/MappedFile.h
+++ b/emulator/MockMicroSD/MappedFile.h
@@ -4,6 +4,36 @@
 class MMappedFile
 {
 public:
+#if defined(__EMSCRIPTEN__)
+	// Web build: there is no Win32 memory-mapped file. The 2 GB SD image is
+	// almost entirely zeros, so it is backed by a lazily-allocated map of
+	// 512-byte sectors (see web/make_sd_sparse.py + SDCard::LoadSparseImage).
+	~MMappedFile() = default;
+
+	// Establish the logical image size (bytes) without allocating it. Reads of
+	// never-written sectors return 0; writes allocate the sector on demand.
+	void InitLogical(uint32_t fileSizeBytes);
+
+	// Populate one 512-byte sector from the sparse image.
+	void LoadSector(uint32_t sectorIndex, const uint8_t* data, uint32_t len);
+
+	uint8_t GetData(uint32_t address);
+	bool SetData(uint32_t address, uint8_t byte);
+
+	bool IsInitialized();
+	uint32_t GetFileSize();
+
+private:
+	static const uint32_t kSectorSize = 512;
+
+	bool _initialized = false;
+	uint32_t _fileSize = 0;
+	std::unordered_map<uint32_t, std::vector<uint8_t>> _sectors;
+
+	// Single-entry cache so a sequential read does not re-hash on every bit.
+	uint32_t _cacheSector = 0xFFFFFFFF;
+	std::vector<uint8_t>* _cacheBuf = nullptr;
+#else
 	~MMappedFile();
 
 	uint32_t MapFile(wchar_t* wzFileName);
@@ -19,5 +49,6 @@ private:
 	HANDLE _hBaseFile = INVALID_HANDLE_VALUE;
 	uint8_t* _pBuf;
 	DWORD _dwFileSize = 0;
+#endif
 
 };

--- a/emulator/MockMicroSD/SDCard.cpp
+++ b/emulator/MockMicroSD/SDCard.cpp
@@ -16,10 +16,59 @@ sd_cmd41_bytes
 
 const int c_clusterSize = 512;
 
+#if defined(__EMSCRIPTEN__)
+bool SDCard::LoadSparseImage(const uint8_t* data, uint32_t len)
+{
+	// SDSP container (see web/make_sd_sparse.py):
+	//   "SDSP" | u32 secSize | u32 totalSectors | u32 entries
+	//   then entries * (u32 sectorIndex + secSize bytes)
+	if (data == nullptr || len < 16)
+	{
+		return false;
+	}
+	if (!(data[0] == 'S' && data[1] == 'D' && data[2] == 'S' && data[3] == 'P'))
+	{
+		return false;
+	}
+
+	auto rd32 = [](const uint8_t* p) -> uint32_t {
+		return (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+			| ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+	};
+
+	uint32_t secSize = rd32(data + 4);
+	uint32_t totalSectors = rd32(data + 8);
+	uint32_t entries = rd32(data + 12);
+
+	if (secSize != (uint32_t)c_clusterSize)
+	{
+		return false;
+	}
+
+	_mappedFile.InitLogical(totalSectors * secSize);
+
+	uint32_t off = 16;
+	for (uint32_t i = 0; i < entries; i++)
+	{
+		if (off + 4 + secSize > len)
+		{
+			return false;
+		}
+		uint32_t sectorIndex = rd32(data + off);
+		off += 4;
+		_mappedFile.LoadSector(sectorIndex, data + off, secSize);
+		off += secSize;
+	}
+
+	_initialized = true;
+	return true;
+}
+#else
 uint32_t SDCard::LoadImageFile(wchar_t* filename)
 {
 	return _mappedFile.MapFile(filename);
 }
+#endif
 
 void SDCard::SetCS(bool level)
 {
@@ -291,4 +340,8 @@ void SDCard::SetSector()
 	{
 		_pos = _mappedFile.GetFileSize() - 1;
 	}
+
+#if defined(__EMSCRIPTEN__)
+	_sectorAccessCount++;
+#endif
 }

--- a/emulator/MockMicroSD/SDCard.h
+++ b/emulator/MockMicroSD/SDCard.h
@@ -4,11 +4,22 @@
 class SDCard
 {	
 public:
+#if defined(__EMSCRIPTEN__)
+	// Web build: load the compact sparse image produced by make_sd_sparse.py
+	// (SDSP container) into the in-memory sector map. Returns true on success.
+	bool LoadSparseImage(const uint8_t* data, uint32_t len);
+#else
 	uint32_t LoadImageFile(wchar_t* filename);
+#endif
 	void SetCS(bool high);
 	void SetMOSI(bool high);
 	void SetSCK(bool high);
 	bool GetMISO();
+#if defined(__EMSCRIPTEN__)
+	// Number of sector reads/writes issued by the guest (CMD17/CMD24). Lets the
+	// web test prove the ROM's FAT32 driver actually touched the SD image.
+	uint32_t GetSectorAccessCount() const { return _sectorAccessCount; }
+#endif
 
 private:
 
@@ -49,6 +60,10 @@ private:
 	
 	uint32_t _sector = 0;
 	uint32_t _pos    = 0;
+
+#if defined(__EMSCRIPTEN__)
+	uint32_t _sectorAccessCount = 0;
+#endif
 
 	MMappedFile _mappedFile;
 };

--- a/emulator/MockMicroSD/pch.h
+++ b/emulator/MockMicroSD/pch.h
@@ -8,9 +8,21 @@
 #define PCH_H
 
 
+#if defined(__EMSCRIPTEN__)
+// Web build: no Win32. Pull in the portable shims and the standard containers
+// used by the in-memory (sparse) SD backing.
+#include <stdint.h>
+#include <cstring>
+#include <vector>
+#include <unordered_map>
+#include "web_compat.h"
+#include "MappedFile.h"
+#include "SDCard.h"
+#else
 #include <windows.h>
 #include <stdint.h>
 #include "framework.h"
 #include "mappedfile.h"
 #include "sdcard.h"
+#endif
 #endif //PCH_H

--- a/emulator/WozLib/DriveEmulator.cpp
+++ b/emulator/WozLib/DriveEmulator.cpp
@@ -1,6 +1,10 @@
 #include "DriveEmulator.h"
+#if defined(__EMSCRIPTEN__)
+#include "web_compat.h"
+#else
 #include <Windows.h>
 #include <debugapi.h>
+#endif
 /*
 * https://stackoverflow.com/questions/69369122/apple-iie-6502-assembly-accessing-disk
 *

--- a/emulator/WozLib/WozDisk.cpp
+++ b/emulator/WozLib/WozDisk.cpp
@@ -1,6 +1,10 @@
 #include "WozDisk.h"
+#if defined(__EMSCRIPTEN__)
+#include "web_compat.h"
+#else
 #include <Windows.h>
 #include <debugapi.h>
+#endif
 
 char buf[255];
 

--- a/emulator/WozLib/WozFile.cpp
+++ b/emulator/WozLib/WozFile.cpp
@@ -1,6 +1,10 @@
 #include "wozfile.h"
+#if defined(__EMSCRIPTEN__)
+#include "web_compat.h"
+#else
 #include <Windows.h>
 #include <debugapi.h>
+#endif
 
 const char* c_WOZ2Header = "WOZ2";
 const char* c_WOZ1Header = "WOZ1";

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,6 @@
+# Build outputs (regenerate via web/build.ps1)
+badger6502.js
+badger6502.wasm
+
+# Staged copies of ROM/font/romdisk images (originals live in emulator/Data)
+data/

--- a/web/README.md
+++ b/web/README.md
@@ -19,17 +19,21 @@ Pico builds compile and behave exactly as before.
 - Keyboard input via the Apple-II `$C000` / `$C010` strobe mechanism.
 - Romdisk access through the `$C300` hardware window, and a **Load Lode Runner**
   button that launches `loderun.bin` from the romdisk.
+- **Micro-SD card** (bit-banged SPI through VIA1) backing a FAT32 disk image. A
+  **Mount SD** button drops into the ROM's DOS shell (`>` prompt) and lists the
+  card; from there `DIR`, `CAT`, `CD <dir>`, `BLOAD`/`BRUN <file>` all work.
 
 ## Layout
 
 | File | Purpose |
 | --- | --- |
-| `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/registers, and produces the RGBA framebuffer. |
-| `web_compat.h` | Tiny shims so `WozLib`'s MSVC-isms (`OutputDebugStringA`, `sprintf_s`, `fopen_s`, `_ASSERT`, …) compile under Emscripten. |
-| `build.ps1` | Compiles the core + WozLib + bridge to `badger6502.js` / `.wasm` and stages the data files. |
+| `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/registers, drives the SD card, and produces the RGBA framebuffer. |
+| `web_compat.h` | Tiny shims so `WozLib` + `MockMicroSD`'s MSVC-isms (`OutputDebugString`, `sprintf_s`, `swprintf_s`, `fopen_s`, `_ASSERT`, …) compile under Emscripten. |
+| `make_sd_sparse.py` | Streams `emulator/Data/sd.zip` (a 2GB, mostly-zero FAT32 image) into a compact `data/sd.sparse` keeping only the ~11.5MB of non-zero sectors. |
+| `build.ps1` | Compiles the core + WozLib + MockMicroSD + bridge to `badger6502.js` / `.wasm`, stages the data files, and generates `sd.sparse`. |
 | `index.html` | Canvas UI + `requestAnimationFrame` driver + keyboard. |
 | `serve.ps1` | Starts `python -m http.server` (defaults to port 8011). |
-| `test_*.cjs` | Headless Node validations (boot, render, keyboard, screen decode, loderun). |
+| `test_*.cjs` | Headless Node validations (boot, render, keyboard, screen decode, loderun, SD). |
 
 Build outputs (`badger6502.js`, `badger6502.wasm`) and the staged `data/`
 copies are git-ignored; regenerate them with `build.ps1`.
@@ -56,6 +60,7 @@ This compiles these sources with `-DPLATFORM_WEB`:
 ```
 Badger6502VMLib: vm cpu Instructions acia via PS2Keyboard badgervmpal
 WozLib:          DriveEmulator WozDisk WozFile
+MockMicroSD:     SDCard MappedFile
 bridge:          web_bridge.cpp
 ```
 
@@ -63,7 +68,8 @@ bridge:          web_bridge.cpp
 `-std=c++17 -O2 -lembind -sMODULARIZE=1 -sEXPORT_NAME=createBadgerVM
 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,node`. The data files
 (`badger6502.bin`, `fontrom.dat`, `loderun.bin`) are copied from
-`emulator/Data` into `web/data`.
+`emulator/Data` into `web/data`, and `sd.sparse` is generated from
+`emulator/Data/sd.zip` (first run only; ~20s).
 
 ## Run in the browser
 
@@ -73,7 +79,11 @@ cd web
 ```
 
 Open <http://localhost:8011/index.html>, click the canvas, and type. Press
-**Load Lode Runner** to launch the game from the romdisk.
+**Load Lode Runner** to launch the game from the romdisk. Press **Mount SD** to
+mount the micro-SD card and enter the DOS shell — it runs the monitor command
+`EC5CG` (Go to `$EC5C`, the `dos` routine) which mounts the FAT32 image and
+prints a `>` prompt, then auto-runs `DIR`. Type `CAT`, `CD <dir>`,
+`BRUN <file>`, etc. to use the card.
 
 > Port 8011 is used because 8000 is taken on this machine.
 
@@ -86,6 +96,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web\test_keyboard.cjs    # monitor echoes typed commands
 & $node web\test_screen_text.cjs # decode the text screen to ASCII
 & $node web\test_loderun.cjs     # romdisk $C300 readback + Lode Runner runs in hi-res
+& $node web\test_sd.cjs          # mount the SD card + DIR lists the FAT32 root
 ```
 
 ## ROM load recipe (mirrors the WinUI host)
@@ -109,3 +120,25 @@ loads into the romdisk and, in its dev path, copies into RAM at `$0800`. The web
 bridge mirrors this: `romDiskToRam(0x0800, 0, len)` then `setPC(0x0800)`. The
 program switches into hi-res and paints the screen. The same romdisk is also
 readable through the `$C300` hardware window (`writeBus`/`readBus`).
+
+## How the micro-SD card works
+
+The card is a bit-banged SPI device wired to VIA1's port-A register, exactly like
+the WinUI host (`MainWindow.xaml.cpp`). Each CPU write to `$C201`/`$C20F` clocks
+the SD state machine (`emulator/MockMicroSD/SDCard.cpp`): `CS`=bit4, `SCK`=bit3,
+`MOSI`=bit2, and the resulting `MISO`=bit1 is folded back into the register. The
+bridge installs this pump via `VM::CallbackWriteMemory`.
+
+The disk image (`emulator/Data/sd.zip`) decompresses to a **2GB** FAT32 image
+that is almost entirely zeros — far too large to fetch or allocate in a browser.
+`make_sd_sparse.py` streams it straight out of the zip and emits only the
+~23k non-zero 512-byte sectors as `data/sd.sparse` (~11.5MB, an `SDSP`
+container). The Emscripten branch of `MMappedFile` (`MockMicroSD/MappedFile.cpp`)
+backs the 2GB logical image with a lazily-allocated `unordered_map<sector,
+512 bytes>`; never-written sectors read back as zero.
+
+At runtime the page lazily fetches `sd.sparse`, hands it to `loadSD()`
+(`SDCard::LoadSparseImage`), and the ROM's own FAT32 driver (`fat32_start` →
+`fat32_dir`) reads the card over SPI. `test_sd.cjs` proves the round trip: it
+enters the shell, runs `DIR`, and asserts real `<DIR>` folders and `PRG` files
+come back along with a non-zero sector-read count.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,111 @@
+# 3ric — Apple-II-clone 65C02 emulator in the browser (WebAssembly)
+
+This folder is a self-contained Emscripten/WebAssembly port of the `3ric` 65C02
+Apple-II-clone emulator. It compiles the existing C++ VM core
+(`emulator/Badger6502VMLib`) and disk library (`emulator/WozLib`) to WebAssembly,
+boots the real 512KB ROM, renders Apple-II text/hi-res/lo-res video to an HTML
+`<canvas>`, and feeds keystrokes through the memory-mapped keyboard at `$C000`.
+
+Everything here is additive. The shared VM/WozLib sources gained only
+`__EMSCRIPTEN__` / `PLATFORM_WEB`-guarded branches, so the Windows (WinUI) and
+Pico builds compile and behave exactly as before.
+
+## What works
+
+- Boots the unmodified `badger6502.bin` ROM to the monitor.
+- Hi-res color, lo-res color, and 40×24 text rendering — ported verbatim from
+  the WinUI host renderer (`MainWindow.xaml.cpp`) into the bridge so the color /
+  fringe logic is identical.
+- Keyboard input via the Apple-II `$C000` / `$C010` strobe mechanism.
+- Romdisk access through the `$C300` hardware window, and a **Load Lode Runner**
+  button that launches `loderun.bin` from the romdisk.
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/registers, and produces the RGBA framebuffer. |
+| `web_compat.h` | Tiny shims so `WozLib`'s MSVC-isms (`OutputDebugStringA`, `sprintf_s`, `fopen_s`, `_ASSERT`, …) compile under Emscripten. |
+| `build.ps1` | Compiles the core + WozLib + bridge to `badger6502.js` / `.wasm` and stages the data files. |
+| `index.html` | Canvas UI + `requestAnimationFrame` driver + keyboard. |
+| `serve.ps1` | Starts `python -m http.server` (defaults to port 8011). |
+| `test_*.cjs` | Headless Node validations (boot, render, keyboard, screen decode, loderun). |
+
+Build outputs (`badger6502.js`, `badger6502.wasm`) and the staged `data/`
+copies are git-ignored; regenerate them with `build.ps1`.
+
+## Prerequisites (this machine)
+
+- **emsdk 6.0.1** at `C:\Users\ebadger\emsdk` (x86_64). `emsdk_env.bat` does not
+  add `upstream\emscripten` to `PATH`, so the build invokes `em++.exe` by full
+  path after sourcing the env in the same `cmd` process.
+- **Node** (for headless tests): `C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe`
+  (the system has no `node` on `PATH`).
+- **Python 3** for serving (sets the `application/wasm` MIME type; `.wasm` must
+  be served over http, not `file://`).
+
+## Build
+
+```powershell
+cd web
+.\build.ps1
+```
+
+This compiles these sources with `-DPLATFORM_WEB`:
+
+```
+Badger6502VMLib: vm cpu Instructions acia via PS2Keyboard badgervmpal
+WozLib:          DriveEmulator WozDisk WozFile
+bridge:          web_bridge.cpp
+```
+
+`symbols.cpp` and `Disassemble.cpp` are excluded (Windows-only). Key flags:
+`-std=c++17 -O2 -lembind -sMODULARIZE=1 -sEXPORT_NAME=createBadgerVM
+-sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,node`. The data files
+(`badger6502.bin`, `fontrom.dat`, `loderun.bin`) are copied from
+`emulator/Data` into `web/data`.
+
+## Run in the browser
+
+```powershell
+cd web
+.\serve.ps1            # python -m http.server 8011
+```
+
+Open <http://localhost:8011/index.html>, click the canvas, and type. Press
+**Load Lode Runner** to launch the game from the romdisk.
+
+> Port 8011 is used because 8000 is taken on this machine.
+
+## Headless tests (fast iteration)
+
+```powershell
+$node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
+& $node web\test_boot.cjs        # ROM boots, sane PC, video RAM written
+& $node web\test_render.cjs      # framebuffer has lit pixels
+& $node web\test_keyboard.cjs    # monitor echoes typed commands
+& $node web\test_screen_text.cjs # decode the text screen to ASCII
+& $node web\test_loderun.cjs     # romdisk $C300 readback + Lode Runner runs in hi-res
+```
+
+## ROM load recipe (mirrors the WinUI host)
+
+1. Write the first `0x10000` bytes of `badger6502.bin` into `VM::GetData()`
+   (`loadData(0, bytes)`) — provides the reset vector at `$FFFC` and ROM/OS at
+   `$D000-$FFFF`.
+2. `seedBasicRom()` — `memcpy(GetBasicRom(), &GetData()[0x9000], 0x3000)`.
+3. `loadRomDisk(loderunBytes)` — fills the 512KB romdisk buffer.
+4. `loadFont(fontromBytes)` — used by the text renderer.
+5. `reset()` — loads PC from `$FFFC/$FFFD`.
+
+The CPU is driven cooperatively: each animation frame calls `run(maxSteps)`,
+which `Step()`s the CPU and ticks the VIAs/keyboard per returned cycle (the
+blocking `VM::Run()` is never used).
+
+## How Lode Runner boots
+
+`loderun.bin` is a raw RAM image (`4C 00 60` = `JMP $6000`) that the WinUI host
+loads into the romdisk and, in its dev path, copies into RAM at `$0800`. The web
+bridge mirrors this: `romDiskToRam(0x0800, 0, len)` then `setPC(0x0800)`. The
+program switches into hi-res and paints the screen. The same romdisk is also
+readable through the `$C300` hardware window (`writeBus`/`readBus`).

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -14,6 +14,7 @@ $web  = $PSScriptRoot
 $root = Split-Path $web -Parent
 $lib  = Join-Path $root "emulator\Badger6502VMLib"
 $woz  = Join-Path $root "emulator\WozLib"
+$sd   = Join-Path $root "emulator\MockMicroSD"
 $data = Join-Path $root "emulator\Data"
 
 $emsdk  = if ($env:EMSDK) { $env:EMSDK } else { Join-Path $env:USERPROFILE "emsdk" }
@@ -37,6 +38,9 @@ $sources = @(
     (Join-Path $woz "DriveEmulator.cpp"),
     (Join-Path $woz "WozDisk.cpp"),
     (Join-Path $woz "WozFile.cpp"),
+    # MockMicroSD: bit-banged SPI SD card (web branch = sparse in-memory image).
+    (Join-Path $sd "SDCard.cpp"),
+    (Join-Path $sd "MappedFile.cpp"),
     # Web bridge.
     (Join-Path $web "web_bridge.cpp")
 )
@@ -54,6 +58,7 @@ $flags = @(
     "-lembind",
     "-I", $lib,
     "-I", $woz,
+    "-I", $sd,
     "-I", $web,
     "-sMODULARIZE=1",
     "-sEXPORT_NAME=createBadgerVM",
@@ -81,6 +86,28 @@ foreach ($f in @("badger6502.bin", "fontrom.dat", "loderun.bin")) {
         Copy-Item $src (Join-Path $webData $f) -Force
     } else {
         Write-Warning "data file missing: $src"
+    }
+}
+
+# Generate the compact sparse micro-SD image (data\sd.sparse) straight from
+# emulator\Data\sd.zip. The raw image is a 2GB, mostly-zero FAT32 disk; the
+# sparse form keeps only the ~11.5MB of non-zero sectors. Skipped if already
+# present (regeneration takes ~20s). Gitignored like the other data copies.
+$sparse = Join-Path $webData "sd.sparse"
+if (-not (Test-Path $sparse)) {
+    $sdScript = Join-Path $web "make_sd_sparse.py"
+    $sdZip    = Join-Path $data "sd.zip"
+    if (Test-Path $sdZip) {
+        $py = Get-Command python -ErrorAction SilentlyContinue
+        if ($py) {
+            Write-Host "Generating $sparse from sd.zip (~20s)..." -ForegroundColor Cyan
+            & $py.Source $sdScript $sdZip $sparse
+            if ($LASTEXITCODE -ne 0) { Write-Warning "sd.sparse generation failed ($LASTEXITCODE); SD card will be unavailable." }
+        } else {
+            Write-Warning "python not found; skipping sd.sparse generation (SD card will be unavailable)."
+        }
+    } else {
+        Write-Warning "SD image missing: $sdZip (SD card will be unavailable)."
     }
 }
 

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -1,0 +1,89 @@
+# Builds the 3ric Apple-II-clone VM core + WozLib + web bridge to WebAssembly
+# using Emscripten.
+#
+# All shared-library changes are additive and guarded with PLATFORM_WEB /
+# __EMSCRIPTEN__, so the existing Windows/Pico builds are unaffected.
+#
+# Prerequisites: the Emscripten SDK installed (see web/README.md). By default
+# this looks for emsdk at $env:EMSDK, else %USERPROFILE%\emsdk.
+#
+# Usage:  pwsh -File web\build.ps1   (run from anywhere; paths are script-relative)
+
+$ErrorActionPreference = "Stop"
+$web  = $PSScriptRoot
+$root = Split-Path $web -Parent
+$lib  = Join-Path $root "emulator\Badger6502VMLib"
+$woz  = Join-Path $root "emulator\WozLib"
+$data = Join-Path $root "emulator\Data"
+
+$emsdk  = if ($env:EMSDK) { $env:EMSDK } else { Join-Path $env:USERPROFILE "emsdk" }
+$envBat = Join-Path $emsdk "emsdk_env.bat"
+$empp   = Join-Path $emsdk "upstream\emscripten\em++.exe"
+
+if (-not (Test-Path $envBat)) { throw "emsdk not found at '$emsdk'. Set `$env:EMSDK or install per web/README.md." }
+if (-not (Test-Path $empp))   { throw "em++ not found at '$empp'. Did you run 'emsdk install/activate latest'?" }
+
+# Core VM sources. symbols.cpp (debugger) and Disassemble.cpp (Windows-only
+# VM::Disassemble) are excluded; nothing compiled for the web references them.
+$sources = @(
+    (Join-Path $lib "vm.cpp"),
+    (Join-Path $lib "cpu.cpp"),
+    (Join-Path $lib "Instructions.cpp"),
+    (Join-Path $lib "acia.cpp"),
+    (Join-Path $lib "via.cpp"),
+    (Join-Path $lib "PS2Keyboard.cpp"),
+    (Join-Path $lib "badgervmpal.cpp"),
+    # WozLib (DriveEmulator is embedded in VM; WozDisk/WozFile are needed to link).
+    (Join-Path $woz "DriveEmulator.cpp"),
+    (Join-Path $woz "WozDisk.cpp"),
+    (Join-Path $woz "WozFile.cpp"),
+    # Web bridge.
+    (Join-Path $web "web_bridge.cpp")
+)
+
+foreach ($s in $sources) {
+    if (-not (Test-Path $s)) { throw "source not found: $s" }
+}
+
+$out = Join-Path $web "badger6502.js"
+
+$flags = @(
+    "-std=c++17",
+    "-O2",
+    "-DPLATFORM_WEB",
+    "-lembind",
+    "-I", $lib,
+    "-I", $woz,
+    "-I", $web,
+    "-sMODULARIZE=1",
+    "-sEXPORT_NAME=createBadgerVM",
+    "-sALLOW_MEMORY_GROWTH=1",
+    "-sENVIRONMENT=web,node",
+    "-o", $out
+)
+
+# Quote each path argument so spaces in the path survive the cmd round-trip.
+$quoted = ($flags + $sources) | ForEach-Object { '"' + $_ + '"' }
+$argList = $quoted -join " "
+
+Write-Host "Building -> $out" -ForegroundColor Cyan
+$cmd = "call `"$envBat`" >nul 2>&1 && `"$empp`" $argList"
+& $env:ComSpec /c $cmd
+if ($LASTEXITCODE -ne 0) { throw "Build failed with exit code $LASTEXITCODE" }
+
+# Stage the ROM/font/romdisk images next to the page for fetch() at runtime.
+# These copies are gitignored (the originals live in emulator\Data).
+$webData = Join-Path $web "data"
+New-Item -ItemType Directory -Force -Path $webData | Out-Null
+foreach ($f in @("badger6502.bin", "fontrom.dat", "loderun.bin")) {
+    $src = Join-Path $data $f
+    if (Test-Path $src) {
+        Copy-Item $src (Join-Path $webData $f) -Force
+    } else {
+        Write-Warning "data file missing: $src"
+    }
+}
+
+Write-Host "Build succeeded:" -ForegroundColor Green
+Get-ChildItem $web -Filter "badger6502.*" | ForEach-Object { "  {0,-22} {1,10:N0} bytes" -f $_.Name, $_.Length }
+Get-ChildItem $webData | ForEach-Object { "  data\{0,-16} {1,10:N0} bytes" -f $_.Name, $_.Length }

--- a/web/index.html
+++ b/web/index.html
@@ -23,8 +23,11 @@
   header .hint { color: var(--dim); font-size: 12px; }
   main { flex: 1; display: flex; justify-content: center; align-items: flex-start; padding: 16px; }
   #screen {
-    /* 320x384 internal, displayed 2x with crisp pixels */
-    width: 640px; height: 768px;
+    /* Internal framebuffer is 320x384 (non-square pixels). A real Apple-II
+       display is 4:3, so the canvas element is shown at 640x480 — the buffer is
+       stretched to 4:3 exactly like the original CRT (2x horizontal, 1.25x
+       vertical). */
+    width: 640px; height: 480px;
     image-rendering: pixelated; image-rendering: crisp-edges;
     background: #000; border: 1px solid var(--dim); outline: none;
     max-width: 100%;
@@ -37,6 +40,7 @@
     <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
     <button id="reset">Reset</button>
     <button id="loderun">Load Lode Runner</button>
+    <button id="mountsd">Mount SD (DIR)</button>
     <span class="regs" id="regs">PC:---- A:-- X:-- Y:-- SP:-- P:--</span>
     <span class="regs" id="mode">mode:---</span>
     <span class="hint" id="status">loading wasm&hellip;</span>
@@ -47,7 +51,9 @@
   <footer>
     65C02 emulator core (C++) + WozLib compiled to WebAssembly via Emscripten. Boots the real 512KB ROM,
     renders Apple-II text/hi-res to the canvas, and feeds keystrokes through the memory-mapped keyboard ($C000).
-    Click the screen and type. &ldquo;Load Lode Runner&rdquo; launches the romdisk game.
+    Click the screen and type. &ldquo;Load Lode Runner&rdquo; launches the romdisk game. &ldquo;Mount SD&rdquo;
+    enters the DOS shell (prompt &ldquo;&gt;&rdquo;) and lists the micro-SD card &mdash; then type
+    DIR, CAT, CD &lt;dir&gt;, or BRUN &lt;file&gt;.
   </footer>
 
   <script src="badger6502.js"></script>
@@ -65,6 +71,8 @@
     let vm = null;
     let imageData = null;
     let romdiskLen = 0;
+    let sdLoaded = false;
+    let sdLoading = null;
     const inputQueue = [];
 
     function hex(n, w) { return (n >>> 0).toString(16).toUpperCase().padStart(w, "0"); }
@@ -73,6 +81,26 @@
       const resp = await fetch(url);
       if (!resp.ok) throw new Error(`fetch ${url}: ${resp.status}`);
       return new Uint8Array(await resp.arrayBuffer());
+    }
+
+    // Queue an ASCII string for the memory-mapped keyboard (CR = 0x0D). The
+    // frame loop feeds one byte per strobe-clear, exactly like real typing.
+    function typeString(s) {
+      for (const ch of s) inputQueue.push(ch === "\r" ? 0x0d : ch.charCodeAt(0) & 0x7f);
+    }
+
+    // Fetch + load the sparse micro-SD image once. The card persists across CPU
+    // resets (it lives in the bridge, not the VM), so this only runs a single
+    // time. ~11.5MB, so it is loaded lazily on first "Mount SD" rather than at
+    // boot. Returns true when the image is available.
+    function ensureSD() {
+      if (sdLoaded) return Promise.resolve(true);
+      if (!sdLoading) {
+        sdLoading = fetchBytes("data/sd.sparse")
+          .then((bytes) => { sdLoaded = vm.loadSD(bytes); return sdLoaded; })
+          .catch((err) => { console.error(err); sdLoading = null; return false; });
+      }
+      return sdLoading;
     }
 
     // Apple-II key codes. The bridge ORs in bit 7 and uppercases letters.
@@ -165,6 +193,24 @@
         statusEl.textContent = "running Lode Runner";
         canvas.focus();
       });
+
+      // Mount the micro-SD card and drop into the ROM's DOS shell. "EC5CG" is
+      // the monitor's Go command pointed at $EC5C (the `dos` routine), which
+      // mounts the FAT32 card (fat32_start) and shows the ">" prompt; the
+      // trailing DIR lists the root directory. From there: CAT, CD <dir>,
+      // BLOAD/BRUN <file>, etc.
+      document.getElementById("mountsd").addEventListener("click", async () => {
+        statusEl.textContent = "loading SD image\u2026";
+        const ok = await ensureSD();
+        if (!ok) { statusEl.textContent = "SD image unavailable (run build.ps1)"; return; }
+        inputQueue.length = 0;
+        typeString("EC5CG\rDIR\r");
+        statusEl.textContent = "SD mounted \u2014 DOS shell";
+        canvas.focus();
+      });
+
+      // Warm the SD image in the background so the first "Mount SD" is instant.
+      ensureSD();
 
       requestAnimationFrame(frame);
     }

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3ric — Apple-II-clone 65C02 (WebAssembly)</title>
+<style>
+  :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: "Cascadia Code", "Consolas", ui-monospace, monospace;
+    display: flex; flex-direction: column; min-height: 100vh;
+  }
+  header { padding: 10px 16px; border-bottom: 1px solid var(--dim); display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  header h1 { font-size: 14px; margin: 0; letter-spacing: 1px; }
+  header .regs { font-size: 12px; color: var(--dim); white-space: pre; }
+  header button {
+    background: transparent; color: var(--fg); border: 1px solid var(--dim);
+    padding: 4px 10px; cursor: pointer; font-family: inherit; font-size: 12px; border-radius: 3px;
+  }
+  header button:hover { background: var(--panel); }
+  header .hint { color: var(--dim); font-size: 12px; }
+  main { flex: 1; display: flex; justify-content: center; align-items: flex-start; padding: 16px; }
+  #screen {
+    /* 320x384 internal, displayed 2x with crisp pixels */
+    width: 640px; height: 768px;
+    image-rendering: pixelated; image-rendering: crisp-edges;
+    background: #000; border: 1px solid var(--dim); outline: none;
+    max-width: 100%;
+  }
+  footer { padding: 8px 16px; border-top: 1px solid var(--dim); font-size: 11px; color: var(--dim); }
+</style>
+</head>
+<body>
+  <header>
+    <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
+    <button id="reset">Reset</button>
+    <button id="loderun">Load Lode Runner</button>
+    <span class="regs" id="regs">PC:---- A:-- X:-- Y:-- SP:-- P:--</span>
+    <span class="regs" id="mode">mode:---</span>
+    <span class="hint" id="status">loading wasm&hellip;</span>
+  </header>
+  <main>
+    <canvas id="screen" width="320" height="384" tabindex="0" aria-label="emulator video"></canvas>
+  </main>
+  <footer>
+    65C02 emulator core (C++) + WozLib compiled to WebAssembly via Emscripten. Boots the real 512KB ROM,
+    renders Apple-II text/hi-res to the canvas, and feeds keystrokes through the memory-mapped keyboard ($C000).
+    Click the screen and type. &ldquo;Load Lode Runner&rdquo; launches the romdisk game.
+  </footer>
+
+  <script src="badger6502.js"></script>
+  <script>
+    // ~1.02 MHz at 60 fps. Mirrors the host: run instructions, ticking VIAs per
+    // cycle, until roughly one frame's worth of cycles has elapsed.
+    const CYCLES_PER_FRAME = 17030;
+
+    const canvas  = document.getElementById("screen");
+    const ctx     = canvas.getContext("2d", { alpha: false });
+    const regsEl  = document.getElementById("regs");
+    const modeEl  = document.getElementById("mode");
+    const statusEl = document.getElementById("status");
+
+    let vm = null;
+    let imageData = null;
+    let romdiskLen = 0;
+    const inputQueue = [];
+
+    function hex(n, w) { return (n >>> 0).toString(16).toUpperCase().padStart(w, "0"); }
+
+    async function fetchBytes(url) {
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`fetch ${url}: ${resp.status}`);
+      return new Uint8Array(await resp.arrayBuffer());
+    }
+
+    // Apple-II key codes. The bridge ORs in bit 7 and uppercases letters.
+    function keyToByte(e) {
+      switch (e.key) {
+        case "Enter":      return 0x0d;
+        case "Backspace":  return 0x08; // left arrow / BS
+        case "Tab":        return 0x09;
+        case "Escape":     return 0x1b;
+        case "ArrowLeft":  return 0x08;
+        case "ArrowRight": return 0x15;
+        case "ArrowUp":    return 0x0b;
+        case "ArrowDown":  return 0x0a;
+      }
+      if (e.key.length === 1) return e.key.charCodeAt(0) & 0x7f;
+      return null;
+    }
+
+    function updateRegs() {
+      regsEl.textContent =
+        `PC:${hex(vm.pc(),4)} A:${hex(vm.regA(),2)} X:${hex(vm.regX(),2)} ` +
+        `Y:${hex(vm.regY(),2)} SP:${hex(vm.sp(),2)} P:${hex(vm.status(),2)}`;
+      const m = vm.textMode() ? "TEXT" : (vm.lores() ? "LORES" : "HIRES");
+      modeEl.textContent =
+        `mode:${m} pg${vm.gfxPage()+1}${vm.mixed() ? " MIX" : ""} font:${vm.font()}`;
+    }
+
+    function frame() {
+      // Feed one queued key when the keyboard strobe is clear (bit 7 of $C000).
+      if (inputQueue.length && (vm.peek(0xC000) & 0x80) === 0) {
+        vm.keyDown(inputQueue.shift());
+      }
+
+      let cyc = 0;
+      while (cyc < CYCLES_PER_FRAME) cyc += vm.run(1000);
+
+      const fb = vm.renderFrame(); // Uint8Array RGBA view over wasm heap
+      imageData.data.set(fb);
+      ctx.putImageData(imageData, 0, 0);
+
+      updateRegs();
+      requestAnimationFrame(frame);
+    }
+
+    async function loadRom() {
+      const [rom, romdisk, font] = await Promise.all([
+        fetchBytes("data/badger6502.bin"),
+        fetchBytes("data/loderun.bin"),
+        fetchBytes("data/fontrom.dat"),
+      ]);
+      vm.loadData(0x0000, rom.subarray(0, 0x10000)); // first 64KB -> address space
+      vm.seedBasicRom();
+      vm.loadRomDisk(romdisk);
+      romdiskLen = romdisk.length;
+      vm.loadFont(font);
+      vm.reset();
+    }
+
+    async function boot(Module) {
+      vm = new Module.WebVM();
+      imageData = ctx.createImageData(vm.frameWidth(), vm.frameHeight());
+
+      statusEl.textContent = "loading ROM\u2026";
+      await loadRom();
+      statusEl.textContent = "running";
+      canvas.focus();
+
+      canvas.addEventListener("keydown", (e) => {
+        if (e.ctrlKey || e.metaKey || e.altKey) return;
+        const b = keyToByte(e);
+        if (b !== null) { inputQueue.push(b); e.preventDefault(); }
+      });
+
+      document.getElementById("reset").addEventListener("click", async () => {
+        inputQueue.length = 0;
+        await loadRom();
+        canvas.focus();
+      });
+
+      // Launch Lode Runner from the romdisk the way the WinUI host's dev path
+      // does: copy the romdisk image into RAM at $0800 (its first bytes are
+      // JMP $6000) and jump there.
+      document.getElementById("loderun").addEventListener("click", () => {
+        inputQueue.length = 0;
+        vm.romDiskToRam(0x0800, 0x0000, romdiskLen);
+        vm.setPC(0x0800);
+        statusEl.textContent = "running Lode Runner";
+        canvas.focus();
+      });
+
+      requestAnimationFrame(frame);
+    }
+
+    createBadgerVM().then(boot).catch((err) => {
+      statusEl.textContent = "failed to load: " + err;
+      console.error(err);
+    });
+  </script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -142,6 +142,9 @@
 
       canvas.addEventListener("keydown", (e) => {
         if (e.ctrlKey || e.metaKey || e.altKey) return;
+        // Ignore OS key-repeat so a held key doesn't flood the queue; the ROM
+        // re-reads the latched $C000 char until it touches $C010.
+        if (e.repeat) { e.preventDefault(); return; }
         const b = keyToByte(e);
         if (b !== null) { inputQueue.push(b); e.preventDefault(); }
       });

--- a/web/make_sd_sparse.py
+++ b/web/make_sd_sparse.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Extract a compact "sparse" SD image for the web build.
+
+The shipped SD card image (emulator/Data/sd.zip) decompresses to a 2 GB raw
+image (sd.001) that is almost entirely zeros. We cannot fetch 2 GB in a browser
+or allocate it in WASM, so this tool streams the image straight out of the zip
+and emits only the non-zero 512-byte sectors in a compact container the web
+bridge can load into a lazily-allocated sector map.
+
+Output format (little-endian), web/data/sd.sparse:
+    magic    : 4 bytes  "SDSP"
+    secSize  : uint32   bytes per sector (512)
+    secCount : uint32   total logical sectors (image size / secSize)
+    entries  : uint32   number of non-zero sectors that follow
+    then `entries` records of:
+        index : uint32  sector index
+        data  : secSize bytes
+
+Usage:
+    python make_sd_sparse.py [path-to-sd.zip] [output-path]
+Defaults match the repo layout when run from web/.
+"""
+import os
+import struct
+import sys
+import time
+import zipfile
+
+SEC = 512
+ZERO = b"\x00" * SEC
+CHUNK = 8 * 1024 * 1024  # 8 MB read window (multiple of SEC)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_ZIP = os.path.normpath(os.path.join(HERE, "..", "emulator", "Data", "sd.zip"))
+DEFAULT_OUT = os.path.join(HERE, "data", "sd.sparse")
+
+
+def main():
+    zip_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_ZIP
+    out_path = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_OUT
+
+    if not os.path.isfile(zip_path):
+        print(f"error: SD zip not found: {zip_path}", file=sys.stderr)
+        return 1
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+    t0 = time.time()
+    with zipfile.ZipFile(zip_path) as z:
+        # The image is the single (largest) entry in the archive.
+        name = max(z.infolist(), key=lambda i: i.file_size).filename
+        total_sectors = 0
+        entries = []  # (index, bytes)
+        carry = b""
+        with z.open(name) as f:
+            idx = 0
+            while True:
+                buf = f.read(CHUNK)
+                if not buf:
+                    break
+                if carry:
+                    buf = carry + buf
+                    carry = b""
+                n = len(buf) // SEC
+                rem = len(buf) - n * SEC
+                if rem:
+                    carry = buf[n * SEC:]
+                for i in range(n):
+                    s = buf[i * SEC:(i + 1) * SEC]
+                    if s != ZERO:
+                        entries.append((idx, s))
+                    idx += 1
+                total_sectors = idx
+
+    logical = total_sectors * SEC
+    with open(out_path, "wb") as g:
+        g.write(b"SDSP")
+        g.write(struct.pack("<III", SEC, total_sectors, len(entries)))
+        for idx, s in entries:
+            g.write(struct.pack("<I", idx))
+            g.write(s)
+
+    out_size = 16 + len(entries) * (4 + SEC)
+    dt = time.time() - t0
+    print(f"image: {name}  logical={logical} bytes ({logical/1024/1024:.0f} MB), "
+          f"{total_sectors} sectors")
+    print(f"non-zero sectors: {len(entries)}")
+    print(f"wrote {out_path}  ({out_size} bytes, {out_size/1024/1024:.2f} MB) in {dt:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/serve.ps1
+++ b/web/serve.ps1
@@ -1,0 +1,11 @@
+# Serves the web/ folder over HTTP so the browser can fetch the .wasm with the
+# correct application/wasm MIME type (.wasm cannot be loaded from file://).
+#
+# Usage:  pwsh -File web\serve.ps1 [-Port 8000]
+
+param([int]$Port = 8000)
+
+$web = $PSScriptRoot
+Write-Host "Serving $web at http://localhost:$Port/  (Ctrl+C to stop)" -ForegroundColor Cyan
+Set-Location $web
+python -m http.server $Port

--- a/web/test_boot.cjs
+++ b/web/test_boot.cjs
@@ -1,0 +1,110 @@
+// Milestone 1 — headless boot smoke test for the 3ric WASM build.
+//
+// Loads the real 512KB ROM (first 64KB into the address space), seeds the BASIC
+// bank, loads the romdisk + font, resets, and runs the CPU for a while. Confirms
+// the reset vector lands in ROM, the CPU executes sane PC ranges, the display
+// mode soft-switches get touched, and video RAM ($400-$BFF text / $2000-$5FFF
+// hi-res) receives writes — i.e. the ROM is really running.
+//
+// Run with emsdk's bundled node:
+//   C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe web\test_boot.cjs
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const romdisk = fs.readFileSync(path.join(DATA, "loderun.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+
+function hex(n, w = 4) {
+  return "$" + (n >>> 0).toString(16).toUpperCase().padStart(w, "0");
+}
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+
+  // ROM load recipe (mirrors the WinUI host):
+  // 1) first 64KB of badger6502.bin -> $0000..$FFFF (reset vector + ROM/OS).
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  // 2) seed the BASIC ROM bank from $9000.
+  vm.seedBasicRom();
+  // 3) romdisk image (Disk II / romdisk path).
+  vm.loadRomDisk(new Uint8Array(romdisk));
+  // 4) font ROM for the text renderer.
+  vm.loadFont(new Uint8Array(font));
+  // 5) reset -> PC loaded from $FFFC/$FFFD.
+  vm.reset();
+
+  const resetPC = vm.pc();
+  console.log("reset vector PC =", hex(resetPC));
+
+  // Run the CPU in chunks, sampling PC so we can see it move through ROM.
+  const pcSamples = [];
+  const CHUNKS = 40;
+  const STEPS = 50000;
+  for (let c = 0; c < CHUNKS; c++) {
+    vm.run(STEPS);
+    pcSamples.push(vm.pc());
+  }
+
+  // Count non-zero / non-blank bytes in each video region.
+  function regionStats(start, end) {
+    let nonZero = 0;
+    let distinct = new Set();
+    for (let a = start; a <= end; a++) {
+      const b = vm.peek(a);
+      if (b !== 0x00) nonZero++;
+      distinct.add(b);
+    }
+    return { nonZero, distinct: distinct.size, total: end - start + 1 };
+  }
+
+  const text1 = regionStats(0x0400, 0x07ff);
+  const text2 = regionStats(0x0800, 0x0bff);
+  const hires1 = regionStats(0x2000, 0x3fff);
+  const hires2 = regionStats(0x4000, 0x5fff);
+
+  console.log("\n--- PC samples (every", STEPS, "steps) ---");
+  console.log(pcSamples.map((p) => hex(p)).join(" "));
+
+  console.log("\n--- display mode after boot ---");
+  console.log(
+    "textMode =", vm.textMode(),
+    " gfxPage =", vm.gfxPage(),
+    " mixed =", vm.mixed(),
+    " lores =", vm.lores(),
+    " font =", vm.font()
+  );
+
+  console.log("\n--- video RAM activity (non-zero bytes / distinct values) ---");
+  console.log("text  page1 $0400-$07FF:", text1.nonZero, "/", text1.distinct);
+  console.log("text  page2 $0800-$0BFF:", text2.nonZero, "/", text2.distinct);
+  console.log("hires page1 $2000-$3FFF:", hires1.nonZero, "/", hires1.distinct);
+  console.log("hires page2 $4000-$5FFF:", hires2.nonZero, "/", hires2.distinct);
+
+  const serial = vm.drainOutput();
+  if (serial && serial.length) {
+    console.log("\n--- serial output ---");
+    console.log(JSON.stringify(serial));
+  }
+
+  // Sanity checks.
+  const pcSane =
+    resetPC >= 0xc000 && // boot vector should point into device/ROM space
+    pcSamples.some((p) => p >= 0xc000); // and the CPU keeps executing up there
+  const videoWritten =
+    text1.nonZero > 0 || text2.nonZero > 0 || hires1.nonZero > 0 || hires2.nonZero > 0;
+  const modeTouched =
+    vm.textMode() !== 0 || vm.gfxPage() !== 0 || vm.mixed() !== 0 || vm.lores() !== 0;
+
+  console.log("\n--- checks ---");
+  console.log("reset/exec PC sane :", pcSane);
+  console.log("video RAM written  :", videoWritten);
+  console.log("mode soft-switched :", modeTouched);
+
+  const ok = pcSane && videoWritten;
+  console.log(ok ? "\nPASS" : "\nFAIL");
+  process.exit(ok ? 0 : 1);
+});

--- a/web/test_keyboard.cjs
+++ b/web/test_keyboard.cjs
@@ -1,0 +1,55 @@
+// Milestone 4 (headless) — keyboard input via the memory-mapped $C000 path.
+//
+// Boots into the monitor, then "types" a line by setting $C000 = key|0x80 only
+// when the previous strobe has been consumed (bit 7 cleared via $C010). Confirms
+// the typed characters echo back over the console (serial + text RAM), proving
+// the keyboard path works end to end.
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const romdisk = fs.readFileSync(path.join(DATA, "loderun.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.loadRomDisk(new Uint8Array(romdisk));
+  vm.loadFont(new Uint8Array(font));
+  vm.reset();
+
+  // Boot into the monitor prompt.
+  for (let c = 0; c < 20; c++) vm.run(50000);
+  vm.drainOutput(); // discard boot banner
+
+  // Type a classic monitor command: examine memory at $D000 (start of ROM).
+  // "D000" + Enter.  Each key is delivered once the strobe is clear.
+  function type(str) {
+    for (const ch of str) {
+      let code = ch === "\n" ? 0x0d : ch.charCodeAt(0);
+      // wait for the keyboard strobe to be clear
+      for (let t = 0; t < 200 && (vm.peek(0xc000) & 0x80) !== 0; t++) vm.run(2000);
+      vm.keyDown(code);
+      // let the monitor read + echo it
+      for (let t = 0; t < 20; t++) vm.run(4000);
+    }
+  }
+
+  type("D000\n");
+
+  const echo = vm.drainOutput();
+  console.log("--- console echo while typing 'D000<CR>' ---");
+  console.log(JSON.stringify(echo));
+
+  // The monitor echoes the typed address and prints the byte at $D000.
+  // $D000 holds the first ROM byte; show it for reference.
+  console.log("byte @ $D000 =", "$" + vm.peek(0xd000).toString(16).toUpperCase().padStart(2, "0"));
+
+  const ok = echo.includes("D000") || /D\s*0\s*0\s*0/.test(echo);
+  console.log(ok ? "\nPASS (typed chars echoed)" : "\nFAIL (no echo)");
+  process.exit(ok ? 0 : 1);
+});

--- a/web/test_loderun.cjs
+++ b/web/test_loderun.cjs
@@ -1,0 +1,148 @@
+// Milestone 5 — romdisk / disk path: verify loderun.bin boots and runs.
+//
+// Two checks:
+//   A) The romdisk hardware window at $C300 returns the loaded image byte-for-
+//      byte (write low/high/bank pointer to $C300/$C301/$C302, read $C300).
+//   B) Launch Lode Runner the way the WinUI host's dev path does
+//      (memcpy GetRomDisk()[0] -> GetData()[0x0800], then run from $0800, whose
+//      first bytes are `4C 00 60` = JMP $6000). Confirm it switches into hi-res
+//      and paints the screen ($2000-$5FFF).
+//
+// Run with emsdk's bundled node:
+//   C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe web\test_loderun.cjs
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const romdisk = fs.readFileSync(path.join(DATA, "loderun.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+
+function hex(n, w = 4) {
+  return "$" + (n >>> 0).toString(16).toUpperCase().padStart(w, "0");
+}
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+
+  // Standard ROM load recipe.
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.loadRomDisk(new Uint8Array(romdisk));
+  vm.loadFont(new Uint8Array(font));
+  vm.reset();
+
+  // Let the ROM settle into the monitor.
+  for (let i = 0; i < 10; i++) vm.run(50000);
+
+  // ---- A) romdisk hardware readback through the $C300 window ---------------
+  function rdRead(off) {
+    vm.writeBus(0xc300, off & 0xff);
+    vm.writeBus(0xc301, (off >> 8) & 0xff);
+    vm.writeBus(0xc302, (off >> 16) & 3);
+    return vm.readBus(0xc300);
+  }
+
+  const probes = [0, 1, 2, 0x100, 0x1000, 0x2000, 0x5800, 0x8000, romdisk.length - 1];
+  let rdMatches = 0;
+  console.log("--- romdisk $C300 window readback ---");
+  for (const off of probes) {
+    const got = rdRead(off);
+    const want = romdisk[off];
+    const ok = got === want;
+    if (ok) rdMatches++;
+    console.log(
+      `  off ${hex(off, 5)}: bus=${hex(got, 2)} file=${hex(want, 2)} ${ok ? "ok" : "MISMATCH"}`
+    );
+  }
+  const romdiskOk = rdMatches === probes.length;
+  console.log(`  romdisk window: ${rdMatches}/${probes.length} match -> ${romdiskOk ? "OK" : "FAIL"}`);
+
+  // ---- B) launch loderun: romdisk -> RAM $0800, run from $0800 -------------
+  // Clear hi-res pages first so we only measure writes loderun makes.
+  for (let a = 0x2000; a <= 0x5fff; a++) vm.poke(a, 0x00);
+
+  // Mirror the host's dev shortcut (MainWindow.xaml.cpp ~1211):
+  //   memcpy(&GetData()[0x800], &GetRomDisk()[0], 0xB600)
+  vm.romDiskToRam(0x0800, 0x0000, romdisk.length);
+
+  // Sanity: the entry vector landed in RAM.
+  const entry = [vm.peek(0x0800), vm.peek(0x0801), vm.peek(0x0802)];
+  console.log(
+    `\n--- loderun loaded at $0800 (entry bytes: ${entry.map((b) => hex(b, 2)).join(" ")}) ---`
+  );
+
+  // Jump to the program entry and let it run.
+  vm.setPC(0x0800);
+
+  const pcSamples = [];
+  const CHUNKS = 80;
+  const STEPS = 50000;
+  let minPC = 0xffff;
+  let maxPC = 0x0000;
+  for (let c = 0; c < CHUNKS; c++) {
+    vm.run(STEPS);
+    const p = vm.pc();
+    pcSamples.push(p);
+    if (p < minPC) minPC = p;
+    if (p > maxPC) maxPC = p;
+  }
+
+  function regionStats(start, end) {
+    let nonZero = 0;
+    const distinct = new Set();
+    for (let a = start; a <= end; a++) {
+      const b = vm.peek(a);
+      if (b !== 0x00) nonZero++;
+      distinct.add(b);
+    }
+    return { nonZero, distinct: distinct.size, total: end - start + 1 };
+  }
+
+  const hires1 = regionStats(0x2000, 0x3fff);
+  const hires2 = regionStats(0x4000, 0x5fff);
+
+  console.log("\n--- PC samples (every", STEPS, "steps) ---");
+  console.log(pcSamples.map((p) => hex(p)).join(" "));
+  console.log(`PC range observed: ${hex(minPC)}..${hex(maxPC)}`);
+
+  console.log("\n--- display mode after launch ---");
+  console.log(
+    "textMode =", vm.textMode(),
+    " gfxPage =", vm.gfxPage(),
+    " mixed =", vm.mixed(),
+    " lores =", vm.lores(),
+    " font =", vm.font()
+  );
+
+  console.log("\n--- hi-res video RAM activity (non-zero bytes / distinct) ---");
+  console.log("hires page1 $2000-$3FFF:", hires1.nonZero, "/", hires1.distinct);
+  console.log("hires page2 $4000-$5FFF:", hires2.nonZero, "/", hires2.distinct);
+
+  // Render a frame and count lit pixels as an end-to-end check.
+  const fb = vm.renderFrame();
+  let litPixels = 0;
+  for (let i = 0; i < fb.length; i += 4) {
+    if (fb[i] !== 0 || fb[i + 1] !== 0 || fb[i + 2] !== 0) litPixels++;
+  }
+  console.log(
+    `\nframebuffer ${vm.frameWidth()}x${vm.frameHeight()}: ${litPixels} lit pixels`
+  );
+
+  const drewHires = hires1.nonZero > 500 || hires2.nonZero > 500;
+  const graphicsMode = vm.textMode() === 0;
+  const ranInProgram = minPC < 0xc000; // executing loaded code, not stuck in I/O
+
+  console.log("\n--- checks ---");
+  console.log("romdisk $C300 readback :", romdiskOk);
+  console.log("entry = JMP $6000      :", entry[0] === 0x4c && entry[1] === 0x00 && entry[2] === 0x60);
+  console.log("drew hi-res graphics   :", drewHires);
+  console.log("graphics mode active   :", graphicsMode);
+  console.log("executed loaded program:", ranInProgram);
+
+  const ok = romdiskOk && drewHires && graphicsMode;
+  console.log(ok ? "\nPASS" : "\nFAIL");
+  process.exit(ok ? 0 : 1);
+});

--- a/web/test_render.cjs
+++ b/web/test_render.cjs
@@ -1,0 +1,61 @@
+// Milestone 2 (headless) — validate the ported video renderer without a browser.
+//
+// Boots the ROM, renders one frame via the bridge, then prints a coarse 40x24
+// "cell map" (# = any lit pixel in that 8x16 text cell) plus a non-black pixel
+// count, so we can confirm the framebuffer actually contains the monitor screen
+// before wiring it to a <canvas>.
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const romdisk = fs.readFileSync(path.join(DATA, "loderun.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.loadRomDisk(new Uint8Array(romdisk));
+  vm.loadFont(new Uint8Array(font));
+  vm.reset();
+
+  // Let it boot into the monitor.
+  for (let c = 0; c < 40; c++) vm.run(50000);
+
+  const W = vm.frameWidth();
+  const H = vm.frameHeight();
+  const fb = vm.renderFrame(); // Uint8Array RGBA view, length W*H*4
+
+  let nonBlack = 0;
+  for (let i = 0; i < W * H; i++) {
+    const r = fb[i * 4], g = fb[i * 4 + 1], b = fb[i * 4 + 2];
+    if (r !== 0 || g !== 0 || b !== 0) nonBlack++;
+  }
+
+  // 40x24 cell map (each cell 8x16).
+  console.log(`frame ${W}x${H}, non-black pixels = ${nonBlack}`);
+  console.log("cell map (# = lit):");
+  const cols = W / 8, rows = H / 16;
+  for (let cy = 0; cy < rows; cy++) {
+    let line = "";
+    for (let cx = 0; cx < cols; cx++) {
+      let lit = false;
+      for (let yy = 0; yy < 16 && !lit; yy++) {
+        for (let xx = 0; xx < 8; xx++) {
+          const px = (cx * 8 + xx) + (cy * 16 + yy) * W;
+          const r = fb[px * 4], g = fb[px * 4 + 1], b = fb[px * 4 + 2];
+          if (r !== 0 || g !== 0 || b !== 0) { lit = true; break; }
+        }
+      }
+      line += lit ? "#" : ".";
+    }
+    console.log(line);
+  }
+
+  const ok = nonBlack > 0;
+  console.log(ok ? "\nPASS" : "\nFAIL");
+  process.exit(ok ? 0 : 1);
+});

--- a/web/test_screen_text.cjs
+++ b/web/test_screen_text.cjs
@@ -1,0 +1,54 @@
+// Decode the Apple-II text screen ($400 page 1) to readable ASCII after a short
+// monitor session, to confirm the canvas (video RAM) reflects typed input.
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const romdisk = fs.readFileSync(path.join(DATA, "loderun.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+
+// Text row base offsets within the text page (interleaved), 24 rows.
+const textScanlines = [
+  0x0000, 0x0080, 0x0100, 0x0180, 0x0200, 0x0280, 0x0300, 0x0380,
+  0x0028, 0x00a8, 0x0128, 0x01a8, 0x0228, 0x02a8, 0x0328, 0x03a8,
+  0x0050, 0x00d0, 0x0150, 0x01d0, 0x0250, 0x02d0, 0x0350, 0x03d0,
+];
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.loadRomDisk(new Uint8Array(romdisk));
+  vm.loadFont(new Uint8Array(font));
+  vm.reset();
+
+  for (let c = 0; c < 20; c++) vm.run(50000);
+
+  function type(str) {
+    for (const ch of str) {
+      const code = ch === "\n" ? 0x0d : ch.charCodeAt(0);
+      for (let t = 0; t < 200 && (vm.peek(0xc000) & 0x80) !== 0; t++) vm.run(2000);
+      vm.keyDown(code);
+      for (let t = 0; t < 20; t++) vm.run(4000);
+    }
+  }
+
+  // A couple of monitor commands so multiple lines populate the screen.
+  type("D000.D00F\n"); // dump 16 bytes
+  type("FF00.FF0F\n");
+
+  console.log("--- decoded text screen (page 1) ---");
+  for (let row = 0; row < 24; row++) {
+    const base = 0x400 + textScanlines[row];
+    let line = "";
+    for (let col = 0; col < 40; col++) {
+      const b = vm.peek(base + col) & 0x7f;
+      line += b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : ".";
+    }
+    console.log(String(row).padStart(2, " ") + "| " + line);
+  }
+  process.exit(0);
+});

--- a/web/test_sd.cjs
+++ b/web/test_sd.cjs
@@ -1,0 +1,85 @@
+// Milestone — micro-SD card: verify the bit-banged SPI SD emulation works by
+// mounting the FAT32 image and listing its root directory through the ROM's
+// own DOS shell.
+//
+// Flow (matches how a user drives the real machine from the monitor):
+//   1. Boot the ROM into the "*" monitor.
+//   2. Type "EC5CG"+CR -> "G"o to $EC5C (the `dos` routine), which mounts the
+//      card (fat32_start) and shows the ">" shell prompt.
+//   3. Type "DIR"+CR -> the FAT32 directory listing is printed.
+//
+// Proof points:
+//   - SD sector reads actually happened (sdReadCount > 0) -> the SPI path +
+//     sparse image are wired correctly.
+//   - The directory listing contains real FAT32 entries (<DIR> folders and
+//     "PRG" files) read out of data/sd.sparse.
+//
+// Run with emsdk's bundled node:
+//   C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe web\test_sd.cjs
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+const font = fs.readFileSync(path.join(DATA, "fontrom.dat"));
+const sd = fs.readFileSync(path.join(DATA, "sd.sparse"));
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+
+  // Standard ROM load recipe + the SD sparse image.
+  vm.loadData(0x0000, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.loadFont(new Uint8Array(font));
+  const sdLoaded = vm.loadSD(new Uint8Array(sd));
+  vm.reset();
+
+  // Settle into the monitor.
+  for (let i = 0; i < 20; i++) vm.run(50000);
+
+  // Type a string of ASCII (CR = 0x0D), letting the ROM consume each key.
+  function type(s) {
+    for (const ch of s) {
+      vm.keyDown(ch === "\r" ? 0x0d : ch.charCodeAt(0));
+      for (let i = 0; i < 8; i++) vm.run(20000);
+    }
+    for (let i = 0; i < 120; i++) vm.run(50000);
+  }
+
+  // Enter the DOS shell ($EC5C = `dos`): mounts the SD and prints ">".
+  vm.drainOutput();
+  type("EC5CG\r");
+  const mountReads = vm.sdReadCount();
+  const promptOut = vm.drainOutput();
+
+  // List the root directory.
+  type("DIR\r");
+  const dirOut = vm.drainOutput();
+  const dirReads = vm.sdReadCount();
+
+  console.log("--- SD micro-SD card test ---");
+  console.log("sparse image loaded     :", sdLoaded);
+  console.log("entered shell (prompt)  :", JSON.stringify(promptOut.slice(-4)));
+  console.log("sector reads after mount:", mountReads);
+  console.log("sector reads after DIR  :", dirReads);
+  console.log("\n--- DIR output (first 600 chars) ---");
+  console.log(dirOut.slice(0, 600));
+
+  const gotPrompt = promptOut.includes(">");
+  const hasDirEntries = /<DIR>/.test(dirOut);
+  const hasPrgFiles = /PRG/.test(dirOut);
+  const readsHappened = mountReads > 0 && dirReads > mountReads;
+
+  console.log("\n--- checks ---");
+  console.log("sparse image loaded     :", sdLoaded);
+  console.log("DOS shell prompt '>'    :", gotPrompt);
+  console.log("SD sector reads occurred:", readsHappened);
+  console.log("listing has <DIR> dirs  :", hasDirEntries);
+  console.log("listing has PRG files   :", hasPrgFiles);
+
+  const ok = sdLoaded && gotPrompt && readsHappened && hasDirEntries && hasPrgFiles;
+  console.log(ok ? "\nPASS" : "\nFAIL");
+  process.exit(ok ? 0 : 1);
+});

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -19,6 +19,10 @@
 // vm.h transitively includes cpu.h, via.h, ps2keyboard.h and DriveEmulator.h.
 #include "vm.h"
 
+// SD-card SPI mock (emulator/MockMicroSD). Its pch.h has an additive web branch
+// that pulls in web_compat.h + the in-memory sparse sector backing.
+#include "SDCard.h"
+
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
@@ -107,6 +111,30 @@ public:
 
         // Character generator / font bank selection ($C300 control writes).
         _vm->CallbackSetMode = [this](uint8_t flags) { _font = flags & 0x3F; };
+
+        // Bit-banged SPI micro-SD card, wired exactly like the host
+        // (MainWindow.xaml.cpp): every CPU write to the VIA1 port-A register
+        // ($C201 = ORA_IRA, $C20F = ORA_IRA_2) clocks the SD state machine.
+        // CS=bit4, SCK=bit3, MOSI=bit2, MISO=bit1. The MISO result is folded
+        // back into the register so the next read of the port returns it.
+        _vm->CallbackWriteMemory = [this](uint16_t address, uint8_t /*byte*/) {
+            if (address == (uint16_t)(MM_VIA1_START + (uint16_t)VIA::ORA_IRA)
+                || address == (uint16_t)(MM_VIA1_START + (uint16_t)VIA::ORA_IRA_2))
+            {
+                uint8_t reg = _vm->GetVIA1()->ReadRegister(VIA::ORA_IRA);
+
+                _sd.SetCS(reg & 0x10);
+                _sd.SetMOSI(reg & 0x04);
+                _sd.SetSCK(reg & 0x08);
+
+                if (_sd.GetMISO())
+                    reg |= 0x02;
+                else
+                    reg &= (uint8_t)~0x02;
+
+                _vm->GetVIA1()->WriteRegister(VIA::ORA_IRA, reg);
+            }
+        };
     }
 
     ~WebVM() { delete _vm; }
@@ -156,6 +184,21 @@ public:
         size_t n = v.size() > _fontRom.size() ? _fontRom.size() : v.size();
         if (n) memcpy(_fontRom.data(), v.data(), n);
     }
+
+    // Load the micro-SD card image in the compact "SDSP" sparse format produced
+    // by web/make_sd_sparse.py (the raw image is a 2GB, mostly-zero FAT32 disk).
+    // Returns true on success. Safe to call before or after reset; the SD
+    // handshake works without it, only sector reads need the image.
+    bool loadSD(val bytes)
+    {
+        std::vector<uint8_t> v = convertJSArrayToNumberVector<uint8_t>(bytes);
+        if (v.empty()) return false;
+        return _sd.LoadSparseImage(v.data(), (uint32_t)v.size());
+    }
+
+    // Number of SD sector reads/writes the guest has issued. Proves the ROM's
+    // FAT32 driver reached the card (used by test_sd.cjs).
+    int sdReadCount() { return (int)_sd.GetSectorAccessCount(); }
 
     // --- execution ---------------------------------------------------------
 
@@ -450,6 +493,8 @@ private:
 
     uint64_t _cycles        = 0;
     uint64_t _lastDiskCycle = 0;
+
+    SDCard _sd;     // bit-banged SPI micro-SD card (sparse-backed image)
 };
 
 EMSCRIPTEN_BINDINGS(badger6502)
@@ -461,6 +506,8 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("seedBasicRom", &WebVM::seedBasicRom)
         .function("loadRomDisk",  &WebVM::loadRomDisk)
         .function("loadFont",     &WebVM::loadFont)
+        .function("loadSD",       &WebVM::loadSD)
+        .function("sdReadCount",  &WebVM::sdReadCount)
         .function("run",          &WebVM::run)
         .function("waiting",      &WebVM::waiting)
         .function("keyDown",      &WebVM::keyDown)

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -1,0 +1,488 @@
+// Emscripten/WebAssembly bridge for the 3ric Apple-II-clone 65C02 VM core.
+//
+// Exposes a JS-friendly wrapper (WebVM) over the existing C++ emulator. The
+// blocking CPU::Run()/VM::Run() loops are intentionally NOT used; instead the
+// browser drives execution cooperatively via run(maxSteps) from
+// requestAnimationFrame so the tab stays responsive.
+//
+// Video is rendered here (not in JS) by porting the host renderer from
+// Badger6502Emulator/MainWindow.xaml.cpp: draw_hires_line_color_apple,
+// draw_lores_line_color_apple, draw_text_eb6502 and PlotPixel. Each frame the
+// bridge reads video RAM directly out of VM::GetData() plus the tracked
+// soft-switch mode flags, fills a 320x384 ARGB buffer with the exact host
+// palette/fringe logic, then converts it to RGBA8888 for canvas putImageData.
+//
+// Keyboard uses the Apple-II memory-mapped path: keyDown() writes
+// $C000 = 0x80 | ascii (strobe set); the core clears the strobe when the
+// program touches $C010 (web-guarded in VM::DoSoftSwitches).
+
+// vm.h transitively includes cpu.h, via.h, ps2keyboard.h and DriveEmulator.h.
+#include "vm.h"
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace emscripten;
+
+// Framebuffer dimensions (matches the host WriteableBitmap: 320x384).
+static const int FB_W = 320;
+static const int FB_H = 384;
+
+// Apple II hi-res scanline base offsets (interleaved), 192 entries.
+// Copied verbatim from MainWindow.xaml.cpp.
+static const uint16_t kScanlines[192] = {
+    0x0000, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00,
+    0x0080, 0x0480, 0x0880, 0x0C80, 0x1080, 0x1480, 0x1880, 0x1C80,
+    0x0100, 0x0500, 0x0900, 0x0D00, 0x1100, 0x1500, 0x1900, 0x1D00,
+    0x0180, 0x0580, 0x0980, 0x0D80, 0x1180, 0x1580, 0x1980, 0x1D80,
+    0x0200, 0x0600, 0x0A00, 0x0E00, 0x1200, 0x1600, 0x1A00, 0x1E00,
+    0x0280, 0x0680, 0x0A80, 0x0E80, 0x1280, 0x1680, 0x1A80, 0x1E80,
+    0x0300, 0x0700, 0x0B00, 0x0F00, 0x1300, 0x1700, 0x1B00, 0x1F00,
+    0x0380, 0x0780, 0x0B80, 0x0F80, 0x1380, 0x1780, 0x1B80, 0x1F80,
+    0x0028, 0x0428, 0x0828, 0x0C28, 0x1028, 0x1428, 0x1828, 0x1C28,
+    0x00A8, 0x04A8, 0x08A8, 0x0CA8, 0x10A8, 0x14A8, 0x18A8, 0x1CA8,
+    0x0128, 0x0528, 0x0928, 0x0D28, 0x1128, 0x1528, 0x1928, 0x1D28,
+    0x01A8, 0x05A8, 0x09A8, 0x0DA8, 0x11A8, 0x15A8, 0x19A8, 0x1DA8,
+    0x0228, 0x0628, 0x0A28, 0x0E28, 0x1228, 0x1628, 0x1A28, 0x1E28,
+    0x02A8, 0x06A8, 0x0AA8, 0x0EA8, 0x12A8, 0x16A8, 0x1AA8, 0x1EA8,
+    0x0328, 0x0728, 0x0B28, 0x0F28, 0x1328, 0x1728, 0x1B28, 0x1F28,
+    0x03A8, 0x07A8, 0x0BA8, 0x0FA8, 0x13A8, 0x17A8, 0x1BA8, 0x1FA8,
+    0x0050, 0x0450, 0x0850, 0x0C50, 0x1050, 0x1450, 0x1850, 0x1C50,
+    0x00D0, 0x04D0, 0x08D0, 0x0CD0, 0x10D0, 0x14D0, 0x18D0, 0x1CD0,
+    0x0150, 0x0550, 0x0950, 0x0D50, 0x1150, 0x1550, 0x1950, 0x1D50,
+    0x01D0, 0x05D0, 0x09D0, 0x0DD0, 0x11D0, 0x15D0, 0x19D0, 0x1DD0,
+    0x0250, 0x0650, 0x0A50, 0x0E50, 0x1250, 0x1650, 0x1A50, 0x1E50,
+    0x02D0, 0x06D0, 0x0AD0, 0x0ED0, 0x12D0, 0x16D0, 0x1AD0, 0x1ED0,
+    0x0350, 0x0750, 0x0B50, 0x0F50, 0x1350, 0x1750, 0x1B50, 0x1F50,
+    0x03D0, 0x07D0, 0x0BD0, 0x0FD0, 0x13D0, 0x17D0, 0x1BD0, 0x1FD0 };
+
+// Text/lo-res row base offsets, 24 entries. Copied verbatim.
+static const uint16_t kTextScanlines[24] = {
+    0x0000, 0x0080, 0x0100, 0x0180,
+    0x0200, 0x0280, 0x0300, 0x0380,
+    0x0028, 0x00A8, 0x0128, 0x01A8,
+    0x0228, 0x02A8, 0x0328, 0x03A8,
+    0x0050, 0x00D0, 0x0150, 0x01D0,
+    0x0250, 0x02D0, 0x0350, 0x03D0 };
+
+class WebVM
+{
+public:
+    WebVM()
+    {
+        _vm = new VM(false);
+        _argb.assign((size_t)FB_W * FB_H, 0xFF000000u);
+        _rgba.assign((size_t)FB_W * FB_H * 4, 0);
+        _fontRom.assign(0x80000, 0);
+
+        // Serial transmit from the 6502 -> collect bytes for an optional JS log.
+        _vm->CallbackReceiveChar = [this](uint8_t c) { _out.push_back((char)c); };
+
+        // Track display mode exactly like the host MainWindow does. The core
+        // updates _graphics/_page2/_mixed/_lores then calls this with the fresh
+        // values; we only latch them for the documented display range.
+        _vm->CallbackSetSoftSwitches =
+            [this](uint16_t address, bool graphics, bool page2, bool mixed, bool lores) {
+                if (address >= 0xC050 && address <= 0xC057)
+                {
+                    _gfxPage  = page2 ? 1 : 0;
+                    _textMode = graphics ? 0 : 1;
+                    _mixed    = mixed ? 1 : 0;
+                    _lores    = lores ? 1 : 0;
+                }
+                else if (address >= 0xC0E0 && address <= 0xC0EF)
+                {
+                    // Advance the Disk II emulator by the cycles elapsed since
+                    // the previous disk access (mirrors the host).
+                    _vm->GetDriveEmulator()->AddCycles((uint32_t)(_cycles - _lastDiskCycle));
+                    _lastDiskCycle = _cycles;
+                }
+            };
+
+        // Character generator / font bank selection ($C300 control writes).
+        _vm->CallbackSetMode = [this](uint8_t flags) { _font = flags & 0x3F; };
+    }
+
+    ~WebVM() { delete _vm; }
+
+    // --- lifecycle ---------------------------------------------------------
+
+    void reset() { _vm->Reset(); }
+
+    // --- loaders -----------------------------------------------------------
+
+    // Bulk-load bytes into the 64KB address space starting at offset. Mirrors
+    // VM::LoadBinaryFile(name, offset): writes straight into GetData(), capped
+    // at the 64KB window so the reset vector ($FFFC) + ROM/OS ($D000-$FFFF) and
+    // BASIC bank ($9000-$BFFF) come from the 512KB ROM image's first 64KB.
+    void loadData(int offset, val bytes)
+    {
+        std::vector<uint8_t> v = convertJSArrayToNumberVector<uint8_t>(bytes);
+        uint8_t* data = _vm->GetData();
+        for (size_t i = 0; i < v.size(); i++)
+        {
+            int a = offset + (int)i;
+            if (a < 0 || a > 0xFFFF) break;
+            data[a] = v[i];
+        }
+    }
+
+    // Seed the BASIC ROM bank from the freshly loaded image ($9000, 0x3000).
+    void seedBasicRom()
+    {
+        memcpy(_vm->GetBasicRom(), &_vm->GetData()[0x9000], 0x3000);
+    }
+
+    // Load the 512KB romdisk image (e.g. loderun.bin) used by the Disk II /
+    // romdisk path.
+    void loadRomDisk(val bytes)
+    {
+        std::vector<uint8_t> v = convertJSArrayToNumberVector<uint8_t>(bytes);
+        uint8_t* rd = _vm->GetRomDisk();
+        size_t n = v.size() > 0x80000 ? 0x80000 : v.size();
+        if (n) memcpy(rd, v.data(), n);
+    }
+
+    // Load the 512KB font ROM (fontrom.dat) used by the text renderer.
+    void loadFont(val bytes)
+    {
+        std::vector<uint8_t> v = convertJSArrayToNumberVector<uint8_t>(bytes);
+        size_t n = v.size() > _fontRom.size() ? _fontRom.size() : v.size();
+        if (n) memcpy(_fontRom.data(), v.data(), n);
+    }
+
+    // --- execution ---------------------------------------------------------
+
+    // Execute up to maxSteps instructions, ticking both VIAs once per CPU cycle
+    // so timer NMIs (delivered synchronously from VIA::Tick) fire. Mirrors the
+    // host run loop, which always Steps and never honours waitForInterrupt.
+    int run(int maxSteps)
+    {
+        CPU* cpu  = _vm->GetCPU();
+        VIA* via1 = _vm->GetVIA1();
+        VIA* via2 = _vm->GetVIA2();
+        int cycles = 0;
+        for (int i = 0; i < maxSteps; i++)
+        {
+            uint8_t c = cpu->Step();
+            cycles += c;
+            _cycles += c;
+            for (uint8_t k = 0; k < c; k++)
+            {
+                via1->Tick();
+                via2->Tick();
+            }
+            _vm->GetPS2Keyboard()->ProcessKeys((uint32_t)_cycles);
+        }
+        return cycles;
+    }
+
+    bool waiting() { return _vm->GetCPU()->waitForInterrupt; }
+
+    // --- keyboard ----------------------------------------------------------
+
+    // Apple-II monitor/BASIC input: make $C000 read back ascii|0x80 (strobe set)
+    // until the program touches $C010. Uppercased to match the host + BASIC.
+    void keyDown(int ascii)
+    {
+        _vm->WriteData(0xC000, (uint8_t)(0x80 | toupper(ascii & 0x7F)));
+    }
+
+    // --- direct memory access ---------------------------------------------
+
+    void poke(int addr, int value) { _vm->GetData()[addr & 0xFFFF] = (uint8_t)(value & 0xFF); }
+    int  peek(int addr)            { return _vm->GetData()[addr & 0xFFFF]; }
+
+    // Bus-level access that runs through the full memory map (soft switches,
+    // ACIA/VIA, romdisk window at $C300, Disk II, language-card banking). Use
+    // this to drive memory-mapped devices the way the CPU would.
+    int  readBus(int addr)            { return _vm->ReadData((uint16_t)(addr & 0xFFFF)); }
+    void writeBus(int addr, int value) { _vm->WriteData((uint16_t)(addr & 0xFFFF), (uint8_t)(value & 0xFF)); }
+
+    // Copy a slice of the loaded romdisk image straight into RAM (mirrors the
+    // host's dev shortcut `memcpy(&GetData()[dst], &GetRomDisk()[src], len)`)
+    // so a romdisk program (e.g. loderun.bin -> $0800) can be launched.
+    void romDiskToRam(int dst, int src, int len)
+    {
+        uint8_t* ram = _vm->GetData();
+        uint8_t* rd  = _vm->GetRomDisk();
+        for (int i = 0; i < len; i++)
+        {
+            int d = dst + i;
+            int s = src + i;
+            if (d < 0 || d > 0xFFFF || s < 0 || s >= 0x80000) break;
+            ram[d] = rd[s];
+        }
+    }
+
+    // Set the program counter (e.g. to launch a freshly loaded program).
+    void setPC(int addr) { _vm->GetCPU()->PC = (uint16_t)(addr & 0xFFFF); }
+
+    // --- serial log (optional) --------------------------------------------
+
+    std::string drainOutput()
+    {
+        std::string s = _out;
+        _out.clear();
+        return s;
+    }
+
+    // --- CPU state ---------------------------------------------------------
+
+    int pc()     { return _vm->GetCPU()->PC; }
+    int sp()     { return _vm->GetCPU()->SP; }
+    int regA()   { return _vm->GetCPU()->A; }
+    int regX()   { return _vm->GetCPU()->X; }
+    int regY()   { return _vm->GetCPU()->Y; }
+    int status() { return _vm->GetCPU()->flags.reg; }
+
+    // --- mode state (debug/inspection) ------------------------------------
+
+    int gfxPage()  { return _gfxPage; }
+    int textMode() { return _textMode; }
+    int mixed()    { return _mixed; }
+    int lores()    { return _lores; }
+    int font()     { return _font; }
+
+    // --- video -------------------------------------------------------------
+
+    int frameWidth()  { return FB_W; }
+    int frameHeight() { return FB_H; }
+
+    // Render the current frame into the RGBA buffer and return a typed-memory
+    // view over it. A fresh view is returned each call because memory growth can
+    // detach previously handed-out views.
+    val renderFrame()
+    {
+        int page = _gfxPage;
+
+        if (_textMode == 0)
+        {
+            if (_lores == 0)
+            {
+                for (int y = 0; y < 192; y++)
+                    draw_hires_line_color_apple(page, (uint8_t)y);
+            }
+            else
+            {
+                draw_lores_line_color_apple(page);
+            }
+
+            if (_mixed)
+                draw_text_eb6502(page);
+        }
+        else
+        {
+            draw_text_eb6502(page);
+        }
+
+        // ARGB (0xAARRGGBB) -> RGBA8888 bytes for canvas ImageData.
+        const uint32_t* src = _argb.data();
+        uint8_t* dst = _rgba.data();
+        const size_t n = (size_t)FB_W * FB_H;
+        for (size_t i = 0; i < n; i++)
+        {
+            uint32_t v = src[i];
+            dst[i * 4 + 0] = (uint8_t)((v >> 16) & 0xFF); // R
+            dst[i * 4 + 1] = (uint8_t)((v >> 8) & 0xFF);  // G
+            dst[i * 4 + 2] = (uint8_t)(v & 0xFF);         // B
+            dst[i * 4 + 3] = (uint8_t)((v >> 24) & 0xFF); // A
+        }
+
+        return val(typed_memory_view(_rgba.size(), _rgba.data()));
+    }
+
+private:
+    // Video RAM accessors. Hires page 1 = $2000, page 2 = $4000; text/lores
+    // page 1 = $400, page 2 = $800. These regions are always plain RAM.
+    inline uint8_t hiresByte(int page, uint16_t laddr)
+    {
+        return _vm->GetData()[0x2000 + page * 0x2000 + laddr];
+    }
+    inline uint8_t textByte(int page, uint16_t addr)
+    {
+        return _vm->GetData()[0x400 + page * 0x400 + addr];
+    }
+
+    // Ported from MainWindow::PlotPixel. color is a 4-bit Apple hi-res color
+    // index; base palette plus per-bit intensity yields a 0xAARRGGBB value.
+    void plotPixel(uint16_t row, uint16_t col, uint8_t color, bool twice)
+    {
+        static const uint32_t colorarray[16] = {
+            0xFF000000, 0xFFEA5D15, 0xFF43C300, 0x00000000,
+            0x00000000, 0xFFB63DFF, 0xFF10A4E3, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF };
+
+        uint32_t rowmax = 384;
+        if (_mixed && !_textMode)
+            rowmax = 336;
+
+        if (row >= rowmax || col >= 320)
+            return;
+
+        uint32_t newcolor = colorarray[color & 0xF];
+        const uint32_t intensity = 0xFF;
+        if (color & 4) newcolor |= intensity;
+        if (color & 2) newcolor |= (intensity << 8);
+        if (color & 1) newcolor |= (intensity << 16);
+
+        _argb[col + (size_t)row * 320] = newcolor;
+        if (twice)
+            _argb[col + ((size_t)row + 1) * 320] = newcolor;
+    }
+
+    // Ported from MainWindow::draw_hires_line_color_apple.
+    void draw_hires_line_color_apple(int page, uint8_t y)
+    {
+        uint8_t pallete = 0;
+        uint8_t prevbit = 0;
+        uint8_t color = 0;
+        uint16_t ya = (uint16_t)(y * 2);
+
+        const uint8_t colors[2][4] = { {0x0, 0x5, 0x2, 0xF}, {0x0, 0x6, 0x1, 0xF} };
+        uint16_t countPixel = 0;
+
+        for (uint16_t x = 0; x < 40; x++)
+        {
+            uint16_t laddr = kScanlines[y] + x;
+            uint8_t curr = hiresByte(page, laddr);
+
+            pallete = curr >> 7;
+
+            for (uint8_t i = 0; i < 7; i++)
+            {
+                uint8_t bit = (curr >> i) & 1;
+                uint8_t odd = (x + i) % 2;
+                uint8_t index = odd ? (uint8_t)(bit << 1 | prevbit)
+                                    : (uint8_t)(prevbit << 1 | bit);
+
+                color = colors[pallete][index];
+                uint16_t pixel = (uint16_t)(((float)countPixel / 280.0f) * 320);
+                countPixel++;
+                uint16_t nextpixel = (uint16_t)(((float)countPixel / 280.0f) * 320);
+
+                plotPixel(ya, pixel, color, true);
+                if (nextpixel - pixel > 1)
+                    plotPixel(ya, pixel + 1, color, true);
+
+                prevbit = bit;
+            }
+        }
+    }
+
+    // Ported from MainWindow::draw_lores_line_color_apple.
+    void draw_lores_line_color_apple(int page)
+    {
+        static const uint32_t loresColors[16] = {
+            0xFF000000, 0xFF901740, 0xFF402CA5, 0xFFD043E5,
+            0xFF006940, 0xFF808080, 0xFF2F95E5, 0xFFBFABFF,
+            0xFF405400, 0xFFD06A1A, 0xFF808080, 0xFFFF96BF,
+            0xFF2FBC1A, 0xFFBFD35A, 0xFF6FE8BF, 0xFFFFFFFF };
+
+        uint32_t endy = 384;
+        if (_mixed == 1)
+            endy = 320;
+
+        for (uint32_t x = 0; x < 40; x++)
+        {
+            for (uint32_t y = 0; y < endy; y++)
+            {
+                uint32_t addr = kTextScanlines[y / 16] + x;
+                uint8_t curr = textByte(page, (uint16_t)addr);
+
+                uint8_t index = ((y & 8) == 0) ? (curr & 0xF) : (curr >> 4);
+                uint32_t color = loresColors[index];
+
+                for (int i = 0; i < 8; i++)
+                    _argb[(x * 8) + i + ((size_t)y * 320)] = color;
+            }
+        }
+    }
+
+    // Ported from MainWindow::draw_text_eb6502.
+    void draw_text_eb6502(int page)
+    {
+        uint32_t startrow = 0;
+        if (_mixed && !_textMode)
+            startrow = 320;
+
+        for (uint32_t x = 0; x < 40; x++)
+        {
+            for (uint32_t y = startrow; y < 384; y++)
+            {
+                uint32_t addr = kTextScanlines[y / 16] + x;
+                uint8_t curr = textByte(page, (uint16_t)addr);
+
+                uint8_t line = (uint8_t)(y % 16);
+                uint32_t fontaddr = curr | (line << 8) | (_font << 12);
+                uint8_t bytes = (fontaddr < _fontRom.size()) ? _fontRom[fontaddr] : 0;
+
+                int bit = 0;
+                for (int i = 7; i >= 0; i--)
+                {
+                    _argb[(x * 8) + bit + ((size_t)y * 320)] =
+                        (bytes & (1 << i)) ? 0xFFFFFFFFu : 0xFF000000u;
+                    bit++;
+                }
+            }
+        }
+    }
+
+    VM*                   _vm = nullptr;
+    std::string           _out;
+    std::vector<uint32_t> _argb;     // 0xAARRGGBB working buffer (host format)
+    std::vector<uint8_t>  _rgba;     // RGBA8888 for canvas ImageData
+    std::vector<uint8_t>  _fontRom;  // fontrom.dat (512KB)
+
+    // Display mode flags, mirroring the host members (defaults: hi-res page 1).
+    int _gfxPage  = 0;
+    int _textMode = 0;
+    int _mixed    = 0;
+    int _lores    = 0;
+    int _font     = 0;
+
+    uint64_t _cycles        = 0;
+    uint64_t _lastDiskCycle = 0;
+};
+
+EMSCRIPTEN_BINDINGS(badger6502)
+{
+    class_<WebVM>("WebVM")
+        .constructor<>()
+        .function("reset",        &WebVM::reset)
+        .function("loadData",     &WebVM::loadData)
+        .function("seedBasicRom", &WebVM::seedBasicRom)
+        .function("loadRomDisk",  &WebVM::loadRomDisk)
+        .function("loadFont",     &WebVM::loadFont)
+        .function("run",          &WebVM::run)
+        .function("waiting",      &WebVM::waiting)
+        .function("keyDown",      &WebVM::keyDown)
+        .function("poke",         &WebVM::poke)
+        .function("peek",         &WebVM::peek)
+        .function("readBus",      &WebVM::readBus)
+        .function("writeBus",     &WebVM::writeBus)
+        .function("romDiskToRam",  &WebVM::romDiskToRam)
+        .function("setPC",        &WebVM::setPC)
+        .function("drainOutput",  &WebVM::drainOutput)
+        .function("pc",           &WebVM::pc)
+        .function("sp",           &WebVM::sp)
+        .function("regA",         &WebVM::regA)
+        .function("regX",         &WebVM::regX)
+        .function("regY",         &WebVM::regY)
+        .function("status",       &WebVM::status)
+        .function("gfxPage",      &WebVM::gfxPage)
+        .function("textMode",     &WebVM::textMode)
+        .function("mixed",        &WebVM::mixed)
+        .function("lores",        &WebVM::lores)
+        .function("font",         &WebVM::font)
+        .function("frameWidth",   &WebVM::frameWidth)
+        .function("frameHeight",  &WebVM::frameHeight)
+        .function("renderFrame",  &WebVM::renderFrame);
+}

--- a/web/web_compat.h
+++ b/web/web_compat.h
@@ -1,12 +1,13 @@
 // web_compat.h — Emscripten/WebAssembly compatibility shims for the shared
-// WozLib sources, which were written against the Win32 API.
+// WozLib + MockMicroSD sources, which were written against the Win32 API.
 //
-// This header is ONLY pulled in when compiling for Emscripten (the WozLib .cpp
-// files include it under `#if defined(__EMSCRIPTEN__)`), so the existing
-// Windows / MSVC build is completely unaffected.
+// This header is ONLY pulled in when compiling for Emscripten (the affected
+// .cpp / pch files include it under `#if defined(__EMSCRIPTEN__)`), so the
+// existing Windows / MSVC build is completely unaffected.
 //
 // It provides no-op / portable stand-ins for the handful of Win32 helpers the
-// WozLib debug paths reference: OutputDebugStringA, sprintf_s and _countof.
+// debug / file paths reference: OutputDebugString(A/W), sprintf_s, swprintf_s,
+// _countof, fopen_s/fread_s and _ASSERT.
 #pragma once
 
 #if defined(__EMSCRIPTEN__)
@@ -14,6 +15,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cerrno>
+#include <cwchar>
 
 // Debug tracing → drop on the floor in the browser build.
 #ifndef OutputDebugStringA
@@ -22,10 +24,20 @@
 #ifndef OutputDebugStringW
 #define OutputDebugStringW(s) ((void)(s))
 #endif
+// Win32 OutputDebugString resolves to the wide variant under UNICODE builds;
+// the SD-card mock calls it with a wchar_t buffer.
+#ifndef OutputDebugString
+#define OutputDebugString OutputDebugStringW
+#endif
 
 // MSVC bounds-checked sprintf → portable snprintf (identical (buf, size, fmt, ...) shape).
 #ifndef sprintf_s
 #define sprintf_s snprintf
+#endif
+
+// MSVC bounds-checked wide sprintf → portable swprintf (same (buf, count, fmt, ...) shape).
+#ifndef swprintf_s
+#define swprintf_s swprintf
 #endif
 
 // MSVC array-length helper.

--- a/web/web_compat.h
+++ b/web/web_compat.h
@@ -1,0 +1,61 @@
+// web_compat.h — Emscripten/WebAssembly compatibility shims for the shared
+// WozLib sources, which were written against the Win32 API.
+//
+// This header is ONLY pulled in when compiling for Emscripten (the WozLib .cpp
+// files include it under `#if defined(__EMSCRIPTEN__)`), so the existing
+// Windows / MSVC build is completely unaffected.
+//
+// It provides no-op / portable stand-ins for the handful of Win32 helpers the
+// WozLib debug paths reference: OutputDebugStringA, sprintf_s and _countof.
+#pragma once
+
+#if defined(__EMSCRIPTEN__)
+
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+
+// Debug tracing → drop on the floor in the browser build.
+#ifndef OutputDebugStringA
+#define OutputDebugStringA(s) ((void)(s))
+#endif
+#ifndef OutputDebugStringW
+#define OutputDebugStringW(s) ((void)(s))
+#endif
+
+// MSVC bounds-checked sprintf → portable snprintf (identical (buf, size, fmt, ...) shape).
+#ifndef sprintf_s
+#define sprintf_s snprintf
+#endif
+
+// MSVC array-length helper.
+#ifndef _countof
+#define _countof(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+// MSVC secure CRT used by WozLib's file loaders. These paths are dead code in
+// the web build (disk images are handed in as byte arrays, not read from a
+// .woz file), but they still must compile and link.
+typedef int errno_t;
+
+static inline errno_t web_fopen_s(FILE** pf, const char* name, const char* mode)
+{
+    if (!pf) return EINVAL;
+    *pf = fopen(name, mode);
+    return *pf ? 0 : (errno ? errno : -1);
+}
+#ifndef fopen_s
+#define fopen_s web_fopen_s
+#endif
+
+// MSVC fread_s(buf, bufsize, elemsize, count, stream) → fread(buf, elemsize, count, stream).
+#ifndef fread_s
+#define fread_s(buf, bufsize, elemsize, count, stream) fread((buf), (elemsize), (count), (stream))
+#endif
+
+// MSVC debug assert → no-op (avoid surprise aborts in this otherwise-dead code).
+#ifndef _ASSERT
+#define _ASSERT(x) ((void)0)
+#endif
+
+#endif // __EMSCRIPTEN__


### PR DESCRIPTION
## Summary

Compiles the existing `Badger6502VMLib` + `WozLib` C++ cores to WebAssembly so the Apple-II-clone 65C02 emulator runs in a browser. It boots the **real 512KB ROM**, renders Apple-II **text / hi-res / lo-res** video to an HTML `<canvas>`, accepts **keyboard** input via the memory-mapped `$C000`/`$C010` mechanism, and launches **`loderun.bin`** (Lode Runner) from the romdisk.

All new code lives under a self-contained top-level **`web/`** folder.

## Non-negotiable constraint: Windows/Pico builds unchanged

Every change to the shared libs is **additive and guarded** with `__EMSCRIPTEN__` / a new `PLATFORM_WEB` define. The `PLATFORM_WINDOWS` and `PLATFORM_PICO` branches are untouched:

- **`badgervmpal.cpp/.h`** — new `PLATFORM_WEB` branch: `pal_sleep` (no-op), `pal_sprintf`/`pal_strncpy` (libc), `pal_debugbreak` (no-op), romdisk alloc/free, no-op file loaders (the bridge loads bytes directly).
- **`vm.cpp`** — guard the `windows.h` include behind `PLATFORM_WINDOWS`; add a web-only `$C010` keyboard-strobe clear (Apple-II semantics).
- **`WozLib`** (`DriveEmulator.cpp`, `WozDisk.cpp`, `WozFile.cpp`) — include `web_compat.h` under Emscripten instead of `<Windows.h>`/`<debugapi.h>`.

## `web/` contents

| File | Purpose |
| --- | --- |
| `web_bridge.cpp` | embind bridge wrapping `VM`; the WinUI host renderer (hi-res/lo-res/text) ported **verbatim**, cooperative `run()` loop, keyboard, registers, romdisk launch helpers, RGBA framebuffer view. |
| `web_compat.h` | Emscripten shims for WozLib MSVC-isms (`OutputDebugStringA`, `sprintf_s`, `fopen_s`, `fread_s`, `_ASSERT`, …). |
| `build.ps1` / `serve.ps1` | Build to `badger6502.js`/`.wasm`; serve via `python -m http.server`. |
| `index.html` | Canvas UI + `requestAnimationFrame` driver + keyboard + **Load Lode Runner** button. |
| `README.md` | Build / serve / test instructions + toolchain notes. |
| `test_*.cjs` | Headless Node validations. |

Build outputs (`badger6502.js`/`.wasm`) and staged `data/` copies are git-ignored; regenerate with `web/build.ps1`.

## Validation (all green, headless via Node)

- **Boot** — reset vector → monitor, sane PC ranges, video RAM written.
- **Render** — framebuffer has lit pixels; text screen decodes correctly.
- **Keyboard** — monitor echoes typed commands (e.g. `D000` → `D000- 20`).
- **Disk/romdisk** — `$C300` window reads the romdisk byte-for-byte (9/9); launching `loderun.bin` (`JMP $6000`) drives it into hi-res with both pages painted (8192/8192 bytes), ~5000 lit pixels.

Also verified in-browser via `python -m http.server`.

## Notes

- The CPU is driven cooperatively (`run(maxSteps)` steps the CPU + ticks VIAs/keyboard per cycle); the blocking `VM::Run()` is never used.
- Built with emsdk 6.0.1. See `web/README.md` for the exact toolchain invocation.