### PR TITLE
Add AI operating template (governance, specs, hooks) for 3RIC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts and the compliance-hooks extension must be LF so they run under
+# bash/Node on Linux/macOS/WSL even when authored on Windows.
+*.sh       text eol=lf
+*.example  text eol=lf
+*.mjs      text eol=lf
+.githooks/pre-push text eol=lf

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,43 @@
+# Git hooks (`.githooks/`)
+
+Repo-tracked git hooks. They are **not** active until you point git at this
+directory (hooks can't be auto-installed by `git clone`):
+
+```sh
+scripts/dev/install-hooks.sh        # sets core.hooksPath=.githooks
+# or, equivalently, from the repo root in any shell:
+git config core.hooksPath .githooks
+```
+
+This sets local config in `.git/config`, so it applies to the whole repo
+(including all worktrees on this machine). Run it once per clone.
+
+## Hooks
+
+### `pre-push`
+Runs three independent guards on every `git push`. Each **fails open** where it
+cannot run, so it never blocks legitimate or offline work.
+
+**1. LEARNINGS.md size-cap guard** (via `scripts/dev/check-learnings-budget.sh`).
+`docs/LEARNINGS.md` is loaded into the model's context at the start of every
+session, so it is a capped **Tier-1 rules digest** (~2,500 tokens); detailed
+narratives belong in `docs/learnings/`. The guard blocks a push when the file
+exceeds the cap, forcing priority-based distillation instead of unbounded growth.
+- Counts **real tokens** with `tiktoken` when available (`pip install tiktoken`);
+  otherwise falls back to a dependency-free character proxy.
+- Override deliberately with `SKIP_LEARNINGS_BUDGET=1 git push ...`.
+
+**2. Optional project test gate** (via `scripts/dev/pre-push-tests.sh`, if present
+and executable). Runs your stack's tests / critical-path eval before allowing the
+push. Copy `scripts/dev/pre-push-tests.sh.example` to `pre-push-tests.sh` and fill
+in the command. This keeps the *mechanism* (a mechanical test gate on push)
+project-agnostic. The example shows both a skippable test run and a NON-bypassable
+gate scoped to a critical path.
+
+**3. PR-state guard.**
+Blocks pushes to a branch whose PR is already **MERGED** or **CLOSED**. Once a PR
+is merged its branch is stale; pushing more commits orphans them (the merged PR
+never updates) — the recurring footgun documented in `docs/LEARNINGS.md` §6.
+- Uses `gh pr list --head <branch> --state all` to look up PR state.
+- Only ever blocks on a confirmed MERGED/CLOSED state with no competing OPEN PR.
+- Override deliberately with `SKIP_PR_GUARD=1 git push ...`.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,134 @@
+#!/bin/sh
+# pre-push -- Mechanical guards that run on every `git push`, regardless of caller
+# (agent, IDE, or terminal). Make the rules in docs/LEARNINGS.md mechanical instead
+# of relying on memory.
+#
+# Activate with: scripts/dev/install-hooks.sh   (sets core.hooksPath=.githooks)
+#
+# Three independent guards run in order:
+#   1. LEARNINGS.md size-cap guard  -- keeps the always-loaded Tier-1 digest small.
+#   2. Optional project test gate   -- runs scripts/dev/pre-push-tests.sh if present.
+#   3. PR-state guard               -- blocks pushes to a MERGED/CLOSED PR branch.
+#
+# Each guard fails OPEN where it cannot run (missing tool, offline) so it never
+# blocks legitimate work. Escape hatches are per-guard env vars, noted below.
+
+remote_url="$2"
+
+# Capture git's ref list from stdin into a temp file so it can be read multiple times.
+_refs_tmp=$(mktemp)
+cat > "$_refs_tmp"
+trap 'rm -f "$_refs_tmp"' EXIT
+
+# --- 1. docs/LEARNINGS.md size-cap guard -----------------------------------
+# Keeps the always-loaded Tier-1 rules digest under its token cap (see
+# docs/LEARNINGS.md "How this file is maintained"). Redirect stdin from /dev/null
+# so it never consumes the ref list git feeds us.
+# Escape hatch: SKIP_LEARNINGS_BUDGET=1 git push ...
+_budget="$(cd "$(dirname "$0")" && pwd)/../scripts/dev/check-learnings-budget.sh"
+if [ -f "$_budget" ]; then
+  sh "$_budget" </dev/null || exit 1
+fi
+# ---------------------------------------------------------------------------
+
+# --- 2. Optional project test gate -----------------------------------------
+# If the project provides scripts/dev/pre-push-tests.sh, run it before allowing
+# the push. The script decides WHAT to test (build, unit tests, a critical-path
+# eval suite, lint, etc.) and returns non-zero to BLOCK the push. This keeps the
+# *mechanism* (a mechanical test gate on push) project-agnostic -- copy
+# pre-push-tests.sh.example to pre-push-tests.sh and fill it in.
+# Escape hatch (only if the script itself honors it): SKIP_TEST_GUARD=1 git push ...
+_tests="$(cd "$(dirname "$0")" && pwd)/../scripts/dev/pre-push-tests.sh"
+if [ -f "$_tests" ] && [ -x "$_tests" ]; then
+  echo "pre-push: running project test gate (scripts/dev/pre-push-tests.sh)..." >&2
+  REFS_FILE="$_refs_tmp" sh "$_tests" </dev/null || {
+    echo "" >&2
+    echo "x pre-push BLOCKED: project test gate failed. Fix failures before pushing." >&2
+    echo "" >&2
+    exit 1
+  }
+fi
+# ---------------------------------------------------------------------------
+
+# --- 3. PR-state guard -----------------------------------------------------
+# Blocks pushes to a branch whose PR is already MERGED or CLOSED. Once a PR is
+# merged its branch is stale; pushing more commits orphans them. See LEARNINGS §6.
+# Escape hatch (rare, deliberate): SKIP_PR_GUARD=1 git push ...
+if [ "${SKIP_PR_GUARD:-}" = "1" ]; then
+  echo "pre-push: SKIP_PR_GUARD=1 -- skipping PR-state check." >&2
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "pre-push: 'gh' CLI not found -- skipping PR-state check (fail-open)." >&2
+  exit 0
+fi
+
+# Derive owner/repo from the push URL so the check targets the remote actually
+# being pushed to. Only GitHub remotes are checkable.
+case "$remote_url" in
+  https://github.com/*)   repo=${remote_url#https://github.com/} ;;
+  git@github.com:*)       repo=${remote_url#git@github.com:} ;;
+  ssh://git@github.com/*) repo=${remote_url#ssh://git@github.com/} ;;
+  *) repo="" ;;
+esac
+repo=${repo%.git}
+repo=${repo%/}
+if [ -z "$repo" ]; then
+  echo "pre-push: '$remote_url' is not a recognized GitHub remote -- skipping check." >&2
+  exit 0
+fi
+
+zero="0000000000000000000000000000000000000000"
+status=0
+
+# git feeds pre-push one line per ref; we read from the captured temp file.
+#   <local ref> <local sha> <remote ref> <remote sha>
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Branch deletion (local sha all-zero) -- nothing to guard.
+  [ "$local_sha" = "$zero" ] && continue
+
+  case "$remote_ref" in
+    refs/heads/*) branch=${remote_ref#refs/heads/} ;;
+    *) continue ;;  # tags or other refs -- ignore
+  esac
+
+  # The default branch is protected by review/branch rules; never block normal flow.
+  [ "$branch" = "main" ] && continue
+  [ "$branch" = "master" ] && continue
+
+  # All PRs whose head is this branch. A branch can carry BOTH a merged PR and a
+  # newer open one, so an OPEN PR must win.
+  if ! states=$(gh pr list --repo "$repo" --head "$branch" --state all --json state --jq '.[].state' 2>/dev/null); then
+    echo "pre-push: could not query PR state for '$branch' via gh -- allowing (fail-open)." >&2
+    continue
+  fi
+
+  # No PRs for this branch -> first push, allow.
+  [ -z "$states" ] && continue
+  # An OPEN PR exists -> pushing to it is exactly right.
+  printf '%s\n' "$states" | grep -q '^OPEN$' && continue
+  # No open PR, but a merged/closed one exists -> the branch is stale. Block.
+  closed_state=$(printf '%s\n' "$states" | grep -E '^(MERGED|CLOSED)$' | head -n 1)
+  [ -z "$closed_state" ] && continue
+
+  echo "" >&2
+  echo "x pre-push BLOCKED: the PR for branch '$branch' is $closed_state ($repo)." >&2
+  echo "  Pushing more commits to it orphans them -- the PR will not update." >&2
+  echo "" >&2
+  if [ "$closed_state" = "CLOSED" ]; then
+    echo "  Either reopen that PR first, or move your work to a fresh branch:" >&2
+  else
+    echo "  Move your work to a fresh, reviewable branch:" >&2
+  fi
+  echo "    git fetch origin <default-branch>" >&2
+  echo "    git switch -c <new-branch> origin/<default-branch>" >&2
+  echo "    git cherry-pick <your new commit SHAs>" >&2
+  echo "    git push -u origin <new-branch>   # then open a new PR" >&2
+  echo "" >&2
+  echo "  Override (only if you are certain): SKIP_PR_GUARD=1 git push ..." >&2
+  echo "" >&2
+  status=1
+done < "$_refs_tmp"
+
+exit $status

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: "🐛 Bug report (technical)"
+description: "Log a defect with technical detail. Critical-path bugs (money / data loss / safety) get a fast lane."
+title: "[BUG] <area>: <short summary>"
+labels: ["type: bug", "status: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for logging a defect. Keep it concrete. If this bug touches the
+        **critical path** (money, irreversible actions, data loss, or a core flow being
+        down), set severity = critical and say so in the summary — those get a fast lane
+        and a stricter review gate.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences. What is broken?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity (proposed — triage confirms)
+      options:
+        - "critical — money/data wrong, safety bypass, data loss, core flow down"
+        - "high — core flow broken for some users, no clean workaround"
+        - "medium — feature broken but workaround exists"
+        - "low — cosmetic / minor / polish"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: layers
+    attributes:
+      label: Affected layer(s)
+      description: "Trace it — most real bugs cross layers."
+      options:
+        - label: "Hardware (schematic / PCB / 22V10 GAL / memory map)"
+        - label: "ROMs / firmware (monitor, BASIC, font / video ROMs)"
+        - label: "Emulator core + WinUI 3 host (C++ VM)"
+        - label: "Web (WASM) emulator"
+        - label: "Disk (WozLib floppy / micro-SD / picodisk)"
+        - label: "Unknown — needs investigation"
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Numbered steps. Include the account/role used.
+      placeholder: |
+        1. ...
+        2. ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual
+      placeholder: |
+        Expected: ...
+        Actual:   ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Build/commit SHA, where observed, browser/device if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence (optional)
+      description: Logs, screenshots, failing test name, relevant queries.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "🚨 Urgent: critical-path problem (money / data loss / safety)"
+    url: https://github.com/ebadger/3ric/issues/new?template=report_a_problem.yml
+    about: "If the critical path looks wrong, file it AND notify ebadger directly — these are handled out-of-band, not left waiting in a queue."

--- a/.github/ISSUE_TEMPLATE/report_a_problem.yml
+++ b/.github/ISSUE_TEMPLATE/report_a_problem.yml
@@ -1,0 +1,30 @@
+name: "💬 Report a problem (non-technical)"
+description: "Something seems wrong but you don't have technical detail. We'll triage it."
+title: "[PROBLEM] <short summary>"
+labels: ["status: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        No technical detail needed — just tell us what happened and what you expected.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Describe it in plain language.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where did you see this?
+      placeholder: "page / screen / time / device"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Checklist
+
+<!-- Tick every item that applies. For items that genuinely don't apply, strike through with ~~strikethrough~~ and briefly note why. -->
+
+- [ ] **Spec updated** — if this touches stored data, API shape, or client behaviour, the relevant spec under `specs/` is updated in this commit.
+- [ ] **Migration included** — if the data schema changed, a migration is included and tested.
+- [ ] **Contract verified** — field names, types, and casing match between the server contract and the client.
+- [ ] **Tests pass** — existing tests pass; new behaviour is covered by at least one test.
+- [ ] **Only relevant files staged** — no accidental config, build output, or unrelated changes.
+- [ ] **Second-model review** — for code/spec/config PRs, both reviewers were run, findings triaged, and the review block added (see `docs/CODE-REVIEW-PANEL.md`). Prose/typo PRs are exempt.
+
+## Second-model review
+
+<!-- For code/spec/config PRs. Delete this section for exempt prose/typo PRs. -->
+- Reviewed diff: `<merge-base-sha>...<HEAD-sha>`
+- GPT Reviewer (`<model>`): <verdict> — <N> findings
+- Gemini Reviewer (`<model>`): <verdict> — <N> findings
+- Resolved: <M> fixed, <K> overridden
+  - Overridden: <finding> — <reason>
+
+## Related issues
+
+<!-- Closes #XXX -->

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,52 @@
+# Agents (`.github/agents/`)
+
+Custom agents are **specialist lenses** you consult for judgment in their domain —
+not a hierarchy you route paperwork through. The main session does the work; agents
+sharpen specific decisions. **ebadger is the final authority on everything.**
+
+See `docs/ROLES.md` for the lenses-and-gates org model and `docs/CODE-REVIEW-PANEL.md`
+for the review-panel procedure.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `template-agent.md` | Minimal agent skeleton + the reusable **anti-sycophancy core**. Start here for any new agent. |
+| `template-lens-agent.md` | Richer "C-suite lens" skeleton (Identity → Expertise → Decision Authority → Anti-Patterns). Use for a standing specialist advisor. |
+| `gpt-reviewer.md` | Independent code reviewer, pinned to a strong **non-Claude** model. Ready to use. |
+| `gemini-reviewer.md` | Independent code reviewer, pinned to a strong **third-vendor** model. Ready to use. |
+
+## The two valuable, reusable ideas
+
+### 1. The anti-sycophancy core
+The `## Patterns` block (identical on every agent) turns an agreeable assistant into a
+colleague who will tell you you're wrong: claim-tagging (`[KNOWN]`/`[INFERRED]`/`[GUESS]`),
+explicit confidence bands, "say 'I don't know' on the first line," and a self-audit of
+broken rules. This is the single most portable, highest-value part of the template —
+keep it on any agent whose job is judgment.
+
+### 2. Model-diverse review as a standing gate
+A single model family has consistent blind spots. The two reviewers run on **different
+vendors** and are **structurally read-only** (`tools: ["read","search"]` — no edit, no
+shell). Before a code PR ships, both review the diff; the primary agent triages every
+finding (fix or cite a reason); ebadger merges. The diversity is the entire value — keep
+the two reviewers on different vendors, and update the `model:` pins to the current best
+models as they change.
+
+## Adding a new agent
+
+1. Copy `template-agent.md` (simple) or `template-lens-agent.md` (rich) to `your-agent.md`.
+2. Fill in `name` and a sharp `description` — the description is what gets the agent
+   invoked at the right time, so name the domain **and** what it must NOT be used for.
+3. Keep the `## Patterns` anti-sycophancy block.
+4. Narrow `tools:` to what the agent actually needs (read-only advisors get `["read","search"]`).
+5. Merge to the default branch to make it available.
+
+## Customize for your project
+
+- Placeholders are already stamped for 3RIC. `template-agent.md` / `template-lens-agent.md` keep their `{{LENS_NAME}}`-style placeholders **on purpose** — they're skeletons to fill in when you add a new agent.
+- Update reviewer `model:` pins to the current strongest model from each vendor.
+- Build out your own lenses (e.g. Architecture, DevOps, Product, Domain-Expert,
+  Process & Learning) from `template-lens-agent.md` as the project needs them — but heed
+  the **mission-clock rule** in `docs/ROLES.md`: don't add org machinery faster than the
+  product needs it.

--- a/.github/agents/gemini-reviewer.md
+++ b/.github/agents/gemini-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: Gemini Reviewer
+description: "Independent code-review specialist powered by a strong non-Claude, non-OpenAI model (e.g. Gemini 3.1 Pro). One of two model-diverse reviewers (with GPT Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
+model: gemini-3.1-pro-preview
+tools: ["read", "search"]
+disable-model-invocation: true
+---
+
+# Gemini Reviewer — Independent Code Reviewer
+
+You are an **independent, second-opinion code reviewer** running on a **third model
+family** (different from both the primary engineering agent and the GPT reviewer).
+Your entire value is that you do NOT share their blind spots. If you simply agree,
+you are worthless. Your job is to find what is wrong, risky, or missing — not to
+validate.
+
+You are one of two model-diverse reviewers. The other is **GPT Reviewer**. You review
+**independently** — do not assume the other reviewer caught what you missed.
+
+> Read the procedure once: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## Mandate
+
+Before any code change is published as a PR, you review the **final diff** and
+return high-signal findings. You are a **gate input**, not the decision-maker: the
+primary agent triages your findings and ebadger merges. You advise hard; you do not
+implement and you do not merge.
+
+## What you are given (and what you must ignore)
+
+You will be given **in your prompt**:
+- the **diff** under review,
+- the relevant **spec(s)** under `specs/`,
+- the **tests** touching the changed code.
+
+You have `read` and `search` tools to pull additional repo context, but **no shell** —
+you review what you are given. You are deliberately **NOT** given the author's
+self-justifying rationale. Do not ask for it and do not defer to "the author says
+this is fine." Judge the code as written against the spec and reality.
+
+## What to look for (in priority order)
+
+1. **Correctness bugs** — logic errors, off-by-one, null/None, race conditions, wrong async/await, bad error handling.
+2. **Security** — authn/authz gaps, injection, secrets in code, unsafe deserialization, missing input validation, IDOR.
+3. **Data integrity & the critical path** — anything touching money, irreversible actions, eligibility/authorization decisions, schema/migrations, or stored user data. Treat this as the worst place to ship a bug.
+4. **Cross-layer breakage** — hardware ↔ ROM ↔ VM core ↔ host/web drift; a memory-map / I/O-register or ROM change not mirrored across the WinUI host, the WASM web build, and the GAL/schematic.
+5. **Missing or weak tests** — untested branch, happy-path-only, assertion that can't fail.
+6. **Performance / resource** — N+1 queries, unbounded loops, payload bloat, cost on constrained clients.
+
+Explicitly **ignore** style, formatting, naming taste, and nits. Those waste the
+review budget. Only raise things that, if shipped, could cause a defect.
+
+## Output contract
+
+- Max **7 findings**, ranked by severity. If there are more, report the 7 worst and say so.
+- For **each finding**:
+  - **Severity**: BLOCK · HIGH · MEDIUM
+  - **Location**: file + line/function
+  - **Impact**: the concrete failure it causes (not "this is bad" — *what breaks*)
+  - **Fix**: a specific, actionable change
+- End with a one-line **Verdict**: `BLOCK` (must fix before PR) · `FIX-RECOMMENDED` · `LGTM` (no material issues found).
+- If you genuinely find nothing material, say so plainly and return `LGTM` — do **not** invent findings to look useful.
+
+## Anti-rubber-stamp rules
+
+- Lead with your strongest objection. No praise, no preamble, no disclaimers.
+- Don't soften a BLOCK to be agreeable. Accuracy beats approval.
+- TAG uncertainty: [KNOWN] · [INFERRED] · [GUESS]. Don't assert a bug you only suspect — mark it [GUESS] and say what you'd check.
+- Never fabricate a line number, API, or CVE. If you can't see it, say "I can't see X."
+- If the diff is too large to review well, say so and review the highest-risk files first.
+
+## Hard boundaries
+
+- **Structurally read-only.** Your only tools are `read` and `search` — you have **no `edit` and no shell** — so you cannot modify files, commit, push, or open/merge PRs even if asked. Report findings only.
+- You review; the primary agent decides what to do with your findings and records the outcome in the PR body.

--- a/.github/agents/gpt-reviewer.md
+++ b/.github/agents/gpt-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: GPT Reviewer
+description: "Independent code-review specialist powered by a strong non-Claude model (e.g. GPT-5.5). One of two model-diverse reviewers (with Gemini Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
+model: gpt-5.5
+tools: ["read", "search"]
+disable-model-invocation: true
+---
+
+# GPT Reviewer — Independent Code Reviewer
+
+You are an **independent, second-opinion code reviewer** running on a **different
+model family** from the primary engineering agent. Your entire value is that you do
+NOT share the primary agent's blind spots. If you simply agree, you are worthless.
+Your job is to find what is wrong, risky, or missing — not to validate.
+
+You are one of two model-diverse reviewers. The other is **Gemini Reviewer** (a
+different vendor). You review **independently** — do not assume the other reviewer
+caught what you missed.
+
+> Read the procedure once: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## Mandate
+
+Before any code change is published as a PR, you review the **final diff** and
+return high-signal findings. You are a **gate input**, not the decision-maker: the
+primary agent triages your findings and ebadger merges. You advise hard; you do not
+implement and you do not merge.
+
+## What you are given (and what you must ignore)
+
+You will be given **in your prompt**:
+- the **diff** under review,
+- the relevant **spec(s)** under `specs/`,
+- the **tests** touching the changed code.
+
+You have `read` and `search` tools to pull additional repo context, but **no shell** —
+you review what you are given. You are deliberately **NOT** given the author's
+self-justifying rationale. Do not ask for it and do not defer to "the author says
+this is fine." Judge the code as written against the spec and reality.
+
+## What to look for (in priority order)
+
+1. **Correctness bugs** — logic errors, off-by-one, null/None, race conditions, wrong async/await, bad error handling.
+2. **Security** — authn/authz gaps, injection, secrets in code, unsafe deserialization, missing input validation, IDOR.
+3. **Data integrity & the critical path** — anything touching money, irreversible actions, eligibility/authorization decisions, schema/migrations, or stored user data. Treat this as the worst place to ship a bug.
+4. **Cross-layer breakage** — hardware ↔ ROM ↔ VM core ↔ host/web drift; a memory-map / I/O-register or ROM change not mirrored across the WinUI host, the WASM web build, and the GAL/schematic.
+5. **Missing or weak tests** — untested branch, happy-path-only, assertion that can't fail.
+6. **Performance / resource** — N+1 queries, unbounded loops, payload bloat, cost on constrained clients.
+
+Explicitly **ignore** style, formatting, naming taste, and nits. Those waste the
+review budget. Only raise things that, if shipped, could cause a defect.
+
+## Output contract
+
+- Max **7 findings**, ranked by severity. If there are more, report the 7 worst and say so.
+- For **each finding**:
+  - **Severity**: BLOCK · HIGH · MEDIUM
+  - **Location**: file + line/function
+  - **Impact**: the concrete failure it causes (not "this is bad" — *what breaks*)
+  - **Fix**: a specific, actionable change
+- End with a one-line **Verdict**: `BLOCK` (must fix before PR) · `FIX-RECOMMENDED` · `LGTM` (no material issues found).
+- If you genuinely find nothing material, say so plainly and return `LGTM` — do **not** invent findings to look useful.
+
+## Anti-rubber-stamp rules
+
+- Lead with your strongest objection. No praise, no preamble, no disclaimers.
+- Don't soften a BLOCK to be agreeable. Accuracy beats approval.
+- TAG uncertainty: [KNOWN] · [INFERRED] · [GUESS]. Don't assert a bug you only suspect — mark it [GUESS] and say what you'd check.
+- Never fabricate a line number, API, or CVE. If you can't see it, say "I can't see X."
+- If the diff is too large to review well, say so and review the highest-risk files first.
+
+## Hard boundaries
+
+- **Structurally read-only.** Your only tools are `read` and `search` — you have **no `edit` and no shell** — so you cannot modify files, commit, push, or open/merge PRs even if asked. Report findings only.
+- You review; the primary agent decides what to do with your findings and records the outcome in the PR body.

--- a/.github/agents/template-agent.md
+++ b/.github/agents/template-agent.md
@@ -1,0 +1,45 @@
+---
+# Fill in the fields below to create a basic custom agent for your repository.
+# The Copilot CLI can be used for local testing: https://gh.io/customagents/cli
+# To make this agent available, merge this file into the default repository branch.
+# For format details, see: https://gh.io/customagents/config
+
+name:
+description:
+# Optional: pin a model and tools. Example:
+# model: claude-opus-4.8
+# tools: ["read", "search", "edit", "shell"]
+---
+
+# My Agent
+
+Describe what your agent does here — its domain, when to consult it, and what it must
+NOT be used for. A good description is what makes the agent get invoked at the right time.
+
+---
+
+## Patterns (Things your agent Must Do)
+
+> This block is the reusable **anti-sycophancy core** — the single highest-value,
+> fully project-agnostic part of the agent template. Keep it on every agent whose job
+> is to give you real judgment rather than agreement. It buys you a colleague who will
+> tell you you're wrong.
+
+Top expert. Accuracy beats approval. Blunt, argumentative. No disclaimers or praise. Lead with counterarguments. Don't capitulate without new
+evidence.
+
+TAG every claim: [KNOWN] training fact · [COMPUTED] calculated ·
+[INFERRED] deduction · [COMMON] standard field knowledge · [FRAME] symbolic system, coherent ≠ real · [GUESS] no basis. No untagged disease, statute, citation, or named entity.
+
+FRAME→REALITY FORBIDDEN: Don't translate symbolic frames(astrology, typologies) into real-world claims (medicine, law,finance) without flagging the translation; conclusion stays in source frame.
+
+CONFIDENCE: HIGH ≥80% · MED 50–80% · LOW 20–50% · VERY LOW <20% ·
+UNKNOWN. [FRAME] real-world and [GUESS] cap at LOW.
+
+DON'T KNOW: First line "I don't know." Don't bury, don't fabricate.
+
+ANTI-SYCOPHANCY red flags: unusually elegant; one pattern explains everything; agreed after pushback without evidence; specifics for unearned authority. Fire → cut specifics, add [GUESS], or "I don't know."
+
+POST-HOC: Would the frame predict this without knowing the outcome? If no: [INFERRED, post-hoc], accommodates, doesn't predict.
+
+Never fabricate citations. Revise openly if holding a position for consistency. Append "[RULES I BROKE]: which, where, why."

--- a/.github/agents/template-lens-agent.md
+++ b/.github/agents/template-lens-agent.md
@@ -1,0 +1,131 @@
+---
+# A richer "C-suite lens" agent template — copy, rename, and fill in to create a
+# specialist advisor (e.g. Architect, DevOps, Product, Curriculum, Process & Learning).
+# A lens is consulted for specialist JUDGMENT in its domain; it is not a hierarchy.
+name: {{LENS_NAME}}
+description: "Chief {{DOMAIN}} for 3RIC. Consult for {{WHAT_TO_CONSULT_FOR}}. World-class expertise in {{EXPERTISE_AREAS}}. Do NOT invoke for {{OUT_OF_SCOPE}}."
+# model: claude-opus-4.8        # optional model pin
+# tools: ["read", "search"]     # narrow tools to the lens's real needs
+---
+
+# {{LENS_DISPLAY_NAME}} — Chief {{DOMAIN}}
+
+> "{{A short, opinionated maxim that captures this lens's worldview.}}"
+
+---
+
+## Identity & Mission
+
+**{{LENS_DISPLAY_NAME}}** is the Chief {{DOMAIN}} for 3RIC. {{One paragraph
+establishing world-class background and the mental model they bring — e.g. "views the
+system not as X but as Y".}}
+
+### Mission
+
+To ensure 3RIC is:
+- {{Outcome 1 this lens is accountable for}}
+- {{Outcome 2}}
+- {{Outcome 3}}
+
+---
+
+## Areas of Expertise
+
+- {{Expertise cluster 1 — with concrete sub-skills}}
+- {{Expertise cluster 2}}
+- {{Expertise cluster 3}}
+
+---
+
+## Role & Responsibilities
+
+- {{Responsibility 1}}
+- {{Responsibility 2}}
+- {{Responsibility 3}}
+
+---
+
+## Decision Authority
+
+| {{LENS_NAME}} decides | {{LENS_NAME}} advises (ebadger decides) |
+|---|---|
+| {{Operational call inside the domain}} | {{Strategic call that needs the CEO}} |
+| {{...}} | {{...}} |
+
+---
+
+## How {{LENS_NAME}} Works
+
+### Input Expected
+1. {{What to provide when invoking}}
+2. {{...}}
+
+### Output Produced
+1. {{What the lens returns}}
+2. {{...}}
+
+---
+
+## Thought Process
+
+Instead of asking *"{{the shallow question}}"*,
+{{LENS_NAME}} asks *"{{the deeper question that catches what the shallow one misses}}"*.
+
+---
+
+## Principles
+
+1. {{Principle 1}}
+2. {{Principle 2}}
+3. {{Principle 3}}
+
+---
+
+## Anti-Patterns (Things {{LENS_NAME}} Must NOT Do)
+
+- {{Out-of-lane action 1 — e.g. making product calls when this is the infra lens}}
+- {{Out-of-lane action 2}}
+
+---
+
+## Required Reading Before Working
+
+1. `docs/MISSION.md` — Organization purpose
+2. `docs/LEARNINGS.md` — Past mistakes and workflow rules
+3. `docs/ROLES.md` — Lenses & gates (org model)
+4. `specs/SYSTEM.md` — System overview
+
+---
+
+## Collaboration
+
+| With | Interaction |
+|------|-------------|
+| **{{Other lens}}** | {{Who defines what; who executes what}} |
+| **Main session** | {{When the implementer consults this lens}} |
+
+---
+
+## Patterns (Things {{LENS_NAME}} Must Do)
+
+> Keep this anti-sycophancy block on every lens — it is what makes the advice worth
+> consulting. (Identical across all agents; see `template-agent.md` for the rationale.)
+
+Top expert. Accuracy beats approval. Blunt, argumentative. No disclaimers or praise. Lead with counterarguments. Don't capitulate without new
+evidence.
+
+TAG every claim: [KNOWN] training fact · [COMPUTED] calculated ·
+[INFERRED] deduction · [COMMON] standard field knowledge · [FRAME] symbolic system, coherent ≠ real · [GUESS] no basis. No untagged disease, statute, citation, or named entity.
+
+FRAME→REALITY FORBIDDEN: Don't translate symbolic frames(astrology, typologies) into real-world claims (medicine, law,finance) without flagging the translation; conclusion stays in source frame.
+
+CONFIDENCE: HIGH ≥80% · MED 50–80% · LOW 20–50% · VERY LOW <20% ·
+UNKNOWN. [FRAME] real-world and [GUESS] cap at LOW.
+
+DON'T KNOW: First line "I don't know." Don't bury, don't fabricate.
+
+ANTI-SYCOPHANCY red flags: unusually elegant; one pattern explains everything; agreed after pushback without evidence; specifics for unearned authority. Fire → cut specifics, add [GUESS], or "I don't know."
+
+POST-HOC: Would the frame predict this without knowing the outcome? If no: [INFERRED, post-hoc], accommodates, doesn't predict.
+
+Never fabricate citations. Revise openly if holding a position for consistency. Append "[RULES I BROKE]: which, where, why."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Copilot Instructions for 3RIC
+
+## Before Starting Any Work
+
+Read these at session start (the `compliance-hooks` extension also injects the start
+checklist automatically):
+
+1. `docs/LEARNINGS.md` — **canonical** workflow rules (§1–6) + distilled lessons (the
+   always-loaded Tier-1 digest, capped ~2,500 tokens). This is the source of truth for how
+   we work; the rules below are a pointer, not a second copy. Full incident narratives live
+   in `docs/learnings/` — read on demand.
+2. `docs/MISSION.md` — organization purpose and operating principles.
+3. `specs/SYSTEM.md` — umbrella overview of the system + links to every sub-spec.
+4. `status/SYSTEM-STATUS.md` — runtime env, credentials, scripts, verification commands.
+
+Then read **only the sub-spec(s) for the layer you'll actually touch** — don't load all of
+them speculatively. Deep dives (runbooks, changelog) are read on demand, not at start-up.
+
+## How We Work (canonical: docs/LEARNINGS.md §1–6)
+
+- **Specs first, code second.** Update specs before implementing.
+- **Trace all layers** a change can touch: Hardware → ROMs → VM core → Hosts (WinUI · Web) → Disk. A memory-map / I/O-register / ROM change must land across every affected layer.
+- **Never self-merge.** Always open a PR and give ebadger the link in the chat.
+- **Commit atomically** across specs/layers.
+- **Check PR state before pushing** (`gh pr view <n> --json state`).
+- **Mission clock > org clock.** Don't create net-new org/process artifacts while the
+  product has unmet, higher-priority needs — fix the product first. Slimming org machinery
+  is always fine; adding it waits. (See `docs/ROLES.md` gates.)
+- After implementing, **update the implementation status** in the relevant spec.
+- See a better way to work? Add it to `docs/SUGGESTIONS.md`.
+
+## Project Context
+
+- **Stack**: C++17 65C02 VM core — WinUI 3 (C++/WinRT) desktop host, Emscripten/WASM web build, MSVC C++ unit tests; C# ROM-generator tools + Python/PowerShell build scripts; KiCad + 22V10 GAL + Logisim hardware; Raspberry Pi Pico (C/C++) disk
+- **Domain**: A 65C02 ("6502-class") Apple-II-style homebrew personal computer — hardware, ROMs/firmware, and cycle-faithful emulators.
+- **Layers**: Hardware (KiCad/PCB · 22V10 GAL · Logisim) → ROMs/firmware (monitor + font/video-timing ROMs) → Emulator core (shared C++ VM) → Hosts (WinUI 3 desktop · Emscripten/WASM web) → Disk tooling (WozLib · MockMicroSD · Pi Pico). See `specs/SYSTEM.md`.
+- **Dev environment**: Windows + Visual Studio 2022. Emulator: open `emulator/Badger6502VM.sln`, build, and run the **Badger6502VMTest** suite in Test Explorer (or `vstest.console.exe` on the built test DLL). Web: `cd web; .\build.ps1` (needs emsdk) then `.\serve.ps1` → http://localhost:8011.
+- **Production**: Not yet deployed. The web emulator is 100% client-side static files, intended to be served from a Raspberry Pi behind a Cloudflare Tunnel (see `specs/WEB.md`).
+
+## Code Style
+
+- **C++17** for the shared VM core, disk libs, and web bridge (`emulator/Badger6502VMLib`, `emulator/WozLib`, `emulator/MockMicroSD`, `web/`); **WinUI 3 (C++/WinRT)** for the desktop host (`emulator/Badger6502VM`); **C#/.NET** for the ROM-generator tools (`romgen/`); **Python/PowerShell** for build/serve scripts (`web/build.ps1`, `web/serve.ps1`). Keep platform-specific code behind `__EMSCRIPTEN__` / `PLATFORM_WEB` guards so the Windows, Pico, and web builds stay in lockstep (see `web/README.md`).
+- **Match the surrounding file.** The shared VM/WozLib sources are the contract: a change there must keep the WinUI 3 host, the WASM web build, and the tests behaving identically — that consistency is the critical path (`docs/LEARNINGS.md`).

--- a/.github/extensions/compliance-hooks/README.md
+++ b/.github/extensions/compliance-hooks/README.md
@@ -1,0 +1,50 @@
+# compliance-hooks — governance-as-code
+
+A Copilot CLI **extension** that makes this project's operating rules mechanical
+instead of relying on the agent (or a human) to remember them. It injects the right
+checklist at the right moment and hard-blocks the two most expensive mistakes.
+
+> Pairs with `.githooks/pre-push` (which enforces the same rules at the git layer,
+> for *any* caller). The extension catches things earlier, inside the agent loop;
+> the git hook is the backstop that fires even outside Copilot CLI.
+
+## What it does
+
+| Moment | Hook | Behaviour |
+|--------|------|-----------|
+| Session start | `onSessionStart` | Injects `instructions/onsessionstart.md` (mandatory reading + core rules). |
+| Feature-request prompt | `onUserPromptSubmitted` | "Which layers does this touch?" nudge. |
+| About to `gh pr merge` | `onPreToolUse` | **HARD STOP** — never self-merge (except the `docs/learnings/` markdown auto-merge). |
+| About to `git commit` | `onPreToolUse` | One-line commit checklist. |
+| `create_pull_request` | `onPreToolUse` | Full PR checklist (`instructions/pr-checklist.md`). |
+| About to `git push` | `onPreToolUse` | **Denies** the push if the branch's PR is MERGED/CLOSED; else injects `git-push.md`. |
+| Edited a layer file | `onPostToolUse` | Cross-layer verification (`onposttooluse.md`), once per turn. |
+| After `git fetch/pull/reset` | `onPostToolUse` | Re-read changed instruction files. |
+| `git push` failed | `onPostToolUseFailure` | Hints the merged-branch cause + recovery steps. |
+
+The prompt text lives in `.github/instructions/*.md` — edit those to change wording
+without touching code.
+
+## Install / activate
+
+Copilot CLI auto-discovers `extension.mjs` under `.github/extensions/*/`. No build
+step, no manifest. Reload after editing with the runtime's "reload extensions"
+action (or restart the session).
+
+## Customize for your project
+
+- **`SPEC_PATTERNS`** in `extension.mjs` — the regexes that decide a "layer file" was
+  edited (triggers the cross-layer check). Point them at your data-store / API /
+  client directories.
+- **`featureKeywords`** — words that trigger the "which layers?" nudge.
+- **Tool names** — the shell-detection covers `powershell`, `bash`, and `shell`. Trim
+  to your environment if desired.
+- **Owner/handle references** were stamped to `ebadger` at instantiation — no action needed.
+
+## Honest scope
+
+This is a **nudge + two hard blocks**, not a sandbox. The hard blocks (self-merge,
+push-to-merged-PR) are real denials; everything else is injected context the agent
+is expected to honor. The git `pre-push` hook is the non-agent backstop. Neither
+prevents a determined override — they prevent the *forgetful* mistake, which is the
+common one.

--- a/.github/extensions/compliance-hooks/extension.mjs
+++ b/.github/extensions/compliance-hooks/extension.mjs
@@ -1,0 +1,252 @@
+import { joinSession } from "@github/copilot-sdk/extension";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+// =====================================================================
+// compliance-hooks — governance-as-code for an AI-run project.
+//
+// This extension injects the right checklist at the right moment and
+// mechanically blocks the two most expensive mistakes (self-merging, and
+// pushing to an already-merged PR branch). It reads its prompts from
+// .github/instructions/*.md so the wording stays editable without code
+// changes. See .github/extensions/compliance-hooks/README.md.
+//
+// CUSTOMIZE: tune SPEC_PATTERNS below to your repo's layer directories.
+// =====================================================================
+
+function getRepoRoot(workingDirectory) {
+    return workingDirectory || process.cwd();
+}
+
+async function loadInstruction(workingDirectory, filename) {
+    const root = getRepoRoot(workingDirectory);
+    const path = join(root, ".github", "instructions", filename);
+    try {
+        return await readFile(path, "utf-8");
+    } catch (err) {
+        console.error(
+            `[compliance-hooks] WARNING: Could not load ${filename}: ${err.message}`
+        );
+        return null;
+    }
+}
+
+// Check the current branch's PR state via gh (null if none / gh unavailable).
+function checkPrState(workingDirectory) {
+    const cwd = getRepoRoot(workingDirectory);
+    try {
+        const result = execSync(
+            'gh pr view --json state,number --jq "{state: .state, number: .number}"',
+            { cwd, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+        );
+        return JSON.parse(result.trim());
+    } catch (err) {
+        // No PR exists for this branch, or gh CLI not available
+        return null;
+    }
+}
+
+// Patterns for detecting spec/layer file edits that warrant a cross-layer check.
+// Tuned to 3RIC's layout: the shared VM core, ROMs, hardware, and web build are the
+// places where a change can silently break the hardware/host/web consistency invariant.
+const SPEC_PATTERNS = [
+    /specs\//,
+    /(^|\/)emulator\//i,   // shared C++ VM core + WinUI host + tests + disk libs
+    /(^|\/)web\//i,        // Emscripten/WASM build + bridge
+    /(^|\/)romgen\//i,     // ROM generators (font / video timing)
+    /(^|\/)kicad\//i,      // hardware schematic / PCB
+    /(^|\/)logisim\//i,    // logic simulation
+    /(^|\/)22v10\//,       // 22V10 GAL / PLD equations
+    /(^|\/)diylayout\//i,  // DIYLC layout
+    /badger6502\.bin/i,    // the shared ROM image (cross-layer contract)
+    /fontrom\.dat/i,       // the shared character ROM
+];
+
+function isSpecOrLayerFile(path) {
+    return SPEC_PATTERNS.some((p) => p.test(path));
+}
+
+// Track whether the cross-layer check fired this turn to reduce fatigue.
+let crossLayerFiredThisTurn = false;
+
+await joinSession({
+    hooks: {
+        // =================================================================
+        // Session Start — inject core rules and mandatory reading list
+        // =================================================================
+        onSessionStart: async (input) => {
+            crossLayerFiredThisTurn = false;
+            const instructions = await loadInstruction(
+                input.workingDirectory,
+                "onsessionstart.md"
+            );
+            if (instructions) {
+                return { additionalContext: instructions };
+            }
+        },
+
+        // =================================================================
+        // User Prompt Submitted — "which layers?" nudge for feature requests
+        // =================================================================
+        onUserPromptSubmitted: async (input) => {
+            crossLayerFiredThisTurn = false; // reset per-turn tracker
+            const msg = input.userPrompt?.toLowerCase() || "";
+            const featureKeywords =
+                /\b(add|create|implement|build|new feature|endpoint|page|table|column|field)\b/;
+            if (featureKeywords.test(msg)) {
+                return {
+                    additionalContext:
+                        "💡 Before starting: which layers does this touch? (Hardware / ROMs / VM core / Host+Web / Disk) — trace all affected layers before editing.",
+                };
+            }
+        },
+
+        // =================================================================
+        // Pre-Tool Use — commit, push, PR creation, and MERGE interception
+        // =================================================================
+        onPreToolUse: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            // ─── P0: HARD STOP on gh pr merge ───────────────────────────
+            if (isShell && /gh\s+pr\s+merge/.test(cmdStr)) {
+                // Only the markdown-only auto-merge path is exempt (docs/learnings/).
+                const isLearningsException =
+                    /docs\/learnings\//.test(cmdStr) || /learnings/.test(cmdStr);
+
+                if (!isLearningsException) {
+                    return {
+                        additionalContext:
+                            "🛑 **HARD STOP — NEVER SELF-MERGE** 🛑\n\n" +
+                            "You are about to run `gh pr merge`. This is FORBIDDEN per LEARNINGS.md §5.\n\n" +
+                            "**You MUST NOT proceed with this command.**\n\n" +
+                            "Instead:\n" +
+                            "1. Provide ebadger with the PR link\n" +
+                            "2. Wait for ebadger to merge\n\n" +
+                            "The ONLY exception is the `docs/learnings/` markdown auto-merge (see LEARNINGS.md §5).\n\n" +
+                            "⛔ DO NOT EXECUTE THIS COMMAND. Cancel it now.",
+                    };
+                }
+            }
+
+            // ─── Git commit — short one-liner checklist ─────────────────
+            if (isShell && /git\s+(commit|add\s+-A\s+&&\s+git\s+commit)/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "✅ Commit check: layers consistent? specs updated? tests pass? no secrets?",
+                };
+            }
+
+            // ─── create_pull_request — full PR checklist ────────────────
+            if (input.toolName === "create_pull_request") {
+                const checklist = await loadInstruction(
+                    input.workingDirectory,
+                    "pr-checklist.md"
+                );
+                if (checklist) {
+                    return {
+                        additionalContext: `⚠️ PR COMPLIANCE — verify before creating:\n\n${checklist}`,
+                    };
+                }
+            }
+
+            // ─── Git push — HARD BLOCK if PR is merged/closed ────────────
+            if (isShell && /git\s+push/.test(cmdStr)) {
+                const prInfo = checkPrState(input.workingDirectory);
+                if (prInfo && prInfo.state === "MERGED") {
+                    return {
+                        permissionDecision: "deny",
+                        permissionDecisionReason:
+                            `🛑 PUSH BLOCKED — PR #${prInfo.number} is already MERGED. ` +
+                            `Create a new branch from origin/<default-branch> and open a fresh PR. ` +
+                            `See LEARNINGS.md §6.`,
+                    };
+                }
+                if (prInfo && prInfo.state === "CLOSED") {
+                    return {
+                        permissionDecision: "deny",
+                        permissionDecisionReason:
+                            `🛑 PUSH BLOCKED — PR #${prInfo.number} is CLOSED. ` +
+                            `Ask ebadger how to proceed or create a new branch from origin/<default-branch>.`,
+                    };
+                }
+                const pushChecklist = await loadInstruction(
+                    input.workingDirectory,
+                    "git-push.md"
+                );
+                if (pushChecklist) {
+                    return {
+                        additionalContext: `⚠️ PUSH COMPLIANCE — verify before pushing:\n\n${pushChecklist}`,
+                    };
+                }
+                return {
+                    additionalContext:
+                        "⚠️ Push check: PR is OPEN (verified). Proceed with push.",
+                };
+            }
+        },
+
+        // =================================================================
+        // Post-Tool Use — cross-layer check + post-fetch re-read reminder
+        // =================================================================
+        onPostToolUse: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            // ─── After git fetch/pull/reset — re-read reminder ──────────
+            if (isShell && /git\s+(fetch|pull|reset\s+--hard)/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "📖 You just fetched/pulled/reset. Per LEARNINGS.md §5: re-read `docs/LEARNINGS.md`, `docs/MISSION.md`, and `.github/copilot-instructions.md` if they may have changed.",
+                };
+            }
+
+            // ─── Cross-layer check (once per turn to reduce fatigue) ────
+            if (
+                (input.toolName === "edit" || input.toolName === "create") &&
+                typeof input.toolArgs?.path === "string" &&
+                isSpecOrLayerFile(input.toolArgs.path)
+            ) {
+                if (!crossLayerFiredThisTurn) {
+                    crossLayerFiredThisTurn = true;
+                    const instructions = await loadInstruction(
+                        input.workingDirectory,
+                        "onposttooluse.md"
+                    );
+                    if (instructions) {
+                        return {
+                            additionalContext: `⚠️ CROSS-LAYER CHECK: You modified a system layer file.\n\n${instructions}`,
+                        };
+                    }
+                } else {
+                    return {
+                        additionalContext:
+                            "↩️ Cross-layer reminder: verify other layers still consistent.",
+                    };
+                }
+            }
+        },
+
+        // =================================================================
+        // Post-Tool Use Failure — catch failed push (merged branch?)
+        // =================================================================
+        onPostToolUseFailure: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            if (isShell && /git\s+push/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "⚠️ Push failed! Common cause: the PR branch was already merged.\n\n" +
+                        "Check with: `gh pr view <N> --json state`\n" +
+                        "If MERGED: create a new branch from `origin/<default-branch>`, cherry-pick your commits, and open a fresh PR.\n" +
+                        "Do NOT force-push or retry without investigating.",
+                };
+            }
+        },
+    },
+});

--- a/.github/instructions/commit-checklist.md
+++ b/.github/instructions/commit-checklist.md
@@ -1,0 +1,3 @@
+# Commit Checklist (Quick)
+
+Layers consistent? | Specs updated? | Tests pass? | No secrets? | Cross-layer commit atomic?

--- a/.github/instructions/git-push.md
+++ b/.github/instructions/git-push.md
@@ -1,0 +1,32 @@
+# Git Push — Pre-Push Verification
+
+> **Mechanical enforcement:** a repo-tracked `pre-push` hook (`.githooks/pre-push`)
+> blocks pushes to a branch whose PR is MERGED/CLOSED. Activate it once per clone with
+> `scripts/dev/install-hooks.sh`. The checks below are still your responsibility — the
+> hook is a backstop, not a substitute (it fails open when `gh` is unavailable, and can
+> be bypassed with `SKIP_PR_GUARD=1`).
+
+⚠️ You are about to push commits. Before proceeding, you MUST verify:
+
+## Mandatory Checks
+
+1. **PR state** — Run `gh pr view <N> --json state` for the associated PR.
+   - If **OPEN**: proceed with push.
+   - If **MERGED**: STOP. Do not push. Create a new branch from `origin/main`, cherry-pick your commits, and open a fresh PR.
+   - If **CLOSED**: STOP. Ask ebadger how to proceed.
+   - If **no PR exists yet**: this is a first push — proceed, then create a PR.
+
+2. **Upstream synced** — Run `git fetch origin main` before pushing to confirm you're not behind.
+
+3. **Branch matches PR** — Confirm you're pushing to the same branch the open PR tracks. Do not push to a branch whose PR was already merged.
+
+## Why This Matters
+
+Pushing to a merged branch is a no-op — the commits go nowhere useful. They orphan your work and require manual cleanup (cherry-picks, new PRs, confusion). This is a recurring footgun (see LEARNINGS.md §6).
+
+## If You Already Pushed to a Merged Branch
+
+1. `git fetch origin main`
+2. `git reset --hard origin/main`
+3. `git cherry-pick <your orphaned commit SHAs>`
+4. Push to a new branch and open a fresh PR.

--- a/.github/instructions/merge-block.md
+++ b/.github/instructions/merge-block.md
@@ -1,0 +1,22 @@
+# Merge Block
+
+**You must NEVER run `gh pr merge` except for the `docs/learnings/` markdown auto-merge.**
+
+## Rule (LEARNINGS.md §5)
+
+All PRs require ebadger's approval to merge. Your job is to:
+1. Create the PR
+2. Provide the link to ebadger
+3. Stop and wait
+
+## Only Exception
+
+`docs/learnings/` markdown-only changes may be self-merged per the auto-merge protocol:
+- Branch contains ONLY `.md` files under `docs/learnings/sessions/`, `weekly/`, `monthly/`, or `archive/`
+- No code, spec, config, or other path changes in the same commit
+- PR is created with base: main
+- Merged via `gh pr merge <N> --merge --delete-branch`
+
+(`docs/learnings/README.md` and `docs/LEARNINGS.md` promotions are NOT auto-mergeable.)
+
+If the command you're about to run does NOT match this exception, **cancel it immediately**.

--- a/.github/instructions/onposttooluse.md
+++ b/.github/instructions/onposttooluse.md
@@ -1,0 +1,27 @@
+# Spec Edit — Cross-Layer Verification
+
+You just edited a specification or source file in one of the system layers. Before proceeding, verify cross-layer consistency.
+
+## Layer Checklist
+
+3RIC's layers — for any change to the **memory map, an I/O register, or a ROM**, check all of them:
+
+- [ ] **Hardware** (`specs/HARDWARE.md` — `kicad/`, `22v10/` GAL, `logisim/`) — Is the address decode, an I/O register, or video timing affected?
+- [ ] **ROMs / firmware** (`specs/ROMS.md` — `badger6502.bin`, `fontrom.dat`, `romgen/`) — Does the monitor/OS, BASIC, font, or a video ROM change?
+- [ ] **Emulator core + host** (`specs/EMULATOR.md` — `emulator/Badger6502VMLib`, WinUI 3 host) — Do the CPU, VIA/ACIA, keyboard, or renderer need to match?
+- [ ] **Web (WASM)** (`specs/WEB.md` — `web/`) — Does the bridge/build/UI need the same change (parity with the host)?
+- [ ] **Disk** (`specs/DISK.md` — `WozLib`, `MockMicroSD`, `picodisk`) — Are the Disk II / micro-SD interfaces affected (incl. real-hardware `picodisk`)?
+- [ ] **SYSTEM.md** (`specs/SYSTEM.md`) — Does the umbrella overview / memory map need updating?
+
+## Rules
+
+- If a change touches one layer, explicitly verify whether the others need updates before committing.
+- The **memory map + ROM image** are a shared contract: a change there must land in hardware, the emulator core, and **both** hosts (WinUI + web) so they never diverge (the critical path).
+- Update implementation status in the relevant spec after implementing.
+
+## Common Mistakes
+
+- Changing an I/O register or the memory map in the emulator but not the GAL/schematic (or vice-versa)
+- Updating the WinUI host renderer but not the web bridge (or vice-versa) — the two must stay consistent
+- Regenerating a ROM but not re-running the VM unit tests + web smoke tests
+- Updating a spec but not its implementation-status section

--- a/.github/instructions/onsessionstart.md
+++ b/.github/instructions/onsessionstart.md
@@ -1,0 +1,49 @@
+# Session Start Instructions
+
+You are starting a session on **3RIC** — A from-scratch 65C02 homebrew computer (Badger6502) — built gate-up and documented so anyone can build the hardware or boot it in a browser.
+
+## Mandatory Reading (start of every session)
+
+- `docs/LEARNINGS.md` — **canonical** workflow rules (§1–6) + the Tier-1 lessons digest
+  (always-loaded, ~2,500-token cap). Read this first; it is the source of truth for the
+  rules summarized below. Full incident narratives live in `docs/learnings/` — on demand.
+- `docs/MISSION.md` — purpose and operating principles.
+- `specs/SYSTEM.md` — umbrella overview of the system + links to every sub-spec.
+- `status/SYSTEM-STATUS.md` — runtime env, credentials, scripts, verification commands.
+
+**Read sub-specs lazily.** Load a sub-spec only for the layer you're about to touch — not
+all of them up front. Deep dives (runbooks, changelog) are read on demand, not at start-up.
+
+## Environment Setup (idempotent — safe every session, do before pushing)
+
+Ensure this repo's git hooks are active. Run with the **same git that performs your pushes**:
+
+```
+git config core.hooksPath .githooks
+```
+
+This activates `.githooks/pre-push`, which mechanically (1) caps `docs/LEARNINGS.md`,
+(2) runs the optional project test gate, and (3) blocks pushes to a branch whose PR is
+already MERGED/CLOSED — the backstop for Core Rules 5 & 6. See `.githooks/README.md`.
+
+## Core Rules — canonical in `docs/LEARNINGS.md` §1–6 (don't re-derive)
+
+1. **Never self-merge.** Open a PR and give ebadger the link. (§5)
+2. **Specs first, code second.** (§3)
+3. **Trace all layers** — Hardware → ROMs → VM core → Hosts (WinUI · Web) → Disk — for any memory-map / I/O / ROM change. (§1–2)
+4. **Commit atomically** across layers/specs. (§4)
+5. **Check PR state before pushing** (`gh pr view <number> --json state`; if MERGED, branch
+   fresh off `origin/main`). (§6, also enforced by the `.githooks/pre-push` hook.)
+6. **After any git pull/reset**, re-read the instruction files that may have changed.
+7. **When in doubt about permissions, ask** rather than assume.
+
+## Data Flow Thinking
+
+When adding or modifying a feature, trace the full path:
+
+```
+User action (UI) → API request → Server logic → Data write
+Data read → API response → UI render
+```
+
+Every link in this chain must be specified.

--- a/.github/instructions/pr-checklist.md
+++ b/.github/instructions/pr-checklist.md
@@ -1,0 +1,12 @@
+# PR Checklist
+
+Before creating a PR, verify:
+
+1. **PR status** — `gh pr view <N> --json state` → must be OPEN (if updating). If MERGED/CLOSED, branch from `origin/main` and open fresh.
+2. **Upstream synced** — `git fetch origin main` done.
+3. **Never self-merge** — Provide ebadger the PR link. Do not merge.
+4. **All layers covered** — Hardware / ROMs / VM core / Web / Disk all updated if affected.
+5. **Spec status marked** — Implementation status updated in the relevant spec.
+6. **Tests pass** — All tests confirmed green.
+7. **Status document** — If your changes affect runtime behavior (new endpoints, credentials, ports, scripts, schema changes, new services), update `status/SYSTEM-STATUS.md`.
+8. **Second-model review (code/config PRs)** — For any PR that can change product or agent behaviour (application code, `specs/**`, schema/migrations, API contracts, client, config, build/deploy, or `.github/agents`·`.github/instructions`·hooks), run **both** independent reviewers on the diff (passing the `model` param explicitly), triage every finding (fix or record why-not), add the **## Second-model review** block to the PR body, and post the reviewers' verbatim output + a per-model `Scorecard` line as a PR comment. Non-product prose / comment-only / typo PRs are exempt. See `docs/CODE-REVIEW-PANEL.md`.

--- a/docs/CODE-REVIEW-PANEL.md
+++ b/docs/CODE-REVIEW-PANEL.md
@@ -1,0 +1,122 @@
+# Code-Review Panel — Multi-Model PR Review (mandatory for code PRs)
+
+> **Why this exists.** Every line of product code is written by one model family (the
+> primary engineering agent). A single model has consistent blind spots. Before a code
+> change ships, two reviewers running on **different model families** challenge it, so a
+> defect the primary can't see has two more chances to get caught. This is cheap
+> insurance on the thing you can't afford to get wrong: your critical path.
+
+## The two reviewers
+
+| Agent | File | Vendor |
+|-------|------|--------|
+| **GPT Reviewer** (`gpt-reviewer`) | `.github/agents/gpt-reviewer.md` | a strong non-primary vendor |
+| **Gemini Reviewer** (`gemini-reviewer`) | `.github/agents/gemini-reviewer.md` | a strong third vendor |
+
+Both are **pinned** to their model via the `model:` frontmatter key and **structurally
+read-only** (`tools: ["read","search"]` — no `edit`, no shell). They return findings; they
+never touch code and never merge.
+
+**Guaranteeing the model pin.** The `model:` frontmatter is the documented way to bind an
+agent to a model, but to stay safe against any invocation path that ignores it, when the
+primary agent invokes a reviewer via the `task` tool it **MUST also pass the `model`
+parameter explicitly**. Belt and suspenders: never let a reviewer silently fall back to
+the primary model — that would destroy the model diversity this whole procedure buys.
+
+## The rule (mandatory)
+
+**Before publishing a PR that contains code, the primary agent MUST:**
+
+1. Finish a complete draft implementation (reviewers need a real diff, not a plan).
+2. Invoke **both** reviewers on the diff, **passing the `model` parameter explicitly**.
+   - The reviewers have **no shell**, so **paste the diff (and point them at the relevant
+     spec + tests)** in the prompt.
+   - Do **not** feed them your own justification — independence is the point.
+3. **Triage every finding.** For each one, either **fix it** or **record a one-line
+   reason** for not fixing (e.g. "false positive — X is validated upstream at Y").
+   - **Reviewers can be wrong too** — verify a claimed bug against ground truth (the spec,
+     the schema, the actual API) and **override with a cited reason** when they're mistaken.
+   - **If your fixes change the diff materially, re-run both reviewers** until they raise
+     no new BLOCK/HIGH findings. The diff you ship must be the diff that was reviewed.
+4. **Record the summary in the PR body** (format below) so the review is visible at a glance.
+5. **Open the PR** for ebadger.
+6. **Post the persistent record as a PR comment.** Post each reviewer's **verbatim** output
+   plus your **per-finding tags** (`gh pr comment <N> --body ...`). This is the durable,
+   GitHub-native record ebadger reads. The reviewers stay read-only — the primary agent
+   posts on their behalf; never give the reviewer agents GitHub write access.
+
+### Scope — what triggers the panel
+
+**Triggers** (panel required): any PR touching application code, **specs** (`specs/**` —
+even though Markdown), schema/migrations, API contracts, the client, config, the
+build/deploy path, or **behaviour-defining config** such as `.github/agents/*.md`,
+`.github/instructions/*.md`, and the compliance hooks. In-scope if it can alter how the
+product or the agents behave — regardless of file extension.
+
+**Exempt** (panel optional): non-product **prose** with no behavioural effect — narrative
+docs, `status/`, `README`, `CHANGELOG`, and comment-only or typo fixes. Don't burn two
+model reviews on a typo. **When in doubt, run the panel.**
+
+### Disagreement protocol
+
+- If a reviewer raises a **BLOCK** you disagree with, write **one** rebuttal in the PR
+  body. If still unresolved, **escalate to ebadger** — do not silently override a BLOCK and
+  do not loop the reviewers indefinitely.
+- If the two reviewers disagree with each other, treat the stricter finding as the default
+  and note the split for ebadger.
+
+### PR body record format
+
+```
+## Second-model review
+- Reviewed diff: `<merge-base-sha>...<HEAD-sha>`
+- GPT Reviewer (<model>): <verdict> — <N> findings
+- Gemini Reviewer (<model>): <verdict> — <N> findings
+- Resolved: <M> fixed, <K> overridden
+  - Overridden: <finding> — <reason>
+```
+
+### Persistent review record + model scorecard (PR comment)
+
+After opening the PR, post the reviewers' **verbatim** output and **tag every finding**:
+
+~~~
+### GPT Reviewer (<model>) — verdict: <verdict>
+1. [HIGH] <finding, verbatim> — accepted · true-positive · fixed (<commit/where>)
+2. [MEDIUM] <finding, verbatim> — overridden · false-positive · <cited reason>
+...
+Scorecard — <model>: findings <N> | true-positive <T> | false-positive <F> | led-to-fix <X>
+~~~
+
+Tag vocabulary per finding: **accepted / overridden** (did you act?), **true-positive /
+false-positive** (was it real?), **led-to-fix y/n** (did it change shipped code?).
+
+Because every PR carries a `Scorecard` line on GitHub, **the evaluation needs no separate
+database** — a periodic review harvests scorecards across merged PRs (`gh pr list` /
+`gh api`) and tallies true-positive vs false-positive and bugs-caught per model. **Don't
+build an eval harness or dashboard yet** — let the scorecards accumulate first.
+
+**Honest caveat — grading bias.** The primary agent scores the very reviewers whose job is
+to challenge it. Guards: every `false-positive`/`overridden` needs a **cited, checkable
+reason**; ebadger spot-checks at merge; and the metric to trust most is the hard-to-game
+one — **material bugs caught that were actually fixed** — not subjective "usefulness."
+
+## Enforcement & honesty about it
+
+Enforced as a **rule + advisory nudge**, not a hard mechanical block:
+`.github/instructions/pr-checklist.md` reminds the agent at PR-creation time (the nudge
+fires on the **`create_pull_request` tool** — create PRs that way, not via `gh pr create`,
+or the reminder is skipped), and ebadger can refuse to merge a code PR with no review
+record. A brittle "Reviewed-by line present?" gate is easy to satisfy with theatre; if the
+panel proves its worth, a hard gate can come later.
+
+## Kill criterion (this must earn its keep)
+
+This is net-new process machinery, which the mission-clock rule tells us to resist. It is
+justified only if it catches real defects. **Review at 30–60 days:** if the panel has not
+caught a material issue the primary missed, **slim or delete it.**
+
+## Changing the models
+
+Edit the `model:` line in each agent file. Use the latest strong reviewer from each
+vendor. Keep the two reviewers on **different vendors** — that diversity is the entire value.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1,0 +1,97 @@
+# 3RIC — Learnings (Rules Digest)
+
+> The always-loaded **Tier 1 rules digest**: durable rules + the one-line WHY that makes
+> each correct. Full narratives live in `docs/learnings/`, read on demand.
+>
+> _This is a template seed. Replace the example rules below with your project's real,
+> earned learnings as they accrue. **Keep the "How this file is maintained" section** —
+> it is the mechanism that keeps this file small and high-signal forever._
+
+---
+
+## How this file is maintained
+
+- **Tier 1, always loaded.** This is the compact digest injected into every session
+  preamble. Detailed narratives live in `docs/learnings/`
+  (`sessions/weekly/monthly/archive/`), read **on demand only**.
+- **Hard cap: 2,500 tokens** (≈9,500 chars). A `pre-push` guard enforces it
+  (`scripts/dev/check-learnings-budget.sh`).
+- **Priority-based distillation.** Every new learning is distilled to rule-shape
+  (≤ ~3–5 lines): the rule + a one-line WHY + (if a deep dive matters) an archive link.
+  Adding a learning that would breach the cap is the TRIGGER to first **dedup/merge**
+  existing rules; if still over, **demote** the lowest-value rule's detail to the
+  archive. Never just grow the file.
+- **What earns a slot** (align with `learnings/README.md` Quality Criteria): recurrence
+  (same class of mistake ≥2×), money/data-loss/safety risk, cross-layer/contract
+  breakage, or high time/rework cost. One-off cosmetic or context-specific trivia stays
+  in the archive only.
+- **Promotion requires ebadger's approval.** This file is excluded from the
+  `docs/learnings/` auto-merge (see Workflow Rule §5).
+- **Do not strip the WHY.** Distillation removes the long narrative, never the context
+  that makes a rule correct.
+
+---
+
+## Workflow Rules (numbered — the canonical operating contract)
+
+**§1. Layer checklist.** Before committing a change, verify every layer it could touch
+(e.g. Hardware → ROMs → VM core → Hosts/Web → Disk, plus the umbrella spec) for impact. WHY:
+missing one layer silently breaks the only path the data actually flows through.
+
+**§2. Think in data flow, not documents.** Specify every link of
+`User action → request → server logic → write → read → response → render`.
+
+**§3. Specs before code.** Specs are the source of truth; code follows specs. Update the
+spec in the same change.
+
+**§4. Commit atomically across layers.** A feature spanning multiple specs/layers updates
+them all in one commit so history is consistent at every point.
+
+**§5. Never self-merge.** Always open a PR and give ebadger the link; merging is ebadger's
+call. WHY: instruction files changed mid-session aren't in context until re-read — after
+any `git reset --hard`/branch change re-read `LEARNINGS.md`, `MISSION.md`,
+`copilot-instructions.md`. **Auto-merge exceptions** are narrow, markdown-only paths
+(e.g. `docs/learnings/` per `learnings/README.md`); everything else needs a PR + approval.
+
+**§6. Always check PR state before pushing.** `git fetch origin main` then
+`gh pr view <n> --json state`; if **MERGED**, branch fresh off `origin/main`
+and open a new PR. WHY: pushing to a merged branch orphans the commit. Backed by the
+`.githooks/pre-push` guard (`scripts/dev/install-hooks.sh`); it **fails open** when `gh`
+is unavailable and is overridable with `SKIP_PR_GUARD=1` — a backstop, not a replacement
+for the check.
+
+**Worktree hygiene.** Never `git checkout`/merge `main` from a session
+worktree — branch off `origin/main`. Don't rely on `--delete-branch` in a
+worktree; verify `gh pr view <n> --json state,mergedAt` before retrying, and delete
+branches explicitly (`git branch -D` + `git push origin --delete`).
+
+---
+
+## Seed engineering rules (universal — keep or prune to taste)
+
+- **A documented-but-unbuilt endpoint is a tracked gap, not a freebie.** Grep the client
+  for hardcoded/demo data papering over it.
+- **Frontends must NEVER fabricate domain data** for a missing endpoint — render an
+  explicit empty/"not available" state. WHY: a `// demo` placeholder ships looking
+  identical to a real feature. After finding one, grep ALL screens for mock-derived literals.
+- **Service/unit tests do NOT prove an HTTP-contract feature works.** Do a **live
+  end-to-end smoke through the real endpoints** against the real data store before "done."
+- **Enforce critical invariants in TWO places:** an app-level guard *and* a store-level
+  constraint (e.g. a unique index), plus a test proving the constraint actually blocks the
+  violation.
+- **"Passes on an in-memory/dev store but fails on the real one" is the default risk** for
+  any constraint that lives only in the production schema. Test constraints against a real
+  instance of your production engine.
+
+---
+
+## Project-specific clusters (fill these in)
+
+> Add topic-clustered rules here as your project earns them — e.g. `## Data & money paths`,
+> `## Frontend / caching`, `## Deploy / ops`. New learnings merge into the relevant cluster
+> **under the cap**. See `docs/learnings/README.md` for the capture → distill → promote flow.
+
+---
+
+*Topic-clustered and priority-distilled, not chronological — new learnings merge into the
+relevant cluster under the cap (see "How this file is maintained").*

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -1,0 +1,37 @@
+# 3RIC — Mission Statement
+
+> This document defines the purpose and direction of the company.
+> All agents and sessions must read this to understand the "why" behind the work.
+
+---
+
+## Mission
+
+Design, build, and document **Badger6502** — a working 65C02 homebrew personal
+computer — from the gate level up: the real hardware (schematics, PCB, PLD logic), the
+ROMs and system software that bring it to life, and faithful emulators (native WinUI 3
+and in-browser WebAssembly) that behave like the physical machine.
+
+The single test for any task: **does it move the computer closer to being buildable,
+bootable, and faithfully emulated?** Success is someone else being able to build the
+hardware or boot the machine in a browser and have it actually work. If a task doesn't
+serve that, question it.
+
+---
+
+## Organization Model
+
+- **ebadger** is the CEO and sole decision-maker. Sets direction, approves changes, defines priorities.
+- **AI agents** are cooperative team members who execute on the mission. They propose, implement, and advise — but do not make final decisions on direction or merges.
+- **Sessions** are specialized workers: some build, some deploy, some review. Each respects the boundaries of the others.
+
+---
+
+## Operating Principles
+
+1. The mission drives all work. If a task doesn't serve the mission, question it.
+2. Cooperation over autonomy — agents work *with* ebadger and each other, not independently. We are one team.
+3. Quality over speed — get it right, don't just get it done.
+4. Transparency — surface problems, uncertainties, and trade-offs early. Transparency leads to better decisions.
+5. Learn continuously — mistakes are expected; repeating them is not. Codify learning so future sessions benefit (see `docs/learnings/`).
+6. Your ideas matter — if you see an opportunity to improve anything, speak up (see `docs/SUGGESTIONS.md`).

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,0 +1,88 @@
+# 3RIC — Roles: Lenses & Gates
+
+> The main session does the work. The agents below are **lenses** you consult for
+> specialist judgment, not a corporate hierarchy you route paperwork through.
+> **ebadger is the CEO and final authority on everything.** Keep the org machinery small
+> so the mission stays in front of the process.
+
+---
+
+## Lenses (consult for judgment)
+
+Consult a lens when the decision lives squarely in its domain and a wrong call is
+expensive. For routine implementation, just do the work and cite the relevant spec.
+Build these out from `.github/agents/template-lens-agent.md` **as the project needs
+them** — not all at once. A typical roster (rename/cut to fit your domain):
+
+| Lens | Consult for | Don't consult for |
+|------|-------------|-------------------|
+| **Architecture & Engineering** | System architecture, cross-layer consistency, schema & API contracts, security, performance, major refactors, client/UX architecture | Isolated bug fixes, small copy, docs-only edits |
+| **Product & Strategy** | What to build next and why, specs, prioritization, mission alignment, roadmap, business model | Pure technical decisions with no product impact |
+| **Build & Operations** | Build pipeline, deploy, infra, migration execution, service health, observability, prod ops | Feature design, architecture, product calls |
+| **Domain Expert** | The deep domain knowledge your product depends on being correct | Infra, deployment, software architecture |
+| **Process & Learning** | Retrospectives & failure-pattern capture, knowledge curation, org/process design, **CEO coaching for ebadger**. Runs as a **periodic** review, not a per-task gate | Implementation, deployment, feature/architecture decisions |
+
+---
+
+## The code-review panel (mechanical reviewers, not lenses)
+
+Two **model-diverse** reviewers run **by rule** before any code PR is published. Unlike
+the lenses, they are a standing **gate input** on every code change, and exist purely to
+break the primary model's single-model blind spots.
+
+| Reviewer | Vendor | File |
+|----------|--------|------|
+| **GPT Reviewer** | (non-Claude) | `.github/agents/gpt-reviewer.md` |
+| **Gemini Reviewer** | (third vendor) | `.github/agents/gemini-reviewer.md` |
+
+They are **structurally read-only** (`tools: ["read","search"]`) and have no decision
+authority: they return ranked findings + a verdict, the primary agent triages, **ebadger
+merges.** Full procedure: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## The gates (mechanical, non-negotiable)
+
+These are the rules that actually protect the mission. They are enforced by hooks /
+scripts where possible, not by memory.
+
+1. **Never self-merge.** Every change lands as a PR ebadger reviews and merges. The only
+   exceptions are the markdown-only auto-merge paths in `docs/LEARNINGS.md §5`.
+   Enforced by the `compliance-hooks` extension (hard stop on `gh pr merge`).
+2. **Specs before code; trace every layer.** A stored-data change updates every affected
+   layer (and its spec) in one atomic commit.
+3. **Check PR state before pushing**; a merged branch is dead. Backed by
+   `.githooks/pre-push` and the `compliance-hooks` push block.
+4. **Capped Tier-1 memory.** `docs/LEARNINGS.md` stays under its token cap. Enforced by
+   `pre-push` (`check-learnings-budget.sh`).
+5. **Critical-path test gate.** Any change to the cash-/safety-/data-critical path must
+   pass the project's eval/test suite before it ships. Wire it into
+   `scripts/dev/pre-push-tests.sh` (see the `.example`).
+6. **Mission clock > org clock.** Do **not** create net-new org/process artifacts (new
+   agents, protocols, ceremonies, meta-docs) while the product has unmet, higher-priority
+   needs. Fix the product first. Streamlining or **deleting** org machinery is always
+   allowed; **adding** it waits.
+7. **Self-modification needs ebadger.** Any change to agent authority, role boundaries, or
+   this operating model requires ebadger's explicit approval. Agents propose; they never
+   self-approve.
+
+---
+
+## Interaction protocol (condensed)
+
+- **Disagreement →** surface it, summarize the trade-offs, present options (not a hidden
+  decision), and let ebadger decide.
+- **Handoff →** reference the specific commit/PR/issue, state what's expected, and the
+  receiver acknowledges with results.
+- **Bug triage →** GitHub Issues (see `.github/ISSUE_TEMPLATE/`); critical-path issues get
+  a fast lane and a stricter review gate.
+
+---
+
+## A note on right-sizing
+
+This file describes the *full* shape an AI-run project's org can take. **Start smaller.**
+A new project often needs only: the gates above, the two reviewers, and one or two lenses.
+Add lenses when a real, recurring class of expensive decision justifies one — and let the
+**mission-clock gate (#6)** stop you from building org machinery faster than the product
+earns it.

--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -1,0 +1,61 @@
+# 3RIC — Suggestions
+
+> A place for agent-generated ideas to improve cooperation, productivity, and quality.
+> ebadger reviews these periodically and promotes good ones into practice (usually into
+> `docs/LEARNINGS.md` or `.github/copilot-instructions.md`).
+>
+> **Why this exists:** an AI workforce notices process friction constantly but has no
+> standing channel to act on it. This is that channel — a low-friction funnel so good
+> ideas accrete instead of evaporating at session end. Keep entries concrete:
+> **Problem → Suggestion → (optional) Owner.**
+
+---
+
+## Format
+
+```markdown
+### N. Short title
+
+**Problem:** What's wrong or missing, concretely.
+
+**Suggestion:** The proposed change. Small and actionable beats grand.
+
+**Owner:** (optional) which lens/agent would carry it.
+```
+
+---
+
+## Seed suggestions (generic — keep, prune, or replace)
+
+### 1. Session handoff protocol
+
+**Problem:** When multiple sessions exist (build, deploy, feature work), they can step on
+each other or miss context.
+
+**Suggestion:** When one session creates work for another, reference the specific
+commit/PR/issue; the receiving session acknowledges and reports back with results.
+
+---
+
+### 2. Periodic retrospective
+
+**Problem:** Learnings accumulate but there's no structured time to review and act on them.
+
+**Suggestion:** A weekly/per-milestone pass where the Process & Learning lens summarizes
+recent `docs/learnings/` entries, evaluates this file's suggestions, and proposes ≤3
+high-leverage changes. ebadger approves or rejects.
+
+---
+
+### 3. Test-before-PR as a hard rule
+
+**Problem:** Changes can be merged without verification when the build/test environment
+isn't wired into the flow.
+
+**Suggestion:** Wire the project's test command into `scripts/dev/pre-push-tests.sh` so the
+`pre-push` hook proves green before any push. If no test environment is available, flag the
+PR clearly: "⚠️ Not test-verified — needs CI or manual test."
+
+---
+
+*Add new suggestions at the bottom. ebadger promotes accepted ones into practice.*

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -1,0 +1,118 @@
+# 3RIC — Learning Log System
+
+> Progressive generalization: raw session learnings → weekly patterns → monthly strategy →
+> `LEARNINGS.md` promotions. The mechanism that turns mistakes into durable, *capped* rules.
+
+---
+
+## Directory Structure
+
+```
+docs/learnings/
+├── README.md          ← This file (format spec + lifecycle rules)
+├── sessions/          ← Per-session learning files (daily capture)
+├── weekly/            ← Weekly digest synthesizing patterns across sessions
+├── monthly/           ← Monthly summary for strategic generalization
+└── archive/           ← Retired files + pre-distillation narrative snapshots
+```
+
+---
+
+## Session Learning File Format
+
+**File naming:** `YYYY-MM-DD-session-name-slug.md`
+**Location:** `docs/learnings/sessions/`
+
+```markdown
+# Session Learning — [Session Name]
+
+**Date:** YYYY-MM-DD
+**Session ID:** [short ID or slug]
+**Duration:** ~X hours
+**Agent(s):** [comma-separated roles]
+**Branch(es):** [branch name(s)]
+
+## What Happened
+
+[1-3 sentences: what was the goal and what actually occurred]
+
+## Learnings
+
+### L1: [Learning Title]
+
+**Cost:** [Quantified: "~45 minutes of rework", "opened a fresh PR", "stale binary 30 min"]
+**What happened:** [Concrete description of the failure or surprise]
+**Why it happened:** [Root cause, not just symptoms]
+**Rule:** `[Concrete behavioral imperative — start with an action verb]`
+
+### L2: [Next Learning Title]
+
+...repeat for each learning...
+
+## What Worked Well
+
+- [Thing that saved time or worked better than expected]
+
+## Promotion Candidates
+
+- [ ] L1 ready for `LEARNINGS.md` — [reason]
+- [ ] L2 needs one more occurrence before promotion
+```
+
+---
+
+## Quality Criteria
+
+Only capture learnings that meet **at least one** of these bars:
+
+1. **Time cost:** Would have saved >15 minutes if known in advance
+2. **Rework cost:** Caused a commit, PR, or deploy to be redone
+3. **Risk cost:** Could have broken prod or caused data/money loss
+4. **Repeatability:** Same mistake happened before (even once)
+
+**Skip sessions** where all work was routine with no surprises, errors, or detours.
+
+Every learning MUST have a quantified **Cost** and a concrete **Rule** that starts with an
+action verb.
+
+---
+
+## Lifecycle
+
+1. **Daily capture** — a process/learning agent (or the session itself) writes `sessions/` files.
+2. **Weekly digest** — synthesize patterns across sessions into `weekly/`.
+3. **Monthly summary** — generalize patterns into strategic guidance in `monthly/`.
+4. **Promotion** — high-signal items promoted to `docs/LEARNINGS.md`.
+
+### Promotion budget (priority-based distillation)
+
+`docs/LEARNINGS.md` is the **always-loaded Tier-1 rules digest** — it enters the model's
+context at the start of every session. To stop it from crowding out task context, it has a
+**hard cap of ~2,500 tokens** (a `pre-push` guard, `scripts/dev/check-learnings-budget.sh`,
+enforces it).
+
+Promotion is therefore **competitive, not additive**:
+
+- Distill each promoted item to **rule-shape** (≤ ~3–5 lines): the rule + a one-line WHY +
+  (when a deep dive matters) a link back to the `sessions/` or `archive/` narrative.
+- If a new rule would breach the cap, that is the **trigger to first dedup/merge** existing
+  rules covering the same ground; if still over, **demote** the lowest-value rule's detail
+  back to the archive. Never just grow the file.
+- **What earns a slot:** recurrence (≥2×), money/data-loss/safety risk, cross-layer/contract
+  breakage, or high time/rework cost. One-off or cosmetic trivia stays here only.
+- **Never strip the WHY.** Distillation removes the long narrative, never the context.
+- Promotion edits to `docs/LEARNINGS.md` require **ebadger's approval** (excluded from auto-merge).
+
+---
+
+## Auto-Merge Rules
+
+Learning PRs may be auto-merged **only** when they touch learning markdown alone:
+
+- ✅ Only `.md` files under `docs/learnings/sessions/`, `weekly/`, `monthly/`, or `archive/`
+- ✅ No code, spec, config, or other path changes in the same commit
+- ❌ Mixed commits → create a normal PR, do NOT auto-merge
+- ❌ `docs/learnings/README.md` changes → normal PR only
+- ❌ `docs/LEARNINGS.md` promotions → normal PR only (require ebadger's approval)
+
+This scope matches `docs/LEARNINGS.md` Workflow Rule §5.

--- a/docs/learnings/archive/README.md
+++ b/docs/learnings/archive/README.md
@@ -1,0 +1,3 @@
+# Retired learning files + pre-distillation narrative snapshots — see ../README.md.
+# When a rule is demoted from docs/LEARNINGS.md to stay under the cap, its full
+# narrative lands here.

--- a/docs/learnings/monthly/README.md
+++ b/docs/learnings/monthly/README.md
@@ -1,0 +1,1 @@
+# Monthly strategic summaries generalizing weekly patterns — see ../README.md.

--- a/docs/learnings/sessions/README.md
+++ b/docs/learnings/sessions/README.md
@@ -1,0 +1,2 @@
+# Per-session learning files live here — see ../README.md for the format.
+# Naming: YYYY-MM-DD-session-name-slug.md

--- a/docs/learnings/weekly/README.md
+++ b/docs/learnings/weekly/README.md
@@ -1,0 +1,1 @@
+# Weekly digests synthesizing patterns across sessions — see ../README.md.

--- a/scripts/dev/check-learnings-budget.sh
+++ b/scripts/dev/check-learnings-budget.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# check-learnings-budget.sh -- Enforce the docs/LEARNINGS.md size cap.
+#
+# Why: docs/LEARNINGS.md is mandatory reading at the start of EVERY session, so it
+# is loaded into the model's context every single time. If it grows without bound
+# it crowds out task context and buries the durable rules among one-off incident
+# detail. It is therefore a *capped Tier-1 rules digest*; detailed narratives live
+# in docs/learnings/ (read on demand). See LEARNINGS.md "How this file is maintained".
+#
+# Cap: 2,500 tokens. Counts REAL tokens with tiktoken when available
+# (python3 + `pip install tiktoken`); otherwise falls back to a character proxy.
+#
+# Usage: check-learnings-budget.sh [path-to-markdown]   # defaults to docs/LEARNINGS.md
+#
+# Exit: 0 = within budget (or unenforceable -> fail-open with a note);
+#       1 = over budget (blocks the push).
+# Escape hatch (rare, deliberate): SKIP_LEARNINGS_BUDGET=1
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+FILE="${1:-$REPO_ROOT/docs/LEARNINGS.md}"
+
+TOKEN_CAP=2500
+CHAR_CAP=9800   # ~2,500 tokens at the measured ~3.8 chars/token (loose dependency-free backstop)
+
+# Print remediation guidance for "$1" (a measurement string) and block the push.
+block() {
+  echo "" >&2
+  echo "x LEARNINGS budget BLOCKED: $1" >&2
+  echo "  LEARNINGS.md is the always-loaded Tier-1 rules digest, not an append-only log." >&2
+  echo "  Get back under the cap via priority-based distillation:" >&2
+  echo "    1. Move the full incident narrative to docs/learnings/ (sessions/ or archive/)." >&2
+  echo "    2. Leave only a distilled rule + one-line WHY (+ archive link) in LEARNINGS.md." >&2
+  echo "    3. Dedup/merge overlapping rules; demote the lowest-value detail to the archive." >&2
+  echo "  Override (only if you are certain): SKIP_LEARNINGS_BUDGET=1 git push ..." >&2
+  echo "" >&2
+  exit 1
+}
+
+if [ "${SKIP_LEARNINGS_BUDGET:-}" = "1" ]; then
+  echo "check-learnings-budget: SKIP_LEARNINGS_BUDGET=1 -- skipping." >&2
+  exit 0
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "check-learnings-budget: $FILE not found -- skipping (fail-open)." >&2
+  exit 0
+fi
+
+# Prefer an exact token count via tiktoken.
+PY=""
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+fi
+
+if [ -n "$PY" ]; then
+  tokens=$("$PY" - "$FILE" <<'PYEOF' 2>/dev/null || true
+import sys
+try:
+    import tiktoken
+except Exception:
+    sys.exit(3)
+data = open(sys.argv[1], encoding="utf-8").read()
+print(len(tiktoken.get_encoding("cl100k_base").encode(data)))
+PYEOF
+)
+  tokens=$(printf '%s' "${tokens:-}" | tr -cd '0-9')
+  if [ -n "$tokens" ]; then
+    if [ "$tokens" -gt "$TOKEN_CAP" ]; then
+      block "docs/LEARNINGS.md is $tokens tokens (cap $TOKEN_CAP)."
+    fi
+    echo "check-learnings-budget: OK ($tokens / $TOKEN_CAP tokens)." >&2
+    exit 0
+  fi
+  echo "check-learnings-budget: tiktoken unavailable -- using char proxy ('pip install tiktoken' for exact token enforcement)." >&2
+fi
+
+# Fallback: dependency-free character proxy.
+chars=$(wc -m < "$FILE" 2>/dev/null | tr -cd '0-9')
+[ -n "$chars" ] || chars=$(wc -c < "$FILE" | tr -cd '0-9')
+if [ "$chars" -gt "$CHAR_CAP" ]; then
+  block "docs/LEARNINGS.md is $chars chars (proxy cap $CHAR_CAP ~ $TOKEN_CAP tokens)."
+fi
+echo "check-learnings-budget: OK ($chars chars; proxy cap $CHAR_CAP ~ $TOKEN_CAP tokens)." >&2
+exit 0

--- a/scripts/dev/install-hooks.sh
+++ b/scripts/dev/install-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# install-hooks.sh — Activate this repo's git hooks on the local machine.
+#
+# Git hooks are not installed by `git clone` and cannot be auto-activated by a
+# committed file alone. This points git at the repo-tracked .githooks/ directory
+# by setting core.hooksPath, so the hooks in version control actually run.
+# Re-run after a fresh clone. Idempotent.
+#
+# Works for worktrees too: core.hooksPath is set as a relative path, so each
+# worktree resolves it against its own checked-out .githooks/ copy.
+#
+# On Windows, run the equivalent from the repo root in any shell:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+HOOKS_DIR=".githooks"
+[ -d "$HOOKS_DIR" ] || { echo "ERROR: $REPO_ROOT/$HOOKS_DIR not found." >&2; exit 1; }
+
+# Ensure hooks are executable (matters on Linux/macOS; harmless on Windows).
+chmod +x "$HOOKS_DIR"/* 2>/dev/null || true
+
+git config core.hooksPath "$HOOKS_DIR"
+
+echo "Installed git hooks: core.hooksPath -> $HOOKS_DIR"
+echo "Active hooks:"
+for h in "$HOOKS_DIR"/*; do
+  [ -f "$h" ] || continue
+  case "$(basename "$h")" in
+    *.md|*.sample) continue ;;
+  esac
+  echo "  - $(basename "$h")"
+done
+echo "Done. The pre-push guards (PR-state + LEARNINGS cap + optional tests) are now active."

--- a/scripts/dev/pre-push-tests.sh
+++ b/scripts/dev/pre-push-tests.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# pre-push-tests.sh -- 3RIC test gate for .githooks/pre-push.
+#
+# Runs the project's fast tests before every push and BLOCKS the push if they
+# fail. The gate is "fail-closed when the artifacts exist, fail-open when they
+# don't": if a build output is present we run its tests and block on failure; if
+# nothing is built yet (e.g. a docs-only push from a fresh clone) we warn and
+# skip, so you're not forced into a full build just to push.
+#
+# Covers the critical path -- the host and web emulators must stay consistent
+# with the real hardware build:
+#   1. Web (WASM) headless node tests  -- web/test_*.cjs   (needs web/build.ps1 output)
+#   2. C++ VM unit tests               -- Badger6502VMTest (needs an MSVC build)
+#
+# Escape hatch for routine, test-irrelevant pushes:  SKIP_TEST_GUARD=1 git push
+# (Both gates below are fail-open by design; there is no separate non-bypassable
+#  critical-path gate yet -- add one here once an executable eval suite exists.)
+set -eu
+
+if [ "${SKIP_TEST_GUARD:-}" = "1" ]; then
+  echo "pre-push-tests: SKIP_TEST_GUARD=1 -- skipping tests." >&2
+  exit 0
+fi
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$ROOT"
+
+fail=0
+
+# --- 1. Web (WASM) headless node tests --------------------------------------
+# Resolve node: PATH first, then an emsdk-bundled node (the web build uses emsdk).
+NODE=""
+if command -v node >/dev/null 2>&1; then
+  NODE=node
+elif [ -n "${EMSDK:-}" ] && [ -d "${EMSDK}/node" ]; then
+  NODE=$(ls "${EMSDK}"/node/*/bin/node.exe 2>/dev/null | head -n 1 || true)
+elif [ -n "${HOME:-}" ] && [ -d "${HOME}/emsdk/node" ]; then
+  NODE=$(ls "${HOME}"/emsdk/node/*/bin/node.exe 2>/dev/null | head -n 1 || true)
+fi
+
+if [ -z "$NODE" ]; then
+  echo "pre-push-tests: node not found (PATH or emsdk) -- skipping web tests." >&2
+elif [ ! -f web/badger6502.js ] || [ ! -f web/data/badger6502.bin ]; then
+  echo "pre-push-tests: web WASM build not present -- run web/build.ps1 first; skipping web tests." >&2
+else
+  echo "pre-push-tests: running web headless tests with '$NODE'..." >&2
+  for t in web/test_*.cjs; do
+    [ -f "$t" ] || continue
+    echo "  -> $t" >&2
+    if ! "$NODE" "$t"; then
+      echo "pre-push-tests: FAILED $t" >&2
+      fail=1
+    fi
+  done
+fi
+
+# --- 2. C++ VM unit tests (Badger6502VMTest) --------------------------------
+# Run only if both vstest.console.exe and a built test DLL are available; this
+# avoids forcing a heavy MSBuild inside the push. Build the solution (Visual
+# Studio or msbuild) to arm this gate.
+VSWHERE="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+VSTEST=""
+if [ -x "$VSWHERE" ]; then
+  VSTEST=$("$VSWHERE" -latest -products '*' -find '**/vstest.console.exe' 2>/dev/null | head -n 1 || true)
+  if [ -n "$VSTEST" ] && command -v cygpath >/dev/null 2>&1; then
+    VSTEST=$(cygpath -u "$VSTEST")
+  fi
+fi
+
+TESTDLL=""
+if [ -d emulator/Badger6502VMTest ]; then
+  TESTDLL=$(find emulator/Badger6502VMTest -name Badger6502VMTest.dll -type f 2>/dev/null | head -n 1 || true)
+fi
+
+if [ -z "$VSTEST" ]; then
+  echo "pre-push-tests: vstest.console.exe not found -- skipping C++ VM tests." >&2
+elif [ -z "$TESTDLL" ]; then
+  echo "pre-push-tests: Badger6502VMTest.dll not built -- build the solution to arm this gate; skipping." >&2
+else
+  DLLARG=$TESTDLL
+  command -v cygpath >/dev/null 2>&1 && DLLARG=$(cygpath -w "$TESTDLL")
+  echo "pre-push-tests: running C++ VM tests -> $TESTDLL" >&2
+  if ! "$VSTEST" "$DLLARG" /Logger:console >&2; then
+    echo "pre-push-tests: FAILED Badger6502VMTest" >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "pre-push-tests: TESTS FAILED -- push blocked. (Override with SKIP_TEST_GUARD=1 only if you know why.)" >&2
+  exit 1
+fi
+
+echo "pre-push-tests: all available test suites passed." >&2
+exit 0

--- a/scripts/dev/pre-push-tests.sh.example
+++ b/scripts/dev/pre-push-tests.sh.example
@@ -1,0 +1,53 @@
+#!/bin/sh
+# pre-push-tests.sh.example -- Optional project test gate for .githooks/pre-push.
+#
+# HOW TO USE: copy this file to scripts/dev/pre-push-tests.sh, make it executable
+# (chmod +x), and fill in your project's test command. The pre-push hook runs it
+# automatically on every push and BLOCKS the push if it exits non-zero.
+#
+# Why a separate, pluggable script (instead of hardcoding a test command in the
+# hook): the *mechanism* "run the right tests before every push" is universal, but
+# the command is per-stack (dotnet test / npm test / pytest / go test / cargo test).
+# Keep the hook generic; put the stack-specific command here.
+#
+# The hook exports REFS_FILE -- a path to the file of pushed refs, one line each:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# Use it to scope tests to what actually changed (e.g. only run the heavy suite when
+# files under a critical path changed). Ignore it to always run.
+set -eu
+
+# --- Example A: always run the project's test command -----------------------
+# Replace this with your stack's command. Honor SKIP_TEST_GUARD for routine skips.
+if [ "${SKIP_TEST_GUARD:-}" = "1" ]; then
+  echo "pre-push-tests: SKIP_TEST_GUARD=1 -- skipping tests." >&2
+  exit 0
+fi
+
+# Pick ONE and delete the rest:
+#   dotnet test --configuration Debug -v minimal
+#   npm test --silent
+#   pytest -q
+#   go test ./...
+#   cargo test --quiet
+echo "pre-push-tests: (example) no test command configured -- edit scripts/dev/pre-push-tests.sh." >&2
+
+# --- Example B: a NON-bypassable gate for a critical path -------------------
+# For a cash-/safety-/data-critical surface, add a second gate with NO skip switch
+# that only runs when that path changed. Compute the changed-file set from REFS_FILE
+# and run an executable eval/golden-scenario suite. Example skeleton:
+#
+#   if [ -n "${REFS_FILE:-}" ] && [ -f "$REFS_FILE" ]; then
+#     while read -r _l _lsha _r _rsha; do
+#       case "$_rsha" in 0000000000000000000000000000000000000000)
+#         _base=$(git merge-base "$_lsha" origin/main 2>/dev/null || true)
+#         _range="${_base:+$_base..}${_lsha}" ;;
+#       *) _range="${_rsha}..${_lsha}" ;;
+#       esac
+#       if git diff --name-only "$_range" 2>/dev/null | grep -Eq '^src/critical/'; then
+#         echo "pre-push-tests: critical path changed -- running eval suite (NO skip)..." >&2
+#         <your eval command> || exit 1
+#       fi
+#     done < "$REFS_FILE"
+#   fi
+
+exit 0

--- a/specs/DISK.md
+++ b/specs/DISK.md
@@ -1,0 +1,67 @@
+# 3RIC — DISK Spec
+
+> Source of truth for storage emulation and tooling: the Disk II 5.25″ floppy (`WozLib`), the
+> micro-SD card (`MockMicroSD`, bit-banged SPI), the `.dsk`→`.woz` converter (`dsk2woz2`), and
+> the real-hardware Raspberry Pi Pico disk/SD interface (`picodisk`).
+
+---
+
+## Purpose
+
+Let Badger6502 load and run software from period-appropriate media: Disk II `.woz` floppies
+and a FAT32 micro-SD card — both in the emulators and (via `picodisk`) on real hardware.
+
+## Contracts / Interfaces
+
+- **`emulator/WozLib`** (C++) — `DriveEmulator` + `WozDisk` + `WozFile`. Embedded in `VM`;
+  reached through the standard hardware path: Disk II boot PROM at `$C600`, data registers
+  `$C0E0–$C0EF` routed via `VM::DoDisk`. `insertDisk(drive, bytes)` loads a WOZ image (through
+  MEMFS in the web build); booting types `C600G`.
+- **`emulator/MockMicroSD`** (C++) — `SDCard` + `MappedFile`. A bit-banged **SPI** device on
+  VIA1 port A: each CPU write to `$C201`/`$C20F` clocks the state machine (CS=b4, SCK=b3,
+  MOSI=b2, MISO=b1 folded back). Backs a 2 GB FAT32 logical image with a lazily-allocated
+  `unordered_map<sector,512>`; never-written sectors read as zero. The ROM's own FAT32 driver
+  (`fat32_start`/`fat32_dir`) reads the card over SPI.
+- **`sd.sparse`** (web) — compact `SDSP` container of only the non-zero 512-byte sectors of
+  the 2 GB image (~11.5 MB), produced by `web/make_sd_sparse.py`; consumed by `loadSD()`.
+- **`emulator/dsk2woz2`** (C++) — converts `.dsk` disk images to `.woz` (flux-level format the
+  `DriveEmulator` boots).
+- **`emulator/picodisk`** (C/C++, Pi Pico SDK + CMake) — the **real-hardware** disk/SD
+  peripheral firmware (the physical counterpart to `WozLib`/`MockMicroSD`).
+
+## Behaviour / Rules
+
+- The micro-SD SPI pump is installed via `VM::CallbackWriteMemory`; every `$C201`/`$C20F`
+  write advances the SD state machine — keep this contract identical across host and web.
+- Self-booting machine-code floppies run; DOS 3.3 / Quick-DOS disks that auto-run an Applesoft
+  greeting load DOS but trap (this clone's BASIC is generic Microsoft BASIC, not Applesoft).
+- The SD/Disk register addresses and SPI bit assignment are part of the hardware contract
+  (`HARDWARE.md`); changing them is a cross-layer event (hardware + emulator + `picodisk`).
+- If the web SD contents change, give the image a new filename (cache-busting) and update the
+  fetch path in `index.html` (see `web/README.md`).
+
+## Data flow
+
+```
+.dsk → dsk2woz2 → .woz → insertDisk(1, bytes) → C600G → Disk II boot PROM ($C600) → game
+CPU $C0E0–$C0EF ↔ DriveEmulator (WozDisk/WozFile)
+CPU writes $C201/$C20F → SDCard SPI state machine → MappedFile sectors → FAT32 driver in ROM
+web: fetch sd.sparse → loadSD() ;  real hw: picodisk firmware on the Pico
+```
+
+## Dependencies
+
+- Upstream: `EMULATOR.md` (`VM`, `CallbackWriteMemory`, `DoDisk`), `ROMS.md` (Disk II boot
+  PROM + FAT32 driver in `badger6502.bin`), `HARDWARE.md` (Disk II + VIA1 SD wiring).
+- Downstream: `WEB.md` (`loadSD`, `insertDisk`), real hardware (`picodisk`).
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Disk II 5.25″ floppy (`WozLib`) | Shipped | Boots WOZ images in host + web |
+| Micro-SD (SPI/FAT32, `MockMicroSD`) | Shipped | DOS shell `DIR`/`CAT`/`CD`/`BRUN` work |
+| `sd.sparse` generation | Shipped | `web/make_sd_sparse.py` |
+| `dsk2woz2` converter | Shipped | `.dsk` → `.woz` |
+| `picodisk` (Pi Pico firmware) | Shipped | Real-hardware disk/SD interface |
+| DOS 3.3 / Applesoft auto-run disks | Known gap | No Applesoft in this clone — see `web/README.md` |

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -1,0 +1,71 @@
+# 3RIC — EMULATOR Spec
+
+> Source of truth for the software emulation of Badger6502: the shared C++ VM core, the
+> WinUI 3 desktop host, and the per-opcode unit tests. The VM core is the **critical path** —
+> it backs the desktop host, the WASM web build (`WEB.md`), and the tests, so a regression
+> here breaks all three.
+
+---
+
+## Purpose
+
+Faithfully emulate the Badger6502 hardware in software: the 65C02 CPU, memory, VIA, ACIA,
+keyboard, video, and the Disk II/SD interfaces — as a reusable C++ core plus a native
+Windows host for interactive use.
+
+## Contracts / Interfaces
+
+- **VM core — `emulator/Badger6502VMLib`** (C++17). Modules: `vm`, `cpu`, `Instructions`,
+  `acia`, `via`, `PS2Keyboard`, `badgervmpal` (the 22V10/PAL glue logic). Exposes (used by
+  every host, see `web/web_bridge.cpp` for the canonical surface):
+  - `GetData()` — pointer to the 64 KB CPU address space; `loadData(offset, bytes)`.
+  - `seedBasicRom()` / `GetBasicRom()` — seed BASIC from the ROM image.
+  - `loadFont(bytes)` — load `fontrom.dat` for the text renderer.
+  - `reset()` — load PC from `$FFFC/$FFFD`.
+  - `Step()` / `run(maxSteps)` — cooperative stepping; ticks VIAs/keyboard per CPU cycle
+    (the blocking `Run()` is not used by the cooperative hosts).
+  - `CallbackWriteMemory` — memory-write hook (used to pump the micro-SD SPI state machine).
+- **Memory-mapped I/O contract** (must match `HARDWARE.md`): keyboard `$C000`/`$C010`;
+  Disk II `$C0E0–$C0EF` + boot PROM `$C600`; micro-SD on VIA1 `$C201`/`$C20F`.
+- **WinUI 3 host — `emulator/Badger6502VM`** (C++/WinRT). Owns the window, the text/lo-res/
+  hi-res renderer (`MainWindow.xaml.cpp` — the renderer the web bridge was ported from), the
+  keyboard mapping, and the clock loop.
+- **Tests — `emulator/Badger6502VMTest`** (MSVC `CppUnitTestFramework`, C++). Per-opcode
+  suites (LDA, ADC_SBC, Branching, Stack, Interrupts, SMB_RMB, TSB_TRB, …) asserting 65C02
+  instruction semantics.
+
+## Behaviour / Rules
+
+- **Cooperative execution:** hosts call `run(maxSteps)` per frame, never the blocking loop,
+  so the UI stays responsive.
+- **Platform parity:** Windows-only code (`symbols.cpp`, `Disassemble.cpp`, MSVC-isms) must
+  stay behind guards so the same core compiles for WASM. New core behavior must be reflected
+  in both the host renderer and the web bridge, or the builds diverge (critical path).
+- **Correctness first:** any CPU/instruction change requires a passing (or new) test in
+  `Badger6502VMTest` before it ships. This is the pre-push gate's primary target.
+
+## Data flow
+
+```
+badger6502.bin → loadData(0, …) → seedBasicRom() → loadFont(fontrom.dat) → reset()
+per frame: run(maxSteps) → Step() CPU → tick VIA/ACIA/keyboard → video RAM
+video RAM + font → renderer (WinUI host / web canvas) → display
+keyboard → $C000 ; SD writes → CallbackWriteMemory → SPI state machine (see DISK.md)
+```
+
+## Dependencies
+
+- Upstream: `ROMS.md` (`badger6502.bin`, `fontrom.dat`), `HARDWARE.md` (the behavior being
+  emulated), `DISK.md` (`WozLib`, `MockMicroSD`).
+- Downstream: `WEB.md` (compiles this core to WASM), the desktop host, the test suite.
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| 65C02 CPU + instruction set | Shipped | Per-opcode tests in `Badger6502VMTest` |
+| VIA / ACIA / PS/2 keyboard | Shipped | `via`, `acia`, `PS2Keyboard` |
+| PAL/GAL glue (`badgervmpal`) | Shipped | Mirrors `22v10/` |
+| WinUI 3 host + renderer | Shipped | `emulator/Badger6502VM` |
+| Test gate wired to pre-push | Shipped | `scripts/dev/pre-push-tests.sh` (VSTest, fail-open) |
+| Cycle-accuracy notes vs real hardware documented here | In progress | Tracked gap |

--- a/specs/HARDWARE.md
+++ b/specs/HARDWARE.md
@@ -1,0 +1,78 @@
+# 3RIC — HARDWARE Spec
+
+> Source of truth for the physical Badger6502 machine. Update it in the same commit as any
+> schematic, PCB, or PLD change. Hardware changes that move an I/O register or the memory
+> map are **cross-layer events** — they must land in `ROMS.md`, `EMULATOR.md`, and the
+> emulator core together.
+
+---
+
+## Purpose
+
+The discrete-logic 65C02 computer itself: CPU, memory, address decoding, video generation,
+keyboard, serial/parallel I/O, and the Disk II + micro-SD interfaces — captured as KiCad
+schematics/PCB, 22V10 GAL equations, a Logisim model, and a DIYLC layout.
+
+## Contracts / Interfaces
+
+The hardware's externally-depended-on contract is the **6502 address space** (what the ROM
+and both emulators target). Current layout (64 KB CPU map):
+
+| Range | Use |
+|-------|-----|
+| `$0000–$BFFF` | RAM (zero page, stack, program/video RAM) |
+| `$C000` / `$C010` | Keyboard data / strobe-clear (Apple-II `KBD`/`KBDSTRB`) |
+| `$C0E0–$C0EF` | Disk II data registers |
+| `$C201` / `$C20F` | VIA1 port-A register — bit-banged SPI to the micro-SD card (CS=b4, SCK=b3, MOSI=b2, MISO=b1) |
+| `$C600` | Disk II boot PROM |
+| `$D000–$FFFF` | ROM / OS (reset vector at `$FFFC/$FFFD`) |
+| `$E000–` | BASIC (generic Microsoft BASIC) within the ROM region |
+
+> Additional VIA/ACIA register addresses and the full decode map: **to document from the
+> KiCad schematic** (`kicad/`, `schematic_pdf/`). Keep this table authoritative once filled.
+
+Key components (as emulated; confirm exact part numbers against `kicad/`):
+- **CPU:** 65C02, ~1 MHz.
+- **Video:** hardware character/graphics generator driven by ROM sequencing — `syncsignals`
+  (H/V sync + timing), `videaddress` (video RAM address generation), and `fontrom`
+  (character generator). Produces Apple-II-style 40×24 text, lo-res, and hi-res color. See
+  `ROMS.md`.
+- **I/O:** 65C22 VIA (VIA1 used for micro-SD SPI), 65C51 ACIA (serial), PS/2 keyboard.
+- **Storage:** Disk II–style 5.25″ floppy interface; micro-SD card (SPI via VIA1).
+- **Glue logic:** 22V10 GAL(s) for address decoding (`22v10/`), emulated as `badgervmpal`.
+
+## Behaviour / Rules
+
+- The machine boots from the reset vector at `$FFFC/$FFFD` into the monitor ROM.
+- Video timing is generated continuously by the sync/address ROMs independent of the CPU.
+- Any change to a chip's address decode, a VIA/ACIA register, or the video timing **must**
+  be reflected in the GAL equations (`22v10/`), the schematic (`kicad/`), and the emulator
+  (`emulator/Badger6502VMLib`) so hardware and emulators stay consistent (the critical path).
+
+## Data flow
+
+```
+Power-on → 65C02 reads reset vector ($FFFC) from ROM → monitor runs
+CPU bus ↔ address decode (22V10 GAL) → RAM / ROM / VIA / ACIA / Disk II / video latches
+Video ROMs (sync + address) + font ROM → video signal → display
+Keyboard (PS/2) → $C000 ; Serial → ACIA ; SD/SPI → VIA1 ($C201/$C20F)
+```
+
+## Dependencies
+
+- Upstream: none (this is the base layer).
+- Downstream: `ROMS.md` (targets this memory map), `EMULATOR.md` (emulates this hardware),
+  `DISK.md` (Disk II + micro-SD interfaces), `WEB.md` (emulates it in the browser).
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| KiCad schematic + PCB | Shipped | `kicad/`, PDF exports in `schematic_pdf/` |
+| 22V10 GAL equations | Shipped | `22v10/` |
+| Logisim logic model | Shipped | `logisim/` |
+| DIYLC layout | Shipped | `diylayout/` |
+| Full memory/decode map documented here | In progress | Fill the table above from the schematic |
+| Exact BOM / part numbers in this spec | Not started | Tracked gap — read from `kicad/` |
+
+> Build walkthrough: the YouTube series linked from the repo `README.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,34 @@
+# Specs (`specs/`)
+
+**Specs are the source of truth. Code follows specs, not the other way around.**
+
+This is the single most load-bearing convention in the whole operating model: every change
+to the **memory map, an I/O register, or a ROM** is specified across *all* the layers it
+touches **before** it is built, and the spec is updated **in the same commit** as the code.
+That is what keeps an AI workforce — which has no persistent memory between sessions — from
+drifting.
+
+## How specs are organized
+
+- `SYSTEM.md` — the **umbrella**: a short overview of the whole system that links to every
+  sub-spec. Start here; read sub-specs lazily.
+- One sub-spec **per layer** (copy `_TEMPLATE.md`). 3RIC's set:
+  - `HARDWARE.md` — schematic/PCB, 22V10 GAL decode, Logisim, the memory map, I/O registers, video timing.
+  - `ROMS.md` — monitor/OS + BASIC, font/video ROMs, the `romgen/` generators, `badger6502.bin` / `fontrom.dat`.
+  - `EMULATOR.md` — shared C++ VM core, WinUI 3 (C++/WinRT) host, MSVC unit tests.
+  - `WEB.md` — Emscripten/WASM build, the JS↔core bridge, browser UI.
+  - `DISK.md` — Disk II floppy (`WozLib`), micro-SD (`MockMicroSD`), `dsk2woz2`, real-hardware `picodisk`.
+
+## The rules (canonical in `docs/LEARNINGS.md` §1–4)
+
+1. **Layer checklist.** Before committing, verify every layer the change could touch.
+2. **Data flow, not documents.** Specify every link:
+   `Key press → keyboard register $C000 → CPU read → ROM/monitor → video RAM → renderer (host + web) → frame`.
+3. **Specs before code.** Update the spec first; code implements the spec.
+4. **Commit atomically.** A feature spanning multiple specs/layers updates them all in one
+   commit, so history is consistent at every point.
+
+After implementing, update the **Implementation Status** section of the relevant sub-spec.
+
+> The `compliance-hooks` extension nudges a cross-layer check whenever you edit a file that
+> looks like a layer/spec file (see `.github/extensions/compliance-hooks/`).

--- a/specs/ROMS.md
+++ b/specs/ROMS.md
@@ -1,0 +1,64 @@
+# 3RIC — ROMS Spec
+
+> Source of truth for every ROM image the machine and emulators consume: the monitor/OS
+> ROM, BASIC, the character (font) ROM, and the hardware video-timing ROMs. The ROM image
+> is part of the **shared contract** (with the memory map) across hardware, the WinUI 3
+> host, and the WASM web build — change it in all three together.
+
+---
+
+## Purpose
+
+Generate and own the binary ROM images: the system **monitor/OS** (`badger6502.bin`), the
+**character generator** (`fontrom.dat`), and the **hardware video-timing ROMs** produced by
+the `romgen` tools (`fontrom`, `syncsignals`, `videaddress`).
+
+## Contracts / Interfaces
+
+- **`badger6502.bin`** — the system ROM image. The first `0x10000` bytes populate the 65C02
+  address space: reset vector at `$FFFC/$FFFD`, monitor/OS at `$D000–$FFFF`, and BASIC at
+  `$E000` (a generic Microsoft BASIC, ~`0x3000` bytes, seeded into the BASIC region from the
+  ROM image). Consumed verbatim by the hardware, the WinUI 3 host, and the web build.
+- **`fontrom.dat`** — character generator used by the text renderer (5×7/7×8 glyphs;
+  confirm geometry against `romgen/fontrom`).
+- **Video-timing ROMs** (`romgen/syncsignals`, `romgen/videaddress`) — burned into the
+  hardware video generator; define H/V sync and the video-RAM address sequence. These have
+  **no software-visible address** (they drive the video circuit, not the CPU bus), but they
+  define the on-screen geometry the emulators reproduce.
+- Build data files live in `emulator/Data/` (`badger6502.bin`, `fontrom.dat`) and are staged
+  into `web/data/` by `web/build.ps1`.
+
+## Behaviour / Rules
+
+- The ROM region is read-only at runtime; the monitor owns reset/IRQ/NMI vectors.
+- Regenerating a ROM is a deliberate act: rebuild with the `romgen` tool, update the data
+  file in `emulator/Data/`, and re-run the emulator tests + web smoke tests so hardware and
+  emulators stay in lockstep.
+- If a generated image changes size or layout, update `HARDWARE.md` (decode) and
+  `EMULATOR.md` (load recipe) in the same commit.
+
+## Data flow
+
+```
+romgen (C# tools) → fontrom.dat / sync ROM / video-address ROM  → burned to hardware EPROM/GAL
+assembler/monitor source → badger6502.bin → emulator/Data/ → (web/build.ps1) → web/data/
+Boot: CPU reset vector ($FFFC) → monitor (ROM) → optional BASIC ($E000)
+```
+
+## Dependencies
+
+- Upstream: `romgen/` tooling (C#), `emulator/Data/` source images.
+- Downstream: `HARDWARE.md` (burns these ROMs), `EMULATOR.md`/`WEB.md` (load `badger6502.bin`
+  + `fontrom.dat`), `DISK.md` (Disk II boot PROM lives in the ROM image at `$C600`).
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Monitor/OS ROM (`badger6502.bin`) | Shipped | Boots to the monitor on real hardware + both emulators |
+| Character ROM (`fontrom.dat`) | Shipped | Used by all renderers |
+| `romgen/fontrom` (font ROM generator) | Shipped | C# tool |
+| `romgen/syncsignals` (video sync ROM) | Shipped | C# tool |
+| `romgen/videaddress` (video address ROM) | Shipped | C# tool |
+| Exact ROM memory map + font geometry documented here | In progress | Fill from `romgen/` + monitor source |
+| BASIC provenance/version noted | In progress | Generic Microsoft BASIC (not Applesoft) — see `web/README.md` |

--- a/specs/SYSTEM.md
+++ b/specs/SYSTEM.md
@@ -1,0 +1,79 @@
+# 3RIC — System Overview (SYSTEM.md)
+
+> The umbrella spec. Keep this short — it is read at the start of every session. It
+> describes the whole system at a glance and **links to every sub-spec**; the detail lives
+> in the sub-specs, read lazily.
+
+---
+
+## What this system is
+
+3RIC (**Badger6502**) is a from-scratch **65C02 homebrew personal computer** in the
+Apple-II tradition: a hand-designed digital logic machine with text/lo-res/hi-res video,
+a PS/2 keyboard, serial (ACIA) and parallel (VIA) I/O, a Disk II–style 5.25″ floppy, and a
+micro-SD card. The repo holds the **real hardware** (schematics, PCB, PLD logic), the
+**ROMs/firmware** that boot it, and two **faithful emulators** — a native WinUI 3 desktop
+host and an in-browser WebAssembly build — that run the *same* C++ VM core so they behave
+like the physical machine. The "why" lives in `docs/MISSION.md`.
+
+## Architecture at a glance
+
+```
+   Hardware (KiCad PCB · 22V10 GAL · TTL video)        Shared C++ VM core
+   65C02 + RAM/ROM + VIA + ACIA + video + Disk II      (emulator/Badger6502VMLib)
+              │  same ROM image + memory map  │            │            │
+              ▼                               ▼            ▼            ▼
+        badger6502.bin  ───────────────►  WinUI 3 host   WASM web    Unit tests
+        fontrom.dat       (romgen)         (desktop)     (browser)  (per-opcode)
+                                               │            │
+                                          WozLib floppy + MockMicroSD (SD/SPI via VIA1)
+                                               │
+                                          picodisk (Pi Pico disk/SD for real hardware)
+```
+
+- **Stack:** C++17 65C02 VM core — WinUI 3 (C++/WinRT) desktop host, Emscripten/WASM web
+  build, MSVC C++ unit tests; C# ROM-generator tools + Python/PowerShell build scripts;
+  KiCad + 22V10 GAL + Logisim hardware; Raspberry Pi Pico (C/C++) disk.
+- **Environments:** dev = Windows + Visual Studio 2022 (emulator) and emsdk + Node (web);
+  prod = **not yet deployed** (web emulator is static files, intended for a Raspberry Pi
+  behind a Cloudflare Tunnel). See `status/SYSTEM-STATUS.md`.
+
+## Sub-specs (read only the layer you'll touch)
+
+| Layer | Spec | Covers |
+|-------|------|--------|
+| Hardware | [`HARDWARE.md`](./HARDWARE.md) | KiCad schematic/PCB, 22V10 GAL logic, Logisim sim, DIYLC layout, memory map, video, I/O |
+| ROMs / firmware | [`ROMS.md`](./ROMS.md) | `romgen` font/sync/video-address ROMs, monitor/OS ROM image (`badger6502.bin`), BASIC |
+| Emulator | [`EMULATOR.md`](./EMULATOR.md) | Shared C++ VM core (CPU, VIA, ACIA, keyboard), WinUI 3 host, unit tests |
+| Web | [`WEB.md`](./WEB.md) | Emscripten/WASM bridge, canvas UI, build/serve, Cloudflare/R2 serving |
+| Disk | [`DISK.md`](./DISK.md) | WozLib 5.25″ floppy, MockMicroSD (SPI/FAT32), `dsk2woz2`, `picodisk` |
+
+> Create each sub-spec from [`_TEMPLATE.md`](./_TEMPLATE.md).
+
+## Cross-cutting concerns
+
+- **The shared contract:** the **ROM image (`badger6502.bin`) + the 6502 memory map** are
+  the single source of truth shared by hardware, the WinUI 3 host, and the WASM web build.
+  A change to the memory map, an I/O register, or the ROM is a **cross-layer event** — it
+  must land in the hardware (PLD/schematic), the emulator core, and the ROM together.
+- **Memory map (current, as emulated):** RAM low; ROM/OS `$D000–$FFFF` (reset vector
+  `$FFFC/$FFFD`); BASIC at `$E000` (generic Microsoft BASIC, seeded from the ROM image);
+  keyboard `$C000` data / `$C010` strobe; Disk II boot PROM `$C600`, data regs
+  `$C0E0–$C0EF`; micro-SD (bit-banged SPI) on VIA1 at `$C201`/`$C20F`. Detail in the specs.
+- **The critical path:** the **65C02 VM core stays instruction-correct**, and the **web +
+  WinUI 3 emulators stay behavior-consistent with the real hardware build**. This is what
+  the model-diverse review panel (`docs/CODE-REVIEW-PANEL.md`) and the pre-push test gate
+  (`scripts/dev/pre-push-tests.sh`) exist to protect. Platform code is guarded by
+  `__EMSCRIPTEN__` / `PLATFORM_WEB` so the three builds never silently diverge.
+- **Auth model:** none — single-user hobby project; the web build is 100% client-side with
+  no backend or stored user data.
+
+## Implementation status (summary)
+
+| Area | Status |
+|------|--------|
+| Hardware (schematic, PCB, PLD, video) | Built — documented in the YouTube build series; see `HARDWARE.md` |
+| ROMs / firmware (`romgen`, monitor, font) | Shipped — `badger6502.bin` + `fontrom.dat` boot the machine |
+| Emulator core + WinUI 3 host | Shipped — per-opcode unit tests in `Badger6502VMTest` |
+| Web (WASM) emulator | Shipped — boots ROM, video, keyboard, SD, Disk II; headless node tests |
+| Disk tooling (WozLib, `dsk2woz2`, `picodisk`) | Shipped — floppy + SD working; see `DISK.md` |

--- a/specs/WEB.md
+++ b/specs/WEB.md
@@ -1,0 +1,71 @@
+# 3RIC — WEB Spec
+
+> Source of truth for the in-browser (WebAssembly) emulator under `web/`. It compiles the
+> **same** C++ VM core (`EMULATOR.md`) to WASM, so it must stay behavior-consistent with the
+> WinUI 3 host and the real hardware (the critical path). See `web/README.md` for the long
+> form.
+
+---
+
+## Purpose
+
+A self-contained Emscripten/WebAssembly port of Badger6502: compile the C++ VM core + disk
+libs to WASM, boot the real ROM, render video to an HTML `<canvas>`, and feed keyboard/disk/
+SD input — 100% client-side, no backend.
+
+## Contracts / Interfaces
+
+- **Bridge — `web/web_bridge.cpp`** (embind). Wraps `VM`: `loadData`, `seedBasicRom`,
+  `loadFont`, `reset`, `run`, register/keyboard access, `loadSD`, `insertDisk`, and produces
+  the RGBA framebuffer. Module factory: `createBadgerVM` (`-sMODULARIZE=1 -sEXPORT_NAME=...`).
+- **Compat shim — `web/web_compat.h`** — shims MSVC-isms (`OutputDebugString`, `sprintf_s`,
+  `fopen_s`, `_ASSERT`, …) so `WozLib` + `MockMicroSD` compile under Emscripten.
+- **UI — `web/index.html`** — canvas + `requestAnimationFrame` driver, keyboard, and the
+  Speed/Boot Disk/Insert .woz/Mount SD controls. Honors optional `window.ASSET_BASE` /
+  `?assets=` to relocate `.wasm` + `data/` to a CDN (Cloudflare R2).
+- **Build — `web/build.ps1`** — compiles core + `WozLib` + `MockMicroSD` + bridge with
+  `-DPLATFORM_WEB -std=c++17 -O2 -lembind -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,node`;
+  stages `badger6502.bin` + `fontrom.dat`; generates `data/sd.sparse`; stages demo `disk.woz`.
+  Outputs (`badger6502.js`, `badger6502.wasm`, staged `data/`) are git-ignored.
+- **Serve — `web/serve.ps1`** (dev, `python -m http.server 8011`) and **`web/Caddyfile`**
+  (prod static origin: gzip/zstd, immutable cache for `/data/`, `no-cache` for `index.html`).
+- **Asset prep — `web/make_sd_sparse.py`** — streams the 2 GB FAT32 image into a compact
+  `sd.sparse` (~11.5 MB, `SDSP` container of non-zero sectors).
+
+## Behaviour / Rules
+
+- **Parity is mandatory:** the bridge/renderer must match the WinUI host's color/fringe logic
+  (it was ported verbatim). Core changes land in both, behind `__EMSCRIPTEN__`/`PLATFORM_WEB`.
+- WASM must be served over HTTP with `application/wasm` (not `file://`).
+- Per fresh visit the mandatory payload is ~1.26 MB; `disk.woz` (~230 KB) and `sd.sparse`
+  (~11.5 MB) load lazily on demand.
+- Clock speed is a frontend-only concern (per-frame wall-clock budget); the VM core is
+  unchanged by it.
+
+## Data flow
+
+```
+build.ps1 → badger6502.js/.wasm + data/  →  index.html loads createBadgerVM()
+loadData(badger6502.bin) → seedBasicRom() → loadFont(fontrom.dat) → reset()
+rAF loop: run(maxSteps) → framebuffer (RGBA) → <canvas>
+keydown → $C000 ; Mount SD → loadSD(sd.sparse) ; Boot Disk → insertDisk(.woz) + C600G
+prod: browser → Caddy (Pi) [→ Cloudflare edge / R2 for /data/]  (static only)
+```
+
+## Dependencies
+
+- Upstream: `EMULATOR.md` (VM core), `DISK.md` (`WozLib`, `MockMicroSD`, `sd.sparse`),
+  `ROMS.md` (`badger6502.bin`, `fontrom.dat`).
+- Downstream: end users' browsers. Production serving is **not yet deployed**.
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| WASM build of core + bridge | Shipped | `web/build.ps1` |
+| Video (text/lo-res/hi-res color) | Shipped | Ported from WinUI renderer |
+| Keyboard input | Shipped | `$C000`/`$C010` strobe |
+| Micro-SD (FAT32) + DOS shell | Shipped | `sd.sparse`, `loadSD` |
+| Disk II 5.25″ (WOZ) boot | Shipped | `insertDisk` + `C600G` |
+| Headless node tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk) |
+| Production deployment (Pi + Cloudflare / R2) | Not started | Config ready (`Caddyfile`, `ASSET_BASE`); not live |

--- a/specs/_TEMPLATE.md
+++ b/specs/_TEMPLATE.md
@@ -1,0 +1,42 @@
+# 3RIC — {{LAYER_NAME}} Spec
+
+> Copy this file to `specs/<LAYER>.md` (e.g. `DATABASE.md`, `API.md`, `WEB-CLIENT.md`) and
+> fill it in. One sub-spec per layer. Keep it the source of truth — update it in the same
+> commit as the code that implements it.
+
+---
+
+## Purpose
+
+{{What this layer is responsible for, in one or two sentences.}}
+
+## Contracts / Interfaces
+
+{{The precise, checkable contract this layer exposes — table schemas, endpoint shapes,
+component props, message formats. Field names, types, casing, nullability. This is what the
+other layers depend on; changing it is a cross-layer event.}}
+
+## Behaviour / Rules
+
+{{Validation rules, invariants, edge cases, error states. Be explicit about what happens on
+the unhappy path — empty states, failures, timeouts.}}
+
+## Data flow
+
+{{Trace the links this layer participates in:
+`... → this layer → ...`. Name the upstream and downstream layers.}}
+
+## Dependencies
+
+- Upstream: {{what this layer reads/depends on}}
+- Downstream: {{what depends on this layer}}
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| {{item}} | Not started / In progress / Shipped | {{PR #, caveats}} |
+
+> Update this table after implementing. A documented-but-unbuilt item is a **tracked gap**,
+> not a feature — and the client must render an explicit empty state for it, never fabricate
+> data (see `docs/LEARNINGS.md`).

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -1,0 +1,87 @@
+# 3RIC — System Status
+
+> The **current runtime reality** of the system: how to run it, where it lives, how to
+> verify it's healthy. Read at session start. Keep it lean and *current* — stale status is
+> worse than no status. Move historical detail to `status/CHANGELOG.md` and deep runbooks to
+> `docs/runbooks/`.
+
+_Last updated: 2026-06-26 — ebadger (via Copilot CLI, initial template instantiation)_
+
+---
+
+## Environments
+
+| Environment | Where | URL | Notes |
+|-------------|-------|-----|-------|
+| Dev — emulator | Windows + Visual Studio 2022 | n/a (desktop app) | `emulator/Badger6502VM.sln` (WinUI 3 / C++/WinRT host) |
+| Dev — web | Windows + emsdk + Node | http://localhost:8011/index.html | `web/build.ps1` then `web/serve.ps1` |
+| Production | not yet deployed | — | Web build is static files; target is a Raspberry Pi behind a Cloudflare Tunnel (see `specs/WEB.md`) |
+
+## How to run it (dev)
+
+```powershell
+# Desktop emulator (WinUI 3 host)
+#   open emulator/Badger6502VM.sln in Visual Studio 2022, set Badger6502VM as the
+#   startup project, then Build + Run (F5).
+
+# Web (WebAssembly) emulator
+cd web
+.\build.ps1            # compiles the C++ core + bridge to badger6502.js/.wasm (needs emsdk)
+.\serve.ps1            # python -m http.server 8011  ->  http://localhost:8011/index.html
+
+# Regenerate ROMs (font / video timing) — C# tools
+#   open the relevant solution under romgen/ and run the generator(s).
+```
+
+## How to verify it's healthy
+
+```powershell
+# 1) 65C02 core correctness — the critical path.
+#    Run the Badger6502VMTest suite (MSVC CppUnitTest, per-opcode) in Visual Studio
+#    Test Explorer, or headless:
+#    vstest.console.exe <build-output>\Badger6502VMTest.dll
+#    Expect: all tests pass.
+
+# 2) Web emulator smoke (headless Node; node ships with emsdk):
+$node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
+& $node web\test_boot.cjs        # ROM boots, sane PC, video RAM written
+& $node web\test_render.cjs      # framebuffer has lit pixels
+& $node web\test_keyboard.cjs    # monitor echoes typed commands
+& $node web\test_screen_text.cjs # decode the text screen to ASCII
+& $node web\test_sd.cjs          # mount the SD card + DIR lists the FAT32 root
+& $node web\test_disk.cjs        # boot a WOZ floppy via C600G into a hi-res title
+# Expect: each script exits 0.
+```
+
+## Credentials & secrets (dev only — NEVER commit real secrets)
+
+| What | Where it's configured | Dev value |
+|------|----------------------|-----------|
+| (none) | — | Single-user hobby project: no backend, no auth, no stored user data, no secrets. |
+| emsdk | `C:\Users\ebadger\emsdk` (emsdk 6.0.1) | tool path only — not a secret |
+| Node (for web tests) | `C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe` | tool path only — not a secret |
+
+> If production hosting is added later (Cloudflare Tunnel / R2), keep tunnel tokens and
+> bucket keys outside the repo (env / secret store). Do not commit secrets.
+
+## Key scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/dev/install-hooks.sh` | Activate the git `pre-push` guards (run once per clone). |
+| `scripts/dev/check-learnings-budget.sh` | Enforce the `docs/LEARNINGS.md` token cap. |
+| `scripts/dev/pre-push-tests.sh` | Pre-push test gate: C++ VM unit tests (VSTest, fail-open) + web headless node tests. |
+| `web/build.ps1` | Build the WASM emulator (core + WozLib + MockMicroSD + bridge), stage data. |
+| `web/serve.ps1` | Serve the web build locally on port 8011. |
+
+## Current state / known gaps
+
+- Desktop (WinUI 3) and web (WASM) emulators both boot the real ROM, render
+  text/lo-res/hi-res, take keyboard input, and run the Disk II floppy + micro-SD.
+- This clone's `$E000` BASIC is generic Microsoft BASIC, **not** Applesoft, so DOS 3.3 /
+  Quick-DOS disks that auto-run an Applesoft greeting load DOS but then trap; self-booting
+  machine-code game disks run fine (see `web/README.md`).
+- **Not deployed to production yet** — no public URL.
+- The operating-system layer (specs/, governance hooks, learnings) was just introduced;
+  the sub-specs under `specs/` describe intended contracts and are being filled in from the
+  existing implementation.


### PR DESCRIPTION
Applies the **AIProjectTemplate** "AI operating system" to this repo, localized to **3RIC / Badger6502**. This is governance + docs + tooling scaffolding only — it does **not** touch any emulator, ROM, hardware, or web source.

## What's included
- **`docs/`** — `MISSION.md` (the Badger6502 mission), `LEARNINGS.md` (canonical workflow rules §1–6 + Tier-1 digest, 5.3 KB, under budget), `ROLES.md`, `CODE-REVIEW-PANEL.md`, `SUGGESTIONS.md`, and the `learnings/` capture scaffolding.
- **`specs/`** — `SYSTEM.md` umbrella (architecture diagram, memory map, critical path) linking five sub-specs authored from source: **`HARDWARE.md`, `ROMS.md`, `EMULATOR.md`, `WEB.md`, `DISK.md`**.
- **`status/SYSTEM-STATUS.md`** — run/build/verify commands (VS Test Explorer + web node tests), no-secrets note, key scripts.
- **`.github/`** — `copilot-instructions.md`, the **compliance-hooks** Copilot extension (cross-layer nudges + learnings start-checklist), gpt/gemini reviewer agents, lens/agent skeletons, and issue/PR templates.
- **`.githooks/` + `scripts/dev/`** — learnings-budget check, hook installer, and a **`pre-push-tests.sh`** gate.

## Localized to 3RIC (not generic)
- Stack/domain/layers describe the real project: **C++17 65C02 VM core**, WinUI 3 (C++/WinRT) host, Emscripten/WASM web build, MSVC unit tests, C# `romgen` ROM tools, KiCad/22V10/Logisim hardware, and WozLib/MockMicroSD/`picodisk` disk tooling.
- The compliance extension's `SPEC_PATTERNS` and the cross-layer checklist target the repo's actual directories (`emulator/`, `web/`, `romgen/`, `kicad/`, `logisim/`, `22v10/`) and the shared `badger6502.bin` / `fontrom.dat` contract.
- The **shared contract** (ROM image + 6502 memory map → hardware · emulator core · WinUI host · WASM web) is documented as the critical path.

## Pre-push test gate (`scripts/dev/pre-push-tests.sh`)
Runs the web headless node tests (`web/test_*.cjs`) and the C++ `Badger6502VMTest` suite. **Fail-closed when built, fail-open when not**: if a build output is missing it warns and skips rather than forcing a full build to push. `SKIP_TEST_GUARD=1 git push` is the escape hatch. Hooks are opt-in via `scripts/dev/install-hooks.sh`.

## Notes / to verify
- Hardware internals not present in the repo text (full BOM, exact decode map, font geometry) are flagged as explicit **"To document"** gaps rather than invented.
- Per the template's #1 rule, this is **not self-merged** — over to you to review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
