### PR TITLE
Fix case-sensitive includes breaking the Linux/WASM Pages build

### DIFF
--- a/emulator/WozLib/WozFile.cpp
+++ b/emulator/WozLib/WozFile.cpp
@@ -1,4 +1,4 @@
-#include "wozfile.h"
+#include "WozFile.h"
 #if defined(__EMSCRIPTEN__)
 #include "web_compat.h"
 #else

--- a/emulator/WozLib/WozFile.h
+++ b/emulator/WozLib/WozFile.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include <mutex>
 #include "WozErrors.h"
-#include "timing.h"
+#include "Timing.h"
 
 // https://applesaucefdc.com/woz/reference2/
 


### PR DESCRIPTION
## Problem

The first Pages deploy (after merging #6) failed: the Emscripten build errored on the Linux runner with `fatal error: 'timing.h' file not found`.

## Cause

A latent **case-sensitivity** bug in the WozLib sources:
- `WozFile.h` did `#include "timing.h"` but the file on disk is **`Timing.h`**
- `WozFile.cpp` did `#include "wozfile.h"` but the file on disk is **`WozFile.h`**

Windows (case-insensitive filesystem) only emitted a `-Wnonportable-include-path` warning, so the local build passed — but Linux (case-sensitive) treats it as fatal. This affects the whole VM because `WozFile.h` is pulled in via `vm.h`.

## Fix

Match the `#include` casing to the real filenames. Harmless on Windows, required on Linux. Also clears the pre-existing non-portable-path warnings.

## Validation

I ran the deploy workflow against this branch on the real Linux runner: the **build job now passes** (compile → stage → upload Pages artifact all green). The deploy step was correctly rejected only because the `github-pages` environment is protected to deploy from `main` — so merging this will build *and* deploy, bringing https://ebadger.github.io/3ric/ live.