### PR TITLE
Host the WebAssembly emulator on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,83 @@
+# Builds the 3ric Apple-II-clone WebAssembly emulator (web/) with Emscripten and
+# publishes it to GitHub Pages. The emulator is 100% client-side, so Pages hosts
+# the whole thing as static files — visitors need no GitHub account.
+#
+# The live site is served at the repo's project Pages URL:
+#   https://ebadger.github.io/3ric/
+name: Deploy emulator to Pages
+
+on:
+  push:
+    branches: [main]
+    # Only rebuild when something the emulator is compiled from changes.
+    paths:
+      - 'web/**'
+      - 'emulator/Badger6502VMLib/**'
+      - 'emulator/WozLib/**'
+      - 'emulator/MockMicroSD/**'
+      - 'emulator/Data/**'
+      - 'emulator/WozFileTestApp/testdata/**'
+      - '.github/workflows/deploy-pages.yml'
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Least-privilege token plus the permissions the Pages deploy needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never run two deployments at once; let an in-flight deploy finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # make_sd_sparse.py + build.ps1's sd.sparse generation need `python`.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Pins the same Emscripten the project is developed against (web/README.md).
+      # Adds em++ to PATH for later steps and caches the toolchain between runs.
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 6.0.1
+          actions-cache-folder: emsdk-cache
+
+      # pwsh is preinstalled on ubuntu-latest. build.ps1 detects the non-Windows
+      # host and invokes em++ directly (no emsdk_env.bat / cmd.exe round-trip).
+      - name: Build WebAssembly emulator
+        run: pwsh -File web/build.ps1
+
+      # Stage only what the page needs (not the C++/test sources) as the site root.
+      - name: Stage site
+        run: |
+          mkdir -p _site
+          cp web/index.html web/badger6502.js web/badger6502.wasm _site/
+          cp -r web/data _site/data
+          ls -la _site _site/data
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
+# 3ric — Apple-II-clone 65C02 computer
+
+**▶ Try the emulator in your browser: <https://ebadger.github.io/3ric/>**
+(runs entirely client-side via WebAssembly — no install and no GitHub account
+needed). Click the canvas and type; use **Boot Disk** for the demo floppy or
+**Mount SD** for the DOS shell. See [`web/`](web/) for how the WebAssembly port
+works, and `.github/workflows/deploy-pages.yml` for the build/deploy pipeline.
+
 See the build documented via [Youtube Videos](https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq)

--- a/web/README.md
+++ b/web/README.md
@@ -174,6 +174,32 @@ budget so the tab never locks up. `Max` sets the multiplier to `Infinity`, so th
 CPU runs as many cycles as fit in that budget. Clock speed is purely a frontend
 concern — the VM core is unchanged.
 
+## Hosting on GitHub Pages (zero-cost, public)
+
+Because the emulator is 100% client-side, the repo publishes it straight to
+**GitHub Pages** — no server to run. The live site is:
+
+**<https://ebadger.github.io/3ric/>**
+
+Anyone with a browser can open it; **no GitHub account is required**. For a
+public repo, Pages hosting and the Actions build are free (soft limits: 1 GB
+site, 100 GB/month bandwidth).
+
+`.github/workflows/deploy-pages.yml` does it automatically on every push to
+`main` that touches the emulator sources:
+
+1. installs Python + Emscripten (`6.0.1`, matching this project),
+2. runs `web/build.ps1` (it detects Linux CI and invokes `em++` directly),
+3. stages `index.html` + `badger6502.js` + `.wasm` + `data/` as the site root,
+4. uploads it as a Pages artifact and deploys.
+
+The build outputs stay git-ignored — CI regenerates them from the committed
+sources (`emulator/Data/*`, the demo `.woz`, etc.) each run. To publish from a
+fork, enable Pages with the **GitHub Actions** source (Settings → Pages), then
+push to `main` or run the workflow manually from the Actions tab. The site is
+served under `/<repo>/`, which works because every asset path in `index.html` is
+relative.
+
 ## Serving in production (Raspberry Pi + Cloudflare)
 
 The emulator is **100% client-side** — the server only hands out static files,

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -17,12 +17,20 @@ $woz  = Join-Path $root "emulator\WozLib"
 $sd   = Join-Path $root "emulator\MockMicroSD"
 $data = Join-Path $root "emulator\Data"
 
-$emsdk  = if ($env:EMSDK) { $env:EMSDK } else { Join-Path $env:USERPROFILE "emsdk" }
-$envBat = Join-Path $emsdk "emsdk_env.bat"
-$empp   = Join-Path $emsdk "upstream\emscripten\em++.exe"
+# Platform detection: $IsWindows is an automatic variable in PowerShell 7+; on
+# Windows PowerShell 5.1 it is undefined, so fall back to $env:OS. On Linux/macOS
+# (e.g. GitHub Actions CI) the emsdk environment is sourced beforehand so em++ is
+# already on PATH, and the Windows emsdk_env.bat / em++.exe lookup is skipped.
+$onWindows = $IsWindows -or ($env:OS -eq 'Windows_NT')
 
-if (-not (Test-Path $envBat)) { throw "emsdk not found at '$emsdk'. Set `$env:EMSDK or install per web/README.md." }
-if (-not (Test-Path $empp))   { throw "em++ not found at '$empp'. Did you run 'emsdk install/activate latest'?" }
+if ($onWindows) {
+    $emsdk  = if ($env:EMSDK) { $env:EMSDK } else { Join-Path $env:USERPROFILE "emsdk" }
+    $envBat = Join-Path $emsdk "emsdk_env.bat"
+    $empp   = Join-Path $emsdk "upstream\emscripten\em++.exe"
+
+    if (-not (Test-Path $envBat)) { throw "emsdk not found at '$emsdk'. Set `$env:EMSDK or install per web/README.md." }
+    if (-not (Test-Path $empp))   { throw "em++ not found at '$empp'. Did you run 'emsdk install/activate latest'?" }
+}
 
 # Core VM sources. symbols.cpp (debugger) and Disassemble.cpp (Windows-only
 # VM::Disassemble) are excluded; nothing compiled for the web references them.
@@ -72,8 +80,17 @@ $quoted = ($flags + $sources) | ForEach-Object { '"' + $_ + '"' }
 $argList = $quoted -join " "
 
 Write-Host "Building -> $out" -ForegroundColor Cyan
-$cmd = "call `"$envBat`" >nul 2>&1 && `"$empp`" $argList"
-& $env:ComSpec /c $cmd
+if ($onWindows) {
+    # Source emsdk_env.bat in the same cmd process that runs em++.exe.
+    $cmd = "call `"$envBat`" >nul 2>&1 && `"$empp`" $argList"
+    & $env:ComSpec /c $cmd
+} else {
+    # Linux/macOS (CI): em++ is already on PATH from a sourced emsdk env; allow an
+    # explicit override via $env:EMPP. PowerShell splats the argument array
+    # directly, so the manual quoting above is unnecessary here.
+    $emppCmd = if ($env:EMPP) { $env:EMPP } else { "em++" }
+    & $emppCmd @($flags + $sources)
+}
 if ($LASTEXITCODE -ne 0) { throw "Build failed with exit code $LASTEXITCODE" }
 
 # Stage the ROM + font images next to the page for fetch() at runtime.


### PR DESCRIPTION
## What this does

Publishes the browser emulator (`web/`) to **GitHub Pages** so anyone can use it from a link — **no GitHub account required**, and **no hosting cost** (free for this public repo).

Live URL once merged: **https://ebadger.github.io/3ric/**

## Why it works

The emulator is 100% client-side (65C02/video/disk all run in the visitor's browser via WebAssembly), so Pages just serves static files. A raw repo link can't do this — GitHub serves repo files as `text/plain` with `nosniff`, so the browser shows source instead of running the page. Pages serves them as a real site with correct MIME types (`application/wasm`, etc.) over HTTPS.

## Changes

- **`.github/workflows/deploy-pages.yml`** — on push to `main` (or manual dispatch): set up Python + Emscripten `6.0.1`, run `web/build.ps1`, stage `index.html` + `badger6502.js`/`.wasm` + `data/` as the site root, and deploy to Pages. Build outputs stay git-ignored; CI regenerates them from the committed sources each run.
- **`web/build.ps1`** — made cross-platform: on Linux/macOS CI it invokes `em++` directly; the Windows path is unchanged and guarded. Verified the Windows build still succeeds locally.
- **`README.md` / `web/README.md`** — link the live site and document the build/deploy pipeline.

Pages is already enabled on the repo with the **GitHub Actions** source, so merging this should kick off the first deploy automatically.

## Notes
- Per-visit payload ≈1.26 MB; `disk.woz` (~230 KB) and `sd.sparse` (~11.5 MB) load lazily. Well within Pages limits (1 GB site, 100 GB/mo bandwidth).
- If it ever gets popular, the existing `ASSET_BASE` hook can offload the heavy files to a CDN (e.g. Cloudflare R2).