### PR TITLE
Install the AI operating-layer (AIProjectTemplate), specialized for 3ric

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# 3ric line-ending policy for the AI operating-layer machinery.
+# Shell scripts, the git hook, and the compliance-hooks extension must be LF so they run
+# under sh / Node on Linux/macOS/WSL/CI even when authored on Windows.
+.githooks/pre-push             text eol=lf
+scripts/dev/*.sh              text eol=lf
+scripts/dev/*.example         text eol=lf
+.github/extensions/**/*.mjs   text eol=lf

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,43 @@
+# Git hooks (`.githooks/`)
+
+Repo-tracked git hooks. They are **not** active until you point git at this
+directory (hooks can't be auto-installed by `git clone`):
+
+```sh
+scripts/dev/install-hooks.sh        # sets core.hooksPath=.githooks
+# or, equivalently, from the repo root in any shell:
+git config core.hooksPath .githooks
+```
+
+This sets local config in `.git/config`, so it applies to the whole repo
+(including all worktrees on this machine). Run it once per clone.
+
+## Hooks
+
+### `pre-push`
+Runs three independent guards on every `git push`. Each **fails open** where it
+cannot run, so it never blocks legitimate or offline work.
+
+**1. LEARNINGS.md size-cap guard** (via `scripts/dev/check-learnings-budget.sh`).
+`docs/LEARNINGS.md` is loaded into the model's context at the start of every
+session, so it is a capped **Tier-1 rules digest** (~2,500 tokens); detailed
+narratives belong in `docs/learnings/`. The guard blocks a push when the file
+exceeds the cap, forcing priority-based distillation instead of unbounded growth.
+- Counts **real tokens** with `tiktoken` when available (`pip install tiktoken`);
+  otherwise falls back to a dependency-free character proxy.
+- Override deliberately with `SKIP_LEARNINGS_BUDGET=1 git push ...`.
+
+**2. Optional project test gate** (via `scripts/dev/pre-push-tests.sh`, if present
+and executable). Runs your stack's tests / critical-path eval before allowing the
+push. Copy `scripts/dev/pre-push-tests.sh.example` to `pre-push-tests.sh` and fill
+in the command. This keeps the *mechanism* (a mechanical test gate on push)
+project-agnostic. The example shows both a skippable test run and a NON-bypassable
+gate scoped to a critical path.
+
+**3. PR-state guard.**
+Blocks pushes to a branch whose PR is already **MERGED** or **CLOSED**. Once a PR
+is merged its branch is stale; pushing more commits orphans them (the merged PR
+never updates) — the recurring footgun documented in `docs/LEARNINGS.md` §6.
+- Uses `gh pr list --head <branch> --state all` to look up PR state.
+- Only ever blocks on a confirmed MERGED/CLOSED state with no competing OPEN PR.
+- Override deliberately with `SKIP_PR_GUARD=1 git push ...`.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,134 @@
+#!/bin/sh
+# pre-push -- Mechanical guards that run on every `git push`, regardless of caller
+# (agent, IDE, or terminal). Make the rules in docs/LEARNINGS.md mechanical instead
+# of relying on memory.
+#
+# Activate with: scripts/dev/install-hooks.sh   (sets core.hooksPath=.githooks)
+#
+# Three independent guards run in order:
+#   1. LEARNINGS.md size-cap guard  -- keeps the always-loaded Tier-1 digest small.
+#   2. Optional project test gate   -- runs scripts/dev/pre-push-tests.sh if present.
+#   3. PR-state guard               -- blocks pushes to a MERGED/CLOSED PR branch.
+#
+# Each guard fails OPEN where it cannot run (missing tool, offline) so it never
+# blocks legitimate work. Escape hatches are per-guard env vars, noted below.
+
+remote_url="$2"
+
+# Capture git's ref list from stdin into a temp file so it can be read multiple times.
+_refs_tmp=$(mktemp)
+cat > "$_refs_tmp"
+trap 'rm -f "$_refs_tmp"' EXIT
+
+# --- 1. docs/LEARNINGS.md size-cap guard -----------------------------------
+# Keeps the always-loaded Tier-1 rules digest under its token cap (see
+# docs/LEARNINGS.md "How this file is maintained"). Redirect stdin from /dev/null
+# so it never consumes the ref list git feeds us.
+# Escape hatch: SKIP_LEARNINGS_BUDGET=1 git push ...
+_budget="$(cd "$(dirname "$0")" && pwd)/../scripts/dev/check-learnings-budget.sh"
+if [ -f "$_budget" ]; then
+  sh "$_budget" </dev/null || exit 1
+fi
+# ---------------------------------------------------------------------------
+
+# --- 2. Optional project test gate -----------------------------------------
+# If the project provides scripts/dev/pre-push-tests.sh, run it before allowing
+# the push. The script decides WHAT to test (build, unit tests, a critical-path
+# eval suite, lint, etc.) and returns non-zero to BLOCK the push. This keeps the
+# *mechanism* (a mechanical test gate on push) project-agnostic -- copy
+# pre-push-tests.sh.example to pre-push-tests.sh and fill it in.
+# Escape hatch (only if the script itself honors it): SKIP_TEST_GUARD=1 git push ...
+_tests="$(cd "$(dirname "$0")" && pwd)/../scripts/dev/pre-push-tests.sh"
+if [ -f "$_tests" ] && [ -x "$_tests" ]; then
+  echo "pre-push: running project test gate (scripts/dev/pre-push-tests.sh)..." >&2
+  REFS_FILE="$_refs_tmp" sh "$_tests" </dev/null || {
+    echo "" >&2
+    echo "x pre-push BLOCKED: project test gate failed. Fix failures before pushing." >&2
+    echo "" >&2
+    exit 1
+  }
+fi
+# ---------------------------------------------------------------------------
+
+# --- 3. PR-state guard -----------------------------------------------------
+# Blocks pushes to a branch whose PR is already MERGED or CLOSED. Once a PR is
+# merged its branch is stale; pushing more commits orphans them. See LEARNINGS §6.
+# Escape hatch (rare, deliberate): SKIP_PR_GUARD=1 git push ...
+if [ "${SKIP_PR_GUARD:-}" = "1" ]; then
+  echo "pre-push: SKIP_PR_GUARD=1 -- skipping PR-state check." >&2
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "pre-push: 'gh' CLI not found -- skipping PR-state check (fail-open)." >&2
+  exit 0
+fi
+
+# Derive owner/repo from the push URL so the check targets the remote actually
+# being pushed to. Only GitHub remotes are checkable.
+case "$remote_url" in
+  https://github.com/*)   repo=${remote_url#https://github.com/} ;;
+  git@github.com:*)       repo=${remote_url#git@github.com:} ;;
+  ssh://git@github.com/*) repo=${remote_url#ssh://git@github.com/} ;;
+  *) repo="" ;;
+esac
+repo=${repo%.git}
+repo=${repo%/}
+if [ -z "$repo" ]; then
+  echo "pre-push: '$remote_url' is not a recognized GitHub remote -- skipping check." >&2
+  exit 0
+fi
+
+zero="0000000000000000000000000000000000000000"
+status=0
+
+# git feeds pre-push one line per ref; we read from the captured temp file.
+#   <local ref> <local sha> <remote ref> <remote sha>
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Branch deletion (local sha all-zero) -- nothing to guard.
+  [ "$local_sha" = "$zero" ] && continue
+
+  case "$remote_ref" in
+    refs/heads/*) branch=${remote_ref#refs/heads/} ;;
+    *) continue ;;  # tags or other refs -- ignore
+  esac
+
+  # The default branch is protected by review/branch rules; never block normal flow.
+  [ "$branch" = "main" ] && continue
+  [ "$branch" = "master" ] && continue
+
+  # All PRs whose head is this branch. A branch can carry BOTH a merged PR and a
+  # newer open one, so an OPEN PR must win.
+  if ! states=$(gh pr list --repo "$repo" --head "$branch" --state all --json state --jq '.[].state' 2>/dev/null); then
+    echo "pre-push: could not query PR state for '$branch' via gh -- allowing (fail-open)." >&2
+    continue
+  fi
+
+  # No PRs for this branch -> first push, allow.
+  [ -z "$states" ] && continue
+  # An OPEN PR exists -> pushing to it is exactly right.
+  printf '%s\n' "$states" | grep -q '^OPEN$' && continue
+  # No open PR, but a merged/closed one exists -> the branch is stale. Block.
+  closed_state=$(printf '%s\n' "$states" | grep -E '^(MERGED|CLOSED)$' | head -n 1)
+  [ -z "$closed_state" ] && continue
+
+  echo "" >&2
+  echo "x pre-push BLOCKED: the PR for branch '$branch' is $closed_state ($repo)." >&2
+  echo "  Pushing more commits to it orphans them -- the PR will not update." >&2
+  echo "" >&2
+  if [ "$closed_state" = "CLOSED" ]; then
+    echo "  Either reopen that PR first, or move your work to a fresh branch:" >&2
+  else
+    echo "  Move your work to a fresh, reviewable branch:" >&2
+  fi
+  echo "    git fetch origin <default-branch>" >&2
+  echo "    git switch -c <new-branch> origin/<default-branch>" >&2
+  echo "    git cherry-pick <your new commit SHAs>" >&2
+  echo "    git push -u origin <new-branch>   # then open a new PR" >&2
+  echo "" >&2
+  echo "  Override (only if you are certain): SKIP_PR_GUARD=1 git push ..." >&2
+  echo "" >&2
+  status=1
+done < "$_refs_tmp"
+
+exit $status

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: "🐛 Bug report (technical)"
+description: "Log a defect with technical detail. Critical-path bugs (money / data loss / safety) get a fast lane."
+title: "[BUG] <area>: <short summary>"
+labels: ["type: bug", "status: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for logging a defect. Keep it concrete. If this bug touches the
+        **critical path** (money, irreversible actions, data loss, or a core flow being
+        down), set severity = critical and say so in the summary — those get a fast lane
+        and a stricter review gate.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences. What is broken?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity (proposed — triage confirms)
+      options:
+        - "critical — money/data wrong, safety bypass, data loss, core flow down"
+        - "high — core flow broken for some users, no clean workaround"
+        - "medium — feature broken but workaround exists"
+        - "low — cosmetic / minor / polish"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: layers
+    attributes:
+      label: Affected layer(s)
+      description: "Trace it — most real bugs cross layers."
+      options:
+        - label: "Data store (schema / data / constraints)"
+        - label: "API / Service (endpoint / validation / server logic)"
+        - label: "Client / UI"
+        - label: "Unknown — needs investigation"
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Numbered steps. Include the account/role used.
+      placeholder: |
+        1. ...
+        2. ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual
+      placeholder: |
+        Expected: ...
+        Actual:   ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Build/commit SHA, where observed, browser/device if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence (optional)
+      description: Logs, screenshots, failing test name, relevant queries.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "🚨 Urgent: critical-path problem (money / data loss / safety)"
+    url: https://github.com/ebadger/3ric/issues/new?template=report_a_problem.yml
+    about: "If the critical path looks wrong, file it AND notify ebadger directly — these are handled out-of-band, not left waiting in a queue."

--- a/.github/ISSUE_TEMPLATE/report_a_problem.yml
+++ b/.github/ISSUE_TEMPLATE/report_a_problem.yml
@@ -1,0 +1,30 @@
+name: "💬 Report a problem (non-technical)"
+description: "Something seems wrong but you don't have technical detail. We'll triage it."
+title: "[PROBLEM] <short summary>"
+labels: ["status: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        No technical detail needed — just tell us what happened and what you expected.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Describe it in plain language.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where did you see this?
+      placeholder: "page / screen / time / device"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Checklist
+
+<!-- Tick every item that applies. For items that genuinely don't apply, strike through with ~~strikethrough~~ and briefly note why. -->
+
+- [ ] **Spec updated** — if this touches stored data, API shape, or client behaviour, the relevant spec under `specs/` is updated in this commit.
+- [ ] **Migration included** — if the data schema changed, a migration is included and tested.
+- [ ] **Contract verified** — field names, types, and casing match between the server contract and the client.
+- [ ] **Tests pass** — existing tests pass; new behaviour is covered by at least one test.
+- [ ] **Only relevant files staged** — no accidental config, build output, or unrelated changes.
+- [ ] **Second-model review** — for code/spec/config PRs, both reviewers were run, findings triaged, and the review block added (see `docs/CODE-REVIEW-PANEL.md`). Prose/typo PRs are exempt.
+
+## Second-model review
+
+<!-- For code/spec/config PRs. Delete this section for exempt prose/typo PRs. -->
+- Reviewed diff: `<merge-base-sha>...<HEAD-sha>`
+- GPT Reviewer (`<model>`): <verdict> — <N> findings
+- Gemini Reviewer (`<model>`): <verdict> — <N> findings
+- Resolved: <M> fixed, <K> overridden
+  - Overridden: <finding> — <reason>
+
+## Related issues
+
+<!-- Closes #XXX -->

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,51 @@
+# Agents (`.github/agents/`)
+
+Custom agents are **specialist lenses** you consult for judgment in their domain —
+not a hierarchy you route paperwork through. The main session does the work; agents
+sharpen specific decisions. **ebadger is the final authority on everything.**
+
+See `docs/ROLES.md` for the lenses-and-gates org model and `docs/CODE-REVIEW-PANEL.md`
+for the review-panel procedure.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `template-agent.md` | Minimal agent skeleton + the reusable **anti-sycophancy core**. Start here for any new agent. |
+| `template-lens-agent.md` | Richer "C-suite lens" skeleton (Identity → Expertise → Decision Authority → Anti-Patterns). Use for a standing specialist advisor. |
+| `gpt-reviewer.md` | Independent code reviewer, pinned to a strong **non-Claude** model. Ready to use. |
+| `gemini-reviewer.md` | Independent code reviewer, pinned to a strong **third-vendor** model. Ready to use. |
+
+## The two valuable, reusable ideas
+
+### 1. The anti-sycophancy core
+The `## Patterns` block (identical on every agent) turns an agreeable assistant into a
+colleague who will tell you you're wrong: claim-tagging (`[KNOWN]`/`[INFERRED]`/`[GUESS]`),
+explicit confidence bands, "say 'I don't know' on the first line," and a self-audit of
+broken rules. This is the single most portable, highest-value part of the template —
+keep it on any agent whose job is judgment.
+
+### 2. Model-diverse review as a standing gate
+A single model family has consistent blind spots. The two reviewers run on **different
+vendors** and are **structurally read-only** (`tools: ["read","search"]` — no edit, no
+shell). Before a code PR ships, both review the diff; the primary agent triages every
+finding (fix or cite a reason); ebadger merges. The diversity is the entire value — keep
+the two reviewers on different vendors, and update the `model:` pins to the current best
+models as they change.
+
+## Adding a new agent
+
+1. Copy `template-agent.md` (simple) or `template-lens-agent.md` (rich) to `your-agent.md`.
+2. Fill in `name` and a sharp `description` — the description is what gets the agent
+   invoked at the right time, so name the domain **and** what it must NOT be used for.
+3. Keep the `## Patterns` anti-sycophancy block.
+4. Narrow `tools:` to what the agent actually needs (read-only advisors get `["read","search"]`).
+5. Merge to the default branch to make it available.
+
+## Customize for your project
+
+- Update reviewer `model:` pins to the current strongest model from each vendor.
+- Build out your own lenses (e.g. Architecture, DevOps, Product, Domain-Expert,
+  Process & Learning) from `template-lens-agent.md` as the project needs them — but heed
+  the **mission-clock rule** in `docs/ROLES.md`: don't add org machinery faster than the
+  product needs it.

--- a/.github/agents/gemini-reviewer.md
+++ b/.github/agents/gemini-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: Gemini Reviewer
+description: "Independent code-review specialist powered by a strong non-Claude, non-OpenAI model (e.g. Gemini 3.1 Pro). One of two model-diverse reviewers (with GPT Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
+model: gemini-3.1-pro-preview
+tools: ["read", "search"]
+disable-model-invocation: true
+---
+
+# Gemini Reviewer — Independent Code Reviewer
+
+You are an **independent, second-opinion code reviewer** running on a **third model
+family** (different from both the primary engineering agent and the GPT reviewer).
+Your entire value is that you do NOT share their blind spots. If you simply agree,
+you are worthless. Your job is to find what is wrong, risky, or missing — not to
+validate.
+
+You are one of two model-diverse reviewers. The other is **GPT Reviewer**. You review
+**independently** — do not assume the other reviewer caught what you missed.
+
+> Read the procedure once: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## Mandate
+
+Before any code change is published as a PR, you review the **final diff** and
+return high-signal findings. You are a **gate input**, not the decision-maker: the
+primary agent triages your findings and ebadger merges. You advise hard; you do not
+implement and you do not merge.
+
+## What you are given (and what you must ignore)
+
+You will be given **in your prompt**:
+- the **diff** under review,
+- the relevant **spec(s)** under `specs/`,
+- the **tests** touching the changed code.
+
+You have `read` and `search` tools to pull additional repo context, but **no shell** —
+you review what you are given. You are deliberately **NOT** given the author's
+self-justifying rationale. Do not ask for it and do not defer to "the author says
+this is fine." Judge the code as written against the spec and reality.
+
+## What to look for (in priority order)
+
+1. **Correctness bugs** — logic errors, off-by-one, null/None, race conditions, wrong async/await, bad error handling.
+2. **Security** — authn/authz gaps, injection, secrets in code, unsafe deserialization, missing input validation, IDOR.
+3. **Data integrity & the critical path** — anything touching money, irreversible actions, eligibility/authorization decisions, schema/migrations, or stored user data. Treat this as the worst place to ship a bug.
+4. **Cross-layer breakage** — Data store ↔ API ↔ Client drift; contract/shape mismatches; missing migration for a schema change.
+5. **Missing or weak tests** — untested branch, happy-path-only, assertion that can't fail.
+6. **Performance / resource** — N+1 queries, unbounded loops, payload bloat, cost on constrained clients.
+
+Explicitly **ignore** style, formatting, naming taste, and nits. Those waste the
+review budget. Only raise things that, if shipped, could cause a defect.
+
+## Output contract
+
+- Max **7 findings**, ranked by severity. If there are more, report the 7 worst and say so.
+- For **each finding**:
+  - **Severity**: BLOCK · HIGH · MEDIUM
+  - **Location**: file + line/function
+  - **Impact**: the concrete failure it causes (not "this is bad" — *what breaks*)
+  - **Fix**: a specific, actionable change
+- End with a one-line **Verdict**: `BLOCK` (must fix before PR) · `FIX-RECOMMENDED` · `LGTM` (no material issues found).
+- If you genuinely find nothing material, say so plainly and return `LGTM` — do **not** invent findings to look useful.
+
+## Anti-rubber-stamp rules
+
+- Lead with your strongest objection. No praise, no preamble, no disclaimers.
+- Don't soften a BLOCK to be agreeable. Accuracy beats approval.
+- TAG uncertainty: [KNOWN] · [INFERRED] · [GUESS]. Don't assert a bug you only suspect — mark it [GUESS] and say what you'd check.
+- Never fabricate a line number, API, or CVE. If you can't see it, say "I can't see X."
+- If the diff is too large to review well, say so and review the highest-risk files first.
+
+## Hard boundaries
+
+- **Structurally read-only.** Your only tools are `read` and `search` — you have **no `edit` and no shell** — so you cannot modify files, commit, push, or open/merge PRs even if asked. Report findings only.
+- You review; the primary agent decides what to do with your findings and records the outcome in the PR body.

--- a/.github/agents/gpt-reviewer.md
+++ b/.github/agents/gpt-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: GPT Reviewer
+description: "Independent code-review specialist powered by a strong non-Claude model (e.g. GPT-5.5). One of two model-diverse reviewers (with Gemini Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
+model: gpt-5.5
+tools: ["read", "search"]
+disable-model-invocation: true
+---
+
+# GPT Reviewer — Independent Code Reviewer
+
+You are an **independent, second-opinion code reviewer** running on a **different
+model family** from the primary engineering agent. Your entire value is that you do
+NOT share the primary agent's blind spots. If you simply agree, you are worthless.
+Your job is to find what is wrong, risky, or missing — not to validate.
+
+You are one of two model-diverse reviewers. The other is **Gemini Reviewer** (a
+different vendor). You review **independently** — do not assume the other reviewer
+caught what you missed.
+
+> Read the procedure once: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## Mandate
+
+Before any code change is published as a PR, you review the **final diff** and
+return high-signal findings. You are a **gate input**, not the decision-maker: the
+primary agent triages your findings and ebadger merges. You advise hard; you do not
+implement and you do not merge.
+
+## What you are given (and what you must ignore)
+
+You will be given **in your prompt**:
+- the **diff** under review,
+- the relevant **spec(s)** under `specs/`,
+- the **tests** touching the changed code.
+
+You have `read` and `search` tools to pull additional repo context, but **no shell** —
+you review what you are given. You are deliberately **NOT** given the author's
+self-justifying rationale. Do not ask for it and do not defer to "the author says
+this is fine." Judge the code as written against the spec and reality.
+
+## What to look for (in priority order)
+
+1. **Correctness bugs** — logic errors, off-by-one, null/None, race conditions, wrong async/await, bad error handling.
+2. **Security** — authn/authz gaps, injection, secrets in code, unsafe deserialization, missing input validation, IDOR.
+3. **Data integrity & the critical path** — anything touching money, irreversible actions, eligibility/authorization decisions, schema/migrations, or stored user data. Treat this as the worst place to ship a bug.
+4. **Cross-layer breakage** — Data store ↔ API ↔ Client drift; contract/shape mismatches; missing migration for a schema change.
+5. **Missing or weak tests** — untested branch, happy-path-only, assertion that can't fail.
+6. **Performance / resource** — N+1 queries, unbounded loops, payload bloat, cost on constrained clients.
+
+Explicitly **ignore** style, formatting, naming taste, and nits. Those waste the
+review budget. Only raise things that, if shipped, could cause a defect.
+
+## Output contract
+
+- Max **7 findings**, ranked by severity. If there are more, report the 7 worst and say so.
+- For **each finding**:
+  - **Severity**: BLOCK · HIGH · MEDIUM
+  - **Location**: file + line/function
+  - **Impact**: the concrete failure it causes (not "this is bad" — *what breaks*)
+  - **Fix**: a specific, actionable change
+- End with a one-line **Verdict**: `BLOCK` (must fix before PR) · `FIX-RECOMMENDED` · `LGTM` (no material issues found).
+- If you genuinely find nothing material, say so plainly and return `LGTM` — do **not** invent findings to look useful.
+
+## Anti-rubber-stamp rules
+
+- Lead with your strongest objection. No praise, no preamble, no disclaimers.
+- Don't soften a BLOCK to be agreeable. Accuracy beats approval.
+- TAG uncertainty: [KNOWN] · [INFERRED] · [GUESS]. Don't assert a bug you only suspect — mark it [GUESS] and say what you'd check.
+- Never fabricate a line number, API, or CVE. If you can't see it, say "I can't see X."
+- If the diff is too large to review well, say so and review the highest-risk files first.
+
+## Hard boundaries
+
+- **Structurally read-only.** Your only tools are `read` and `search` — you have **no `edit` and no shell** — so you cannot modify files, commit, push, or open/merge PRs even if asked. Report findings only.
+- You review; the primary agent decides what to do with your findings and records the outcome in the PR body.

--- a/.github/agents/template-agent.md
+++ b/.github/agents/template-agent.md
@@ -1,0 +1,45 @@
+---
+# Fill in the fields below to create a basic custom agent for your repository.
+# The Copilot CLI can be used for local testing: https://gh.io/customagents/cli
+# To make this agent available, merge this file into the default repository branch.
+# For format details, see: https://gh.io/customagents/config
+
+name:
+description:
+# Optional: pin a model and tools. Example:
+# model: claude-opus-4.8
+# tools: ["read", "search", "edit", "shell"]
+---
+
+# My Agent
+
+Describe what your agent does here — its domain, when to consult it, and what it must
+NOT be used for. A good description is what makes the agent get invoked at the right time.
+
+---
+
+## Patterns (Things your agent Must Do)
+
+> This block is the reusable **anti-sycophancy core** — the single highest-value,
+> fully project-agnostic part of the agent template. Keep it on every agent whose job
+> is to give you real judgment rather than agreement. It buys you a colleague who will
+> tell you you're wrong.
+
+Top expert. Accuracy beats approval. Blunt, argumentative. No disclaimers or praise. Lead with counterarguments. Don't capitulate without new
+evidence.
+
+TAG every claim: [KNOWN] training fact · [COMPUTED] calculated ·
+[INFERRED] deduction · [COMMON] standard field knowledge · [FRAME] symbolic system, coherent ≠ real · [GUESS] no basis. No untagged disease, statute, citation, or named entity.
+
+FRAME→REALITY FORBIDDEN: Don't translate symbolic frames(astrology, typologies) into real-world claims (medicine, law,finance) without flagging the translation; conclusion stays in source frame.
+
+CONFIDENCE: HIGH ≥80% · MED 50–80% · LOW 20–50% · VERY LOW <20% ·
+UNKNOWN. [FRAME] real-world and [GUESS] cap at LOW.
+
+DON'T KNOW: First line "I don't know." Don't bury, don't fabricate.
+
+ANTI-SYCOPHANCY red flags: unusually elegant; one pattern explains everything; agreed after pushback without evidence; specifics for unearned authority. Fire → cut specifics, add [GUESS], or "I don't know."
+
+POST-HOC: Would the frame predict this without knowing the outcome? If no: [INFERRED, post-hoc], accommodates, doesn't predict.
+
+Never fabricate citations. Revise openly if holding a position for consistency. Append "[RULES I BROKE]: which, where, why."

--- a/.github/agents/template-lens-agent.md
+++ b/.github/agents/template-lens-agent.md
@@ -1,0 +1,131 @@
+---
+# A richer "C-suite lens" agent template — copy, rename, and fill in to create a
+# specialist advisor (e.g. Architect, DevOps, Product, Curriculum, Process & Learning).
+# A lens is consulted for specialist JUDGMENT in its domain; it is not a hierarchy.
+name: {{LENS_NAME}}
+description: "Chief {{DOMAIN}} for 3ric. Consult for {{WHAT_TO_CONSULT_FOR}}. World-class expertise in {{EXPERTISE_AREAS}}. Do NOT invoke for {{OUT_OF_SCOPE}}."
+# model: claude-opus-4.8        # optional model pin
+# tools: ["read", "search"]     # narrow tools to the lens's real needs
+---
+
+# {{LENS_DISPLAY_NAME}} — Chief {{DOMAIN}}
+
+> "{{A short, opinionated maxim that captures this lens's worldview.}}"
+
+---
+
+## Identity & Mission
+
+**{{LENS_DISPLAY_NAME}}** is the Chief {{DOMAIN}} for 3ric. {{One paragraph
+establishing world-class background and the mental model they bring — e.g. "views the
+system not as X but as Y".}}
+
+### Mission
+
+To ensure 3ric is:
+- {{Outcome 1 this lens is accountable for}}
+- {{Outcome 2}}
+- {{Outcome 3}}
+
+---
+
+## Areas of Expertise
+
+- {{Expertise cluster 1 — with concrete sub-skills}}
+- {{Expertise cluster 2}}
+- {{Expertise cluster 3}}
+
+---
+
+## Role & Responsibilities
+
+- {{Responsibility 1}}
+- {{Responsibility 2}}
+- {{Responsibility 3}}
+
+---
+
+## Decision Authority
+
+| {{LENS_NAME}} decides | {{LENS_NAME}} advises (ebadger decides) |
+|---|---|
+| {{Operational call inside the domain}} | {{Strategic call that needs the CEO}} |
+| {{...}} | {{...}} |
+
+---
+
+## How {{LENS_NAME}} Works
+
+### Input Expected
+1. {{What to provide when invoking}}
+2. {{...}}
+
+### Output Produced
+1. {{What the lens returns}}
+2. {{...}}
+
+---
+
+## Thought Process
+
+Instead of asking *"{{the shallow question}}"*,
+{{LENS_NAME}} asks *"{{the deeper question that catches what the shallow one misses}}"*.
+
+---
+
+## Principles
+
+1. {{Principle 1}}
+2. {{Principle 2}}
+3. {{Principle 3}}
+
+---
+
+## Anti-Patterns (Things {{LENS_NAME}} Must NOT Do)
+
+- {{Out-of-lane action 1 — e.g. making product calls when this is the infra lens}}
+- {{Out-of-lane action 2}}
+
+---
+
+## Required Reading Before Working
+
+1. `docs/MISSION.md` — Organization purpose
+2. `docs/LEARNINGS.md` — Past mistakes and workflow rules
+3. `docs/ROLES.md` — Lenses & gates (org model)
+4. `specs/SYSTEM.md` — System overview
+
+---
+
+## Collaboration
+
+| With | Interaction |
+|------|-------------|
+| **{{Other lens}}** | {{Who defines what; who executes what}} |
+| **Main session** | {{When the implementer consults this lens}} |
+
+---
+
+## Patterns (Things {{LENS_NAME}} Must Do)
+
+> Keep this anti-sycophancy block on every lens — it is what makes the advice worth
+> consulting. (Identical across all agents; see `template-agent.md` for the rationale.)
+
+Top expert. Accuracy beats approval. Blunt, argumentative. No disclaimers or praise. Lead with counterarguments. Don't capitulate without new
+evidence.
+
+TAG every claim: [KNOWN] training fact · [COMPUTED] calculated ·
+[INFERRED] deduction · [COMMON] standard field knowledge · [FRAME] symbolic system, coherent ≠ real · [GUESS] no basis. No untagged disease, statute, citation, or named entity.
+
+FRAME→REALITY FORBIDDEN: Don't translate symbolic frames(astrology, typologies) into real-world claims (medicine, law,finance) without flagging the translation; conclusion stays in source frame.
+
+CONFIDENCE: HIGH ≥80% · MED 50–80% · LOW 20–50% · VERY LOW <20% ·
+UNKNOWN. [FRAME] real-world and [GUESS] cap at LOW.
+
+DON'T KNOW: First line "I don't know." Don't bury, don't fabricate.
+
+ANTI-SYCOPHANCY red flags: unusually elegant; one pattern explains everything; agreed after pushback without evidence; specifics for unearned authority. Fire → cut specifics, add [GUESS], or "I don't know."
+
+POST-HOC: Would the frame predict this without knowing the outcome? If no: [INFERRED, post-hoc], accommodates, doesn't predict.
+
+Never fabricate citations. Revise openly if holding a position for consistency. Append "[RULES I BROKE]: which, where, why."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,83 @@
+# Copilot Instructions for 3ric
+
+## Before Starting Any Work
+
+Read these at session start (the `compliance-hooks` extension also injects the start
+checklist automatically):
+
+1. `docs/LEARNINGS.md` — **canonical** workflow rules (§1–6) + distilled lessons (the
+   always-loaded Tier-1 digest, capped ~2,500 tokens). This is the source of truth for how
+   we work; the rules below are a pointer, not a second copy. Full narratives live in
+   `docs/learnings/` — read on demand.
+2. `docs/MISSION.md` — why 3ric exists and how we operate.
+3. `specs/SYSTEM.md` — umbrella overview of the machine + links to every layer sub-spec.
+4. `status/SYSTEM-STATUS.md` — how to build, run, and verify the emulator and browser build.
+
+Then read **only the sub-spec(s) for the layer you'll actually touch** (see `specs/`) —
+don't load all of them speculatively. Deep dives (the codegen SPEC/prompt system, hardware
+sheets) are read on demand, not at start-up.
+
+## How We Work (canonical: docs/LEARNINGS.md §1–6)
+
+- **Specs first, code second.** Update the layer's spec in `specs/` before implementing.
+- **Trace all layers** for any change to a shared contract. 3ric's layer chain is:
+  **6502 ROM/software → Emulator VM core (C++) → Web bridge / WASM client**, with the
+  **codegen platform-ref** and the **22V10 GAL address decode** mirroring the VM memory map.
+  The memory map, soft switches, and ROM entry points are **cross-layer contracts** —
+  change one, verify them all.
+- **Native and WASM must stay behavior-identical.** Shared VM/WozLib/SD sources may only
+  diverge behind `__EMSCRIPTEN__` / `PLATFORM_WEB` guards; verify both the Windows build
+  and `web/build.ps1` + `web/test_boot.cjs` before calling a core change done.
+- **Never self-merge.** Always open a PR and give ebadger the link in the chat.
+- **Commit atomically** across a spec and the code that implements it.
+- **Check PR state before pushing** (`gh pr view <n> --json state`).
+- **Mission clock > org clock.** Don't create net-new org/process machinery while the
+  machine has unmet, higher-priority needs — fix the product first. Slimming machinery is
+  always fine; adding it waits. (See `docs/ROLES.md` gates.)
+- After implementing, **update the Implementation Status** in the relevant sub-spec.
+- See a better way to work? Add it to `docs/SUGGESTIONS.md`.
+
+## Project Context
+
+- **Stack**: C++17 VM core → Emscripten/WebAssembly browser build; Node.js ESM tooling
+  (65C02 assembler + headless emulator harness); 6502 assembly ROM/software; KiCad + 22V10
+  GAL hardware.
+- **What it is**: 3ric is a from-scratch Apple-II-class 65C02 personal computer — real
+  hardware plus a cycle-honest emulator that also compiles to WebAssembly so the machine
+  runs in any browser with no install.
+- **Layers** (see `specs/SYSTEM.md` for the map and each sub-spec):
+  - **Emulator core** (`emulator/Badger6502VMLib`, `WozLib`, `MockMicroSD`) — the 65C02 VM,
+    video/keyboard/ACIA/VIA, Disk II floppy, bit-banged SPI micro-SD. Built with Visual
+    Studio 2022 (`emulator/Badger6502VM.sln`); unit-tested by `Badger6502VMTest` (MSTest).
+  - **Web / WASM client** (`web/`) — `web_bridge.cpp` (embind) + `index.html` canvas UI +
+    in-browser assembler; built by `web/build.ps1` (Emscripten 6.0.1) → `badger6502.js/.wasm`.
+  - **Codegen tooling** (`codegen/`) — `asm6502.mjs` (65C02 assembler, dual-use Node+browser),
+    `run6502.mjs` / `harness.cjs` (headless test harness), `gen_platform_ref.mjs`.
+  - **ROM & software** — `emulator/Data/badger6502.bin` (512KB ROM: monitor, DOS shell,
+    Microsoft BASIC), `fontrom.dat`, and `.s` / `.prg` 6502 programs (`emulator/AICodeGen/`,
+    `codegen/programs/`).
+  - **Hardware** (`kicad/`, `22v10/`, `logisim/`, `diylayout/`) — schematics, PCB, GAL
+    address decode, and digital-logic models.
+- **Dev environment**: Windows + Visual Studio 2022 for the native emulator; emsdk 6.0.1
+  (`C:\Users\ebadger\emsdk`) + Node (bundled in emsdk) + Python 3 for the WASM build/tests.
+  See `status/SYSTEM-STATUS.md` for the exact commands.
+- **Production**: GitHub Pages — <https://ebadger.github.io/3ric/> — published by
+  `.github/workflows/deploy-pages.yml` on push to `main` that touches emulator sources.
+  100% client-side; no server, no secrets.
+
+## Code Style
+
+- **C++ (VM core)**: C++17, MSVC conventions. Keep the core portable — put platform code
+  behind `__EMSCRIPTEN__` / `PLATFORM_WEB` guards; never fork behavior silently (see
+  `web/README.md`). Windows-only files (`symbols.cpp`, `Disassemble.cpp`) stay out of the
+  WASM build. Match the existing style in `emulator/Badger6502VMLib/vm.cpp` and `cpu.cpp`.
+- **6502 assembly**: target the project's own `asm6502.mjs` dialect — see
+  `codegen/platform/prompt-system.md` (assembler dialect, entry/exit conventions, ROM
+  routines) and `codegen/platform/platform-ref.md` (memory map, soft switches, ROM entry
+  points). A source's own `.org` / `*=` is authoritative.
+- **JavaScript (codegen/web)**: dependency-free Node ESM (`.mjs`) / CommonJS (`.cjs`).
+  `asm6502.mjs` must stay **dual-use** (Node CLI **and** browser ES module) — keep the
+  `process`/node guards and the dynamic `node:url` import intact.
+- **The memory map is generated context**: after changing `vm.h`'s `MM_*` map or the ROM
+  symbols, regenerate the platform reference —
+  `node codegen/tools/gen_platform_ref.mjs` — so `codegen/platform/platform-ref.*` stays true.

--- a/.github/extensions/compliance-hooks/README.md
+++ b/.github/extensions/compliance-hooks/README.md
@@ -1,0 +1,51 @@
+# compliance-hooks — governance-as-code
+
+A Copilot CLI **extension** that makes this project's operating rules mechanical
+instead of relying on the agent (or a human) to remember them. It injects the right
+checklist at the right moment and hard-blocks the two most expensive mistakes.
+
+> Pairs with `.githooks/pre-push` (which enforces the same rules at the git layer,
+> for *any* caller). The extension catches things earlier, inside the agent loop;
+> the git hook is the backstop that fires even outside Copilot CLI.
+
+## What it does
+
+| Moment | Hook | Behaviour |
+|--------|------|-----------|
+| Session start | `onSessionStart` | Injects `instructions/onsessionstart.md` (mandatory reading + core rules). |
+| Feature-request prompt | `onUserPromptSubmitted` | "Which layers does this touch?" nudge. |
+| About to `gh pr merge` | `onPreToolUse` | **HARD STOP** — never self-merge (except the `docs/learnings/` markdown auto-merge). |
+| About to `git commit` | `onPreToolUse` | One-line commit checklist. |
+| `create_pull_request` | `onPreToolUse` | Full PR checklist (`instructions/pr-checklist.md`). |
+| About to `git push` | `onPreToolUse` | **Denies** the push if the branch's PR is MERGED/CLOSED; else injects `git-push.md`. |
+| Edited a layer file | `onPostToolUse` | Cross-layer verification (`onposttooluse.md`), once per turn. |
+| After `git fetch/pull/reset` | `onPostToolUse` | Re-read changed instruction files. |
+| `git push` failed | `onPostToolUseFailure` | Hints the merged-branch cause + recovery steps. |
+
+The prompt text lives in `.github/instructions/*.md` — edit those to change wording
+without touching code.
+
+## Install / activate
+
+Copilot CLI auto-discovers `extension.mjs` under `.github/extensions/*/`. No build
+step, no manifest. Reload after editing with the runtime's "reload extensions"
+action (or restart the session).
+
+## Customize for your project
+
+- **`SPEC_PATTERNS`** in `extension.mjs` — the regexes that decide a "layer file" was
+  edited (triggers the cross-layer check). For 3ric they point at the layer dirs
+  `specs/`, `emulator/`, `web/`, `codegen/`, `romgen/`, `22v10/`, and `*.s` sources.
+- **`featureKeywords`** — words that trigger the "which layers?" nudge.
+- **Tool names** — the shell-detection covers `powershell`, `bash`, and `shell`. Trim
+  to your environment if desired.
+- **`ebadger` / `ebadger/3ric`** — already stamped in for this repo; update them only
+  if the owner or repo slug changes.
+
+## Honest scope
+
+This is a **nudge + two hard blocks**, not a sandbox. The hard blocks (self-merge,
+push-to-merged-PR) are real denials; everything else is injected context the agent
+is expected to honor. The git `pre-push` hook is the non-agent backstop. Neither
+prevents a determined override — they prevent the *forgetful* mistake, which is the
+common one.

--- a/.github/extensions/compliance-hooks/extension.mjs
+++ b/.github/extensions/compliance-hooks/extension.mjs
@@ -1,0 +1,250 @@
+import { joinSession } from "@github/copilot-sdk/extension";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+// =====================================================================
+// compliance-hooks — governance-as-code for an AI-run project.
+//
+// This extension injects the right checklist at the right moment and
+// mechanically blocks the two most expensive mistakes (self-merging, and
+// pushing to an already-merged PR branch). It reads its prompts from
+// .github/instructions/*.md so the wording stays editable without code
+// changes. See .github/extensions/compliance-hooks/README.md.
+//
+// CUSTOMIZE: tune SPEC_PATTERNS below to your repo's layer directories.
+// =====================================================================
+
+function getRepoRoot(workingDirectory) {
+    return workingDirectory || process.cwd();
+}
+
+async function loadInstruction(workingDirectory, filename) {
+    const root = getRepoRoot(workingDirectory);
+    const path = join(root, ".github", "instructions", filename);
+    try {
+        return await readFile(path, "utf-8");
+    } catch (err) {
+        console.error(
+            `[compliance-hooks] WARNING: Could not load ${filename}: ${err.message}`
+        );
+        return null;
+    }
+}
+
+// Check the current branch's PR state via gh (null if none / gh unavailable).
+function checkPrState(workingDirectory) {
+    const cwd = getRepoRoot(workingDirectory);
+    try {
+        const result = execSync(
+            'gh pr view --json state,number --jq "{state: .state, number: .number}"',
+            { cwd, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+        );
+        return JSON.parse(result.trim());
+    } catch (err) {
+        // No PR exists for this branch, or gh CLI not available
+        return null;
+    }
+}
+
+// Patterns for detecting spec/layer file edits that warrant a cross-layer check.
+// Tuned to 3ric's layers: the memory map / soft switches / ROM entry points are a shared
+// contract across the VM core, the WASM bridge, the codegen platform-ref, the 6502 ROM, and
+// the 22V10 GAL decode — so an edit to any of them is worth a cross-layer nudge.
+const SPEC_PATTERNS = [
+    /specs\//,
+    /(^|\/)emulator\//i,   // C++ VM core, WozLib, MockMicroSD (EMULATOR.md)
+    /(^|\/)web\//i,        // WASM bridge + browser client (WEB-CLIENT.md)
+    /(^|\/)codegen\//i,    // 65C02 assembler + harness + platform-ref (CODEGEN.md)
+    /(^|\/)romgen\//i,     // ROM/font/video data generators (ROM-SOFTWARE.md)
+    /(^|\/)22v10\//i,      // GAL address-decode logic, mirrors the VM memory map (HARDWARE.md)
+    /\.s$/i,               // 6502 assembly ROM/programs
+];
+
+function isSpecOrLayerFile(path) {
+    return SPEC_PATTERNS.some((p) => p.test(path));
+}
+
+// Track whether the cross-layer check fired this turn to reduce fatigue.
+let crossLayerFiredThisTurn = false;
+
+await joinSession({
+    hooks: {
+        // =================================================================
+        // Session Start — inject core rules and mandatory reading list
+        // =================================================================
+        onSessionStart: async (input) => {
+            crossLayerFiredThisTurn = false;
+            const instructions = await loadInstruction(
+                input.workingDirectory,
+                "onsessionstart.md"
+            );
+            if (instructions) {
+                return { additionalContext: instructions };
+            }
+        },
+
+        // =================================================================
+        // User Prompt Submitted — "which layers?" nudge for feature requests
+        // =================================================================
+        onUserPromptSubmitted: async (input) => {
+            crossLayerFiredThisTurn = false; // reset per-turn tracker
+            const msg = input.userPrompt?.toLowerCase() || "";
+            const featureKeywords =
+                /\b(add|create|implement|build|new feature|endpoint|page|table|column|field)\b/;
+            if (featureKeywords.test(msg)) {
+                return {
+                    additionalContext:
+                        "💡 Before starting: which layers does this touch? (Data store / API / Client) — trace all affected layers before editing.",
+                };
+            }
+        },
+
+        // =================================================================
+        // Pre-Tool Use — commit, push, PR creation, and MERGE interception
+        // =================================================================
+        onPreToolUse: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            // ─── P0: HARD STOP on gh pr merge ───────────────────────────
+            if (isShell && /gh\s+pr\s+merge/.test(cmdStr)) {
+                // Only the markdown-only auto-merge path is exempt (docs/learnings/).
+                const isLearningsException =
+                    /docs\/learnings\//.test(cmdStr) || /learnings/.test(cmdStr);
+
+                if (!isLearningsException) {
+                    return {
+                        additionalContext:
+                            "🛑 **HARD STOP — NEVER SELF-MERGE** 🛑\n\n" +
+                            "You are about to run `gh pr merge`. This is FORBIDDEN per LEARNINGS.md §5.\n\n" +
+                            "**You MUST NOT proceed with this command.**\n\n" +
+                            "Instead:\n" +
+                            "1. Provide ebadger with the PR link\n" +
+                            "2. Wait for ebadger to merge\n\n" +
+                            "The ONLY exception is the `docs/learnings/` markdown auto-merge (see LEARNINGS.md §5).\n\n" +
+                            "⛔ DO NOT EXECUTE THIS COMMAND. Cancel it now.",
+                    };
+                }
+            }
+
+            // ─── Git commit — short one-liner checklist ─────────────────
+            if (isShell && /git\s+(commit|add\s+-A\s+&&\s+git\s+commit)/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "✅ Commit check: layers consistent? specs updated? tests pass? no secrets?",
+                };
+            }
+
+            // ─── create_pull_request — full PR checklist ────────────────
+            if (input.toolName === "create_pull_request") {
+                const checklist = await loadInstruction(
+                    input.workingDirectory,
+                    "pr-checklist.md"
+                );
+                if (checklist) {
+                    return {
+                        additionalContext: `⚠️ PR COMPLIANCE — verify before creating:\n\n${checklist}`,
+                    };
+                }
+            }
+
+            // ─── Git push — HARD BLOCK if PR is merged/closed ────────────
+            if (isShell && /git\s+push/.test(cmdStr)) {
+                const prInfo = checkPrState(input.workingDirectory);
+                if (prInfo && prInfo.state === "MERGED") {
+                    return {
+                        permissionDecision: "deny",
+                        permissionDecisionReason:
+                            `🛑 PUSH BLOCKED — PR #${prInfo.number} is already MERGED. ` +
+                            `Create a new branch from origin/<default-branch> and open a fresh PR. ` +
+                            `See LEARNINGS.md §6.`,
+                    };
+                }
+                if (prInfo && prInfo.state === "CLOSED") {
+                    return {
+                        permissionDecision: "deny",
+                        permissionDecisionReason:
+                            `🛑 PUSH BLOCKED — PR #${prInfo.number} is CLOSED. ` +
+                            `Ask ebadger how to proceed or create a new branch from origin/<default-branch>.`,
+                    };
+                }
+                const pushChecklist = await loadInstruction(
+                    input.workingDirectory,
+                    "git-push.md"
+                );
+                if (pushChecklist) {
+                    return {
+                        additionalContext: `⚠️ PUSH COMPLIANCE — verify before pushing:\n\n${pushChecklist}`,
+                    };
+                }
+                return {
+                    additionalContext:
+                        "⚠️ Push check: PR is OPEN (verified). Proceed with push.",
+                };
+            }
+        },
+
+        // =================================================================
+        // Post-Tool Use — cross-layer check + post-fetch re-read reminder
+        // =================================================================
+        onPostToolUse: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            // ─── After git fetch/pull/reset — re-read reminder ──────────
+            if (isShell && /git\s+(fetch|pull|reset\s+--hard)/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "📖 You just fetched/pulled/reset. Per LEARNINGS.md §5: re-read `docs/LEARNINGS.md`, `docs/MISSION.md`, and `.github/copilot-instructions.md` if they may have changed.",
+                };
+            }
+
+            // ─── Cross-layer check (once per turn to reduce fatigue) ────
+            if (
+                (input.toolName === "edit" || input.toolName === "create") &&
+                typeof input.toolArgs?.path === "string" &&
+                isSpecOrLayerFile(input.toolArgs.path)
+            ) {
+                if (!crossLayerFiredThisTurn) {
+                    crossLayerFiredThisTurn = true;
+                    const instructions = await loadInstruction(
+                        input.workingDirectory,
+                        "onposttooluse.md"
+                    );
+                    if (instructions) {
+                        return {
+                            additionalContext: `⚠️ CROSS-LAYER CHECK: You modified a system layer file.\n\n${instructions}`,
+                        };
+                    }
+                } else {
+                    return {
+                        additionalContext:
+                            "↩️ Cross-layer reminder: verify other layers still consistent.",
+                    };
+                }
+            }
+        },
+
+        // =================================================================
+        // Post-Tool Use Failure — catch failed push (merged branch?)
+        // =================================================================
+        onPostToolUseFailure: async (input) => {
+            const cmd = input.toolArgs?.command;
+            const isShell = input.toolName === "powershell" || input.toolName === "bash" || input.toolName === "shell";
+            const cmdStr = isShell && typeof cmd === "string" ? cmd : "";
+
+            if (isShell && /git\s+push/.test(cmdStr)) {
+                return {
+                    additionalContext:
+                        "⚠️ Push failed! Common cause: the PR branch was already merged.\n\n" +
+                        "Check with: `gh pr view <N> --json state`\n" +
+                        "If MERGED: create a new branch from `origin/<default-branch>`, cherry-pick your commits, and open a fresh PR.\n" +
+                        "Do NOT force-push or retry without investigating.",
+                };
+            }
+        },
+    },
+});

--- a/.github/instructions/commit-checklist.md
+++ b/.github/instructions/commit-checklist.md
@@ -1,0 +1,3 @@
+# Commit Checklist (Quick)
+
+Layers consistent? | Specs updated? | Tests pass? | No secrets? | Cross-layer commit atomic?

--- a/.github/instructions/git-push.md
+++ b/.github/instructions/git-push.md
@@ -1,0 +1,32 @@
+# Git Push — Pre-Push Verification
+
+> **Mechanical enforcement:** a repo-tracked `pre-push` hook (`.githooks/pre-push`)
+> blocks pushes to a branch whose PR is MERGED/CLOSED. Activate it once per clone with
+> `scripts/dev/install-hooks.sh`. The checks below are still your responsibility — the
+> hook is a backstop, not a substitute (it fails open when `gh` is unavailable, and can
+> be bypassed with `SKIP_PR_GUARD=1`).
+
+⚠️ You are about to push commits. Before proceeding, you MUST verify:
+
+## Mandatory Checks
+
+1. **PR state** — Run `gh pr view <N> --json state` for the associated PR.
+   - If **OPEN**: proceed with push.
+   - If **MERGED**: STOP. Do not push. Create a new branch from `origin/main`, cherry-pick your commits, and open a fresh PR.
+   - If **CLOSED**: STOP. Ask ebadger how to proceed.
+   - If **no PR exists yet**: this is a first push — proceed, then create a PR.
+
+2. **Upstream synced** — Run `git fetch origin main` before pushing to confirm you're not behind.
+
+3. **Branch matches PR** — Confirm you're pushing to the same branch the open PR tracks. Do not push to a branch whose PR was already merged.
+
+## Why This Matters
+
+Pushing to a merged branch is a no-op — the commits go nowhere useful. They orphan your work and require manual cleanup (cherry-picks, new PRs, confusion). This is a recurring footgun (see LEARNINGS.md §6).
+
+## If You Already Pushed to a Merged Branch
+
+1. `git fetch origin main`
+2. `git reset --hard origin/main`
+3. `git cherry-pick <your orphaned commit SHAs>`
+4. Push to a new branch and open a fresh PR.

--- a/.github/instructions/merge-block.md
+++ b/.github/instructions/merge-block.md
@@ -1,0 +1,22 @@
+# Merge Block
+
+**You must NEVER run `gh pr merge` except for the `docs/learnings/` markdown auto-merge.**
+
+## Rule (LEARNINGS.md §5)
+
+All PRs require ebadger's approval to merge. Your job is to:
+1. Create the PR
+2. Provide the link to ebadger
+3. Stop and wait
+
+## Only Exception
+
+`docs/learnings/` markdown-only changes may be self-merged per the auto-merge protocol:
+- Branch contains ONLY `.md` files under `docs/learnings/sessions/`, `weekly/`, `monthly/`, or `archive/`
+- No code, spec, config, or other path changes in the same commit
+- PR is created with base: main
+- Merged via `gh pr merge <N> --merge --delete-branch`
+
+(`docs/learnings/README.md` and `docs/LEARNINGS.md` promotions are NOT auto-mergeable.)
+
+If the command you're about to run does NOT match this exception, **cancel it immediately**.

--- a/.github/instructions/onposttooluse.md
+++ b/.github/instructions/onposttooluse.md
@@ -1,0 +1,24 @@
+# Spec Edit — Cross-Layer Verification
+
+You just edited a specification or source file in one of the system layers. Before proceeding, verify cross-layer consistency.
+
+## Layer Checklist
+
+Ask yourself for each (rename these to your project's actual layers):
+
+- [ ] **Data store** (`specs/DATABASE.md`, schema/migrations) — Are schema, columns, constraints, or indexes affected?
+- [ ] **API / Service** (`specs/API.md`, server endpoints) — Are endpoints, request/response shapes, or validation rules affected?
+- [ ] **Client / UI** (`specs/WEB-CLIENT.md`, frontend) — Are pages, components, or interactions affected?
+- [ ] **SYSTEM.md** (`specs/SYSTEM.md`) — Does the umbrella overview need updating?
+
+## Rules
+
+- If a change touches one layer, explicitly verify whether the others need updates before committing.
+- Don't treat spec documents as independent — they are a connected system where changes propagate.
+- Update implementation status in the relevant spec after implementing a feature.
+
+## Common Mistakes
+
+- Adding a data-store column but forgetting to expose it in the API response shape
+- Adding an API endpoint but forgetting to update the client to call it
+- Updating a spec but not updating its implementation-status section

--- a/.github/instructions/onsessionstart.md
+++ b/.github/instructions/onsessionstart.md
@@ -1,0 +1,49 @@
+# Session Start Instructions
+
+You are starting a session on **3ric** — a from-scratch Apple-II-class 65C02 computer built and documented as a learn-by-building project
+
+## Mandatory Reading (start of every session)
+
+- `docs/LEARNINGS.md` — **canonical** workflow rules (§1–6) + the Tier-1 lessons digest
+  (always-loaded, ~2,500-token cap). Read this first; it is the source of truth for the
+  rules summarized below. Full incident narratives live in `docs/learnings/` — on demand.
+- `docs/MISSION.md` — purpose and operating principles.
+- `specs/SYSTEM.md` — umbrella overview of the system + links to every sub-spec.
+- `status/SYSTEM-STATUS.md` — runtime env, credentials, scripts, verification commands.
+
+**Read sub-specs lazily.** Load a sub-spec only for the layer you're about to touch — not
+all of them up front. Deep dives (runbooks, changelog) are read on demand, not at start-up.
+
+## Environment Setup (idempotent — safe every session, do before pushing)
+
+Ensure this repo's git hooks are active. Run with the **same git that performs your pushes**:
+
+```
+git config core.hooksPath .githooks
+```
+
+This activates `.githooks/pre-push`, which mechanically (1) caps `docs/LEARNINGS.md`,
+(2) runs the optional project test gate, and (3) blocks pushes to a branch whose PR is
+already MERGED/CLOSED — the backstop for Core Rules 5 & 6. See `.githooks/README.md`.
+
+## Core Rules — canonical in `docs/LEARNINGS.md` §1–6 (don't re-derive)
+
+1. **Never self-merge.** Open a PR and give ebadger the link. (§5)
+2. **Specs first, code second.** (§3)
+3. **Trace all layers** — Data store → API/Service → Client — for any stored-data feature. (§1–2)
+4. **Commit atomically** across layers/specs. (§4)
+5. **Check PR state before pushing** (`gh pr view <number> --json state`; if MERGED, branch
+   fresh off `origin/main`). (§6, also enforced by the `.githooks/pre-push` hook.)
+6. **After any git pull/reset**, re-read the instruction files that may have changed.
+7. **When in doubt about permissions, ask** rather than assume.
+
+## Data Flow Thinking
+
+When adding or modifying a feature, trace the full path:
+
+```
+User action (UI) → API request → Server logic → Data write
+Data read → API response → UI render
+```
+
+Every link in this chain must be specified.

--- a/.github/instructions/pr-checklist.md
+++ b/.github/instructions/pr-checklist.md
@@ -1,0 +1,12 @@
+# PR Checklist
+
+Before creating a PR, verify:
+
+1. **PR status** — `gh pr view <N> --json state` → must be OPEN (if updating). If MERGED/CLOSED, branch from `origin/main` and open fresh.
+2. **Upstream synced** — `git fetch origin main` done.
+3. **Never self-merge** — Provide ebadger the PR link. Do not merge.
+4. **All layers covered** — Data store / API / Client all updated if affected.
+5. **Spec status marked** — Implementation status updated in the relevant spec.
+6. **Tests pass** — All tests confirmed green.
+7. **Status document** — If your changes affect runtime behavior (new endpoints, credentials, ports, scripts, schema changes, new services), update `status/SYSTEM-STATUS.md`.
+8. **Second-model review (code/config PRs)** — For any PR that can change product or agent behaviour (application code, `specs/**`, schema/migrations, API contracts, client, config, build/deploy, or `.github/agents`·`.github/instructions`·hooks), run **both** independent reviewers on the diff (passing the `model` param explicitly), triage every finding (fix or record why-not), add the **## Second-model review** block to the PR body, and post the reviewers' verbatim output + a per-model `Scorecard` line as a PR comment. Non-product prose / comment-only / typo PRs are exempt. See `docs/CODE-REVIEW-PANEL.md`.

--- a/docs/CODE-REVIEW-PANEL.md
+++ b/docs/CODE-REVIEW-PANEL.md
@@ -1,0 +1,122 @@
+# Code-Review Panel — Multi-Model PR Review (mandatory for code PRs)
+
+> **Why this exists.** Every line of product code is written by one model family (the
+> primary engineering agent). A single model has consistent blind spots. Before a code
+> change ships, two reviewers running on **different model families** challenge it, so a
+> defect the primary can't see has two more chances to get caught. This is cheap
+> insurance on the thing you can't afford to get wrong: your critical path.
+
+## The two reviewers
+
+| Agent | File | Vendor |
+|-------|------|--------|
+| **GPT Reviewer** (`gpt-reviewer`) | `.github/agents/gpt-reviewer.md` | a strong non-primary vendor |
+| **Gemini Reviewer** (`gemini-reviewer`) | `.github/agents/gemini-reviewer.md` | a strong third vendor |
+
+Both are **pinned** to their model via the `model:` frontmatter key and **structurally
+read-only** (`tools: ["read","search"]` — no `edit`, no shell). They return findings; they
+never touch code and never merge.
+
+**Guaranteeing the model pin.** The `model:` frontmatter is the documented way to bind an
+agent to a model, but to stay safe against any invocation path that ignores it, when the
+primary agent invokes a reviewer via the `task` tool it **MUST also pass the `model`
+parameter explicitly**. Belt and suspenders: never let a reviewer silently fall back to
+the primary model — that would destroy the model diversity this whole procedure buys.
+
+## The rule (mandatory)
+
+**Before publishing a PR that contains code, the primary agent MUST:**
+
+1. Finish a complete draft implementation (reviewers need a real diff, not a plan).
+2. Invoke **both** reviewers on the diff, **passing the `model` parameter explicitly**.
+   - The reviewers have **no shell**, so **paste the diff (and point them at the relevant
+     spec + tests)** in the prompt.
+   - Do **not** feed them your own justification — independence is the point.
+3. **Triage every finding.** For each one, either **fix it** or **record a one-line
+   reason** for not fixing (e.g. "false positive — X is validated upstream at Y").
+   - **Reviewers can be wrong too** — verify a claimed bug against ground truth (the spec,
+     the schema, the actual API) and **override with a cited reason** when they're mistaken.
+   - **If your fixes change the diff materially, re-run both reviewers** until they raise
+     no new BLOCK/HIGH findings. The diff you ship must be the diff that was reviewed.
+4. **Record the summary in the PR body** (format below) so the review is visible at a glance.
+5. **Open the PR** for ebadger.
+6. **Post the persistent record as a PR comment.** Post each reviewer's **verbatim** output
+   plus your **per-finding tags** (`gh pr comment <N> --body ...`). This is the durable,
+   GitHub-native record ebadger reads. The reviewers stay read-only — the primary agent
+   posts on their behalf; never give the reviewer agents GitHub write access.
+
+### Scope — what triggers the panel
+
+**Triggers** (panel required): any PR touching application code, **specs** (`specs/**` —
+even though Markdown), schema/migrations, API contracts, the client, config, the
+build/deploy path, or **behaviour-defining config** such as `.github/agents/*.md`,
+`.github/instructions/*.md`, and the compliance hooks. In-scope if it can alter how the
+product or the agents behave — regardless of file extension.
+
+**Exempt** (panel optional): non-product **prose** with no behavioural effect — narrative
+docs, `status/`, `README`, `CHANGELOG`, and comment-only or typo fixes. Don't burn two
+model reviews on a typo. **When in doubt, run the panel.**
+
+### Disagreement protocol
+
+- If a reviewer raises a **BLOCK** you disagree with, write **one** rebuttal in the PR
+  body. If still unresolved, **escalate to ebadger** — do not silently override a BLOCK and
+  do not loop the reviewers indefinitely.
+- If the two reviewers disagree with each other, treat the stricter finding as the default
+  and note the split for ebadger.
+
+### PR body record format
+
+```
+## Second-model review
+- Reviewed diff: `<merge-base-sha>...<HEAD-sha>`
+- GPT Reviewer (<model>): <verdict> — <N> findings
+- Gemini Reviewer (<model>): <verdict> — <N> findings
+- Resolved: <M> fixed, <K> overridden
+  - Overridden: <finding> — <reason>
+```
+
+### Persistent review record + model scorecard (PR comment)
+
+After opening the PR, post the reviewers' **verbatim** output and **tag every finding**:
+
+~~~
+### GPT Reviewer (<model>) — verdict: <verdict>
+1. [HIGH] <finding, verbatim> — accepted · true-positive · fixed (<commit/where>)
+2. [MEDIUM] <finding, verbatim> — overridden · false-positive · <cited reason>
+...
+Scorecard — <model>: findings <N> | true-positive <T> | false-positive <F> | led-to-fix <X>
+~~~
+
+Tag vocabulary per finding: **accepted / overridden** (did you act?), **true-positive /
+false-positive** (was it real?), **led-to-fix y/n** (did it change shipped code?).
+
+Because every PR carries a `Scorecard` line on GitHub, **the evaluation needs no separate
+database** — a periodic review harvests scorecards across merged PRs (`gh pr list` /
+`gh api`) and tallies true-positive vs false-positive and bugs-caught per model. **Don't
+build an eval harness or dashboard yet** — let the scorecards accumulate first.
+
+**Honest caveat — grading bias.** The primary agent scores the very reviewers whose job is
+to challenge it. Guards: every `false-positive`/`overridden` needs a **cited, checkable
+reason**; ebadger spot-checks at merge; and the metric to trust most is the hard-to-game
+one — **material bugs caught that were actually fixed** — not subjective "usefulness."
+
+## Enforcement & honesty about it
+
+Enforced as a **rule + advisory nudge**, not a hard mechanical block:
+`.github/instructions/pr-checklist.md` reminds the agent at PR-creation time (the nudge
+fires on the **`create_pull_request` tool** — create PRs that way, not via `gh pr create`,
+or the reminder is skipped), and ebadger can refuse to merge a code PR with no review
+record. A brittle "Reviewed-by line present?" gate is easy to satisfy with theatre; if the
+panel proves its worth, a hard gate can come later.
+
+## Kill criterion (this must earn its keep)
+
+This is net-new process machinery, which the mission-clock rule tells us to resist. It is
+justified only if it catches real defects. **Review at 30–60 days:** if the panel has not
+caught a material issue the primary missed, **slim or delete it.**
+
+## Changing the models
+
+Edit the `model:` line in each agent file. Use the latest strong reviewer from each
+vendor. Keep the two reviewers on **different vendors** — that diversity is the entire value.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1,0 +1,102 @@
+# 3ric — Learnings (Rules Digest)
+
+> The always-loaded **Tier 1 rules digest**: durable rules + the one-line WHY that makes
+> each correct. Full narratives live in `docs/learnings/`, read on demand.
+>
+> _This is a template seed. Replace the example rules below with your project's real,
+> earned learnings as they accrue. **Keep the "How this file is maintained" section** —
+> it is the mechanism that keeps this file small and high-signal forever._
+
+---
+
+## How this file is maintained
+
+- **Tier 1, always loaded.** This is the compact digest injected into every session
+  preamble. Detailed narratives live in `docs/learnings/`
+  (`sessions/weekly/monthly/archive/`), read **on demand only**.
+- **Hard cap: 2,500 tokens** (≈9,500 chars). A `pre-push` guard enforces it
+  (`scripts/dev/check-learnings-budget.sh`).
+- **Priority-based distillation.** Every new learning is distilled to rule-shape
+  (≤ ~3–5 lines): the rule + a one-line WHY + (if a deep dive matters) an archive link.
+  Adding a learning that would breach the cap is the TRIGGER to first **dedup/merge**
+  existing rules; if still over, **demote** the lowest-value rule's detail to the
+  archive. Never just grow the file.
+- **What earns a slot** (align with `learnings/README.md` Quality Criteria): recurrence
+  (same class of mistake ≥2×), money/data-loss/safety risk, cross-layer/contract
+  breakage, or high time/rework cost. One-off cosmetic or context-specific trivia stays
+  in the archive only.
+- **Promotion requires ebadger's approval.** This file is excluded from the
+  `docs/learnings/` auto-merge (see Workflow Rule §5).
+- **Do not strip the WHY.** Distillation removes the long narrative, never the context
+  that makes a rule correct.
+
+---
+
+## Workflow Rules (numbered — the canonical operating contract)
+
+**§1. Layer checklist.** Before committing a change, verify every layer it could touch
+(e.g. 6502 ROM/software → Emulator VM core (C++) → Web bridge/WASM client, plus the codegen
+platform-ref, the 22V10 GAL decode, and the umbrella spec) for impact. WHY: the memory map
+and soft switches are a shared contract — missing one mirror silently breaks it.
+
+**§2. Think in data flow, not documents.** Specify every link of
+`keypress / soft-switch → CPU Step() → memory/device → framebuffer/serial → host → canvas`.
+
+**§3. Specs before code.** Specs are the source of truth; code follows specs. Update the
+spec in the same change.
+
+**§4. Commit atomically across layers.** A feature spanning multiple specs/layers updates
+them all in one commit so history is consistent at every point.
+
+**§5. Never self-merge.** Always open a PR and give ebadger the link; merging is ebadger's
+call. WHY: instruction files changed mid-session aren't in context until re-read — after
+any `git reset --hard`/branch change re-read `LEARNINGS.md`, `MISSION.md`,
+`copilot-instructions.md`. **Auto-merge exceptions** are narrow, markdown-only paths
+(e.g. `docs/learnings/` per `learnings/README.md`); everything else needs a PR + approval.
+
+**§6. Always check PR state before pushing.** `git fetch origin main` then
+`gh pr view <n> --json state`; if **MERGED**, branch fresh off `origin/main`
+and open a new PR. WHY: pushing to a merged branch orphans the commit. Backed by the
+`.githooks/pre-push` guard (`scripts/dev/install-hooks.sh`); it **fails open** when `gh`
+is unavailable and is overridable with `SKIP_PR_GUARD=1` — a backstop, not a replacement
+for the check.
+
+**Worktree hygiene.** Never `git checkout`/merge `main` from a session
+worktree — branch off `origin/main`. Don't rely on `--delete-branch` in a
+worktree; verify `gh pr view <n> --json state,mergedAt` before retrying, and delete
+branches explicitly (`git branch -D` + `git push origin --delete`).
+
+---
+
+## Seed engineering rules (3ric — keep or prune as real learnings accrue)
+
+- **Native and WASM builds must stay behavior-identical.** Shared VM/WozLib/SD sources may
+  diverge only behind `__EMSCRIPTEN__`/`PLATFORM_WEB` guards; verify a core change in *both*
+  the Windows build and `web/build.ps1` + `web/test_boot.cjs` before "done." WHY: the browser
+  demo is the only build most people ever run.
+- **The memory map is a cross-layer contract.** `vm.h` `MM_*` is mirrored by the 22V10 GAL,
+  the web bridge, and `codegen/platform-ref.*`. Change one → update all in the same commit and
+  regenerate the ref (`gen_platform_ref.mjs`). WHY: a silent map drift makes programs
+  load/decode at the wrong address and fail only at runtime.
+- **Never fake emulation output.** An unimplemented opcode/device/soft-switch must be
+  observable (assert/log/explicit unimplemented), never a plausible-looking fake value. WHY:
+  fabricated results look identical to a working feature and hide the gap.
+- **Prove 6502/CPU changes on the emulator, not by reading code.** Run the relevant
+  `Badger6502VMTest` cases and/or a `run6502.mjs` check with an explicit expected
+  serial/screen/halt before shipping. WHY: instruction/flag bugs are invisible in review and
+  surface only as wrong program behavior.
+- **A documented-but-unbuilt opcode/routine is a tracked gap, not a feature.** Record it in
+  the layer spec's Implementation Status and make the emulator surface it explicitly.
+
+---
+
+## Project-specific clusters (fill these in)
+
+> Add topic-clustered rules here as the project earns them — e.g. `## Emulation accuracy`,
+> `## WASM/native parity`, `## Build & deploy (Pages)`. New learnings merge into the relevant
+> cluster **under the cap**. See `docs/learnings/README.md` for the capture → distill → promote flow.
+
+---
+
+*Topic-clustered and priority-distilled, not chronological — new learnings merge into the
+relevant cluster under the cap (see "How this file is maintained").*

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -1,0 +1,52 @@
+# 3ric — Mission Statement
+
+> This document defines the purpose and direction of the project.
+> All agents and sessions read this to understand the "why" behind the work.
+
+---
+
+## Mission
+
+**3ric is a from-scratch Apple-II-class 65C02 personal computer, built to learn — by
+designing a real 8-bit machine at the chip level (schematics, 22V10 GAL logic, a 512 KB
+ROM, and a cycle-honest emulator) and documenting the journey in a YouTube build series.**
+
+The zero-install browser emulator (<https://ebadger.github.io/3ric/>) exists so the machine
+can be shown, shared, and tinkered with by anyone — no hardware, no install, no account.
+
+> **The one-sentence test:** if a task does not help *understand, build, document, or
+> demonstrate how the 3ric computer works end to end*, question it.
+
+This is a personal project. It optimizes for **learning and a good story**, not for
+shipping features against a deadline — so prefer the change that is correct and easy to
+explain over the one that is merely expedient.
+
+---
+
+## Organization Model
+
+- **ebadger** is the owner, builder, and sole decision-maker — and the one narrating the
+  build series. Sets direction, approves changes, defines priorities.
+- **AI agents** are cooperative team members who execute on the mission. They propose,
+  implement, and advise — but do not make final decisions on direction or merges.
+- **Sessions** are specialized workers: some build the emulator core, some the web/WASM
+  port, some generate and test 6502 programs, some review. Each respects the others'
+  boundaries.
+
+---
+
+## Operating Principles
+
+1. **The mission drives all work.** If a task doesn't serve it, question it.
+2. **Cooperation over autonomy** — agents work *with* ebadger and each other, not
+   independently. We are one team.
+3. **Correctness over speed** — an emulator that lies is worse than one that admits a gap.
+   Get the hardware behavior right; when something isn't implemented, make it obvious.
+4. **Transparency** — surface problems, uncertainties, and trade-offs early. Transparency
+   leads to better decisions.
+5. **Learn continuously** — mistakes are expected; repeating them is not. Codify learning
+   so future sessions benefit (see `docs/learnings/`).
+6. **Keep it explainable** — this project is documented publicly; favor changes you could
+   comfortably explain on camera.
+7. **Your ideas matter** — see an opportunity to improve anything? Speak up
+   (see `docs/SUGGESTIONS.md`).

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,0 +1,88 @@
+# 3ric — Roles: Lenses & Gates
+
+> The main session does the work. The agents below are **lenses** you consult for
+> specialist judgment, not a corporate hierarchy you route paperwork through.
+> **ebadger is the CEO and final authority on everything.** Keep the org machinery small
+> so the mission stays in front of the process.
+
+---
+
+## Lenses (consult for judgment)
+
+Consult a lens when the decision lives squarely in its domain and a wrong call is
+expensive. For routine implementation, just do the work and cite the relevant spec.
+Build these out from `.github/agents/template-lens-agent.md` **as the project needs
+them** — not all at once. A typical roster (rename/cut to fit your domain):
+
+| Lens | Consult for | Don't consult for |
+|------|-------------|-------------------|
+| **Architecture & Engineering** | System architecture, cross-layer consistency, schema & API contracts, security, performance, major refactors, client/UX architecture | Isolated bug fixes, small copy, docs-only edits |
+| **Product & Strategy** | What to build next and why, specs, prioritization, mission alignment, roadmap, business model | Pure technical decisions with no product impact |
+| **Build & Operations** | Build pipeline, deploy, infra, migration execution, service health, observability, prod ops | Feature design, architecture, product calls |
+| **Domain Expert** | The deep domain knowledge your product depends on being correct | Infra, deployment, software architecture |
+| **Process & Learning** | Retrospectives & failure-pattern capture, knowledge curation, org/process design, **CEO coaching for ebadger**. Runs as a **periodic** review, not a per-task gate | Implementation, deployment, feature/architecture decisions |
+
+---
+
+## The code-review panel (mechanical reviewers, not lenses)
+
+Two **model-diverse** reviewers run **by rule** before any code PR is published. Unlike
+the lenses, they are a standing **gate input** on every code change, and exist purely to
+break the primary model's single-model blind spots.
+
+| Reviewer | Vendor | File |
+|----------|--------|------|
+| **GPT Reviewer** | (non-Claude) | `.github/agents/gpt-reviewer.md` |
+| **Gemini Reviewer** | (third vendor) | `.github/agents/gemini-reviewer.md` |
+
+They are **structurally read-only** (`tools: ["read","search"]`) and have no decision
+authority: they return ranked findings + a verdict, the primary agent triages, **ebadger
+merges.** Full procedure: `docs/CODE-REVIEW-PANEL.md`.
+
+---
+
+## The gates (mechanical, non-negotiable)
+
+These are the rules that actually protect the mission. They are enforced by hooks /
+scripts where possible, not by memory.
+
+1. **Never self-merge.** Every change lands as a PR ebadger reviews and merges. The only
+   exceptions are the markdown-only auto-merge paths in `docs/LEARNINGS.md §5`.
+   Enforced by the `compliance-hooks` extension (hard stop on `gh pr merge`).
+2. **Specs before code; trace every layer.** A stored-data change updates every affected
+   layer (and its spec) in one atomic commit.
+3. **Check PR state before pushing**; a merged branch is dead. Backed by
+   `.githooks/pre-push` and the `compliance-hooks` push block.
+4. **Capped Tier-1 memory.** `docs/LEARNINGS.md` stays under its token cap. Enforced by
+   `pre-push` (`check-learnings-budget.sh`).
+5. **Critical-path test gate.** Any change to the cash-/safety-/data-critical path must
+   pass the project's eval/test suite before it ships. Wire it into
+   `scripts/dev/pre-push-tests.sh` (see the `.example`).
+6. **Mission clock > org clock.** Do **not** create net-new org/process artifacts (new
+   agents, protocols, ceremonies, meta-docs) while the product has unmet, higher-priority
+   needs. Fix the product first. Streamlining or **deleting** org machinery is always
+   allowed; **adding** it waits.
+7. **Self-modification needs ebadger.** Any change to agent authority, role boundaries, or
+   this operating model requires ebadger's explicit approval. Agents propose; they never
+   self-approve.
+
+---
+
+## Interaction protocol (condensed)
+
+- **Disagreement →** surface it, summarize the trade-offs, present options (not a hidden
+  decision), and let ebadger decide.
+- **Handoff →** reference the specific commit/PR/issue, state what's expected, and the
+  receiver acknowledges with results.
+- **Bug triage →** GitHub Issues (see `.github/ISSUE_TEMPLATE/`); critical-path issues get
+  a fast lane and a stricter review gate.
+
+---
+
+## A note on right-sizing
+
+This file describes the *full* shape an AI-run project's org can take. **Start smaller.**
+A new project often needs only: the gates above, the two reviewers, and one or two lenses.
+Add lenses when a real, recurring class of expensive decision justifies one — and let the
+**mission-clock gate (#6)** stop you from building org machinery faster than the product
+earns it.

--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -1,0 +1,61 @@
+# 3ric — Suggestions
+
+> A place for agent-generated ideas to improve cooperation, productivity, and quality.
+> ebadger reviews these periodically and promotes good ones into practice (usually into
+> `docs/LEARNINGS.md` or `.github/copilot-instructions.md`).
+>
+> **Why this exists:** an AI workforce notices process friction constantly but has no
+> standing channel to act on it. This is that channel — a low-friction funnel so good
+> ideas accrete instead of evaporating at session end. Keep entries concrete:
+> **Problem → Suggestion → (optional) Owner.**
+
+---
+
+## Format
+
+```markdown
+### N. Short title
+
+**Problem:** What's wrong or missing, concretely.
+
+**Suggestion:** The proposed change. Small and actionable beats grand.
+
+**Owner:** (optional) which lens/agent would carry it.
+```
+
+---
+
+## Seed suggestions (generic — keep, prune, or replace)
+
+### 1. Session handoff protocol
+
+**Problem:** When multiple sessions exist (build, deploy, feature work), they can step on
+each other or miss context.
+
+**Suggestion:** When one session creates work for another, reference the specific
+commit/PR/issue; the receiving session acknowledges and reports back with results.
+
+---
+
+### 2. Periodic retrospective
+
+**Problem:** Learnings accumulate but there's no structured time to review and act on them.
+
+**Suggestion:** A weekly/per-milestone pass where the Process & Learning lens summarizes
+recent `docs/learnings/` entries, evaluates this file's suggestions, and proposes ≤3
+high-leverage changes. ebadger approves or rejects.
+
+---
+
+### 3. Test-before-PR as a hard rule
+
+**Problem:** Changes can be merged without verification when the build/test environment
+isn't wired into the flow.
+
+**Suggestion:** Wire the project's test command into `scripts/dev/pre-push-tests.sh` so the
+`pre-push` hook proves green before any push. If no test environment is available, flag the
+PR clearly: "⚠️ Not test-verified — needs CI or manual test."
+
+---
+
+*Add new suggestions at the bottom. ebadger promotes accepted ones into practice.*

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -1,0 +1,118 @@
+# 3ric — Learning Log System
+
+> Progressive generalization: raw session learnings → weekly patterns → monthly strategy →
+> `LEARNINGS.md` promotions. The mechanism that turns mistakes into durable, *capped* rules.
+
+---
+
+## Directory Structure
+
+```
+docs/learnings/
+├── README.md          ← This file (format spec + lifecycle rules)
+├── sessions/          ← Per-session learning files (daily capture)
+├── weekly/            ← Weekly digest synthesizing patterns across sessions
+├── monthly/           ← Monthly summary for strategic generalization
+└── archive/           ← Retired files + pre-distillation narrative snapshots
+```
+
+---
+
+## Session Learning File Format
+
+**File naming:** `YYYY-MM-DD-session-name-slug.md`
+**Location:** `docs/learnings/sessions/`
+
+```markdown
+# Session Learning — [Session Name]
+
+**Date:** YYYY-MM-DD
+**Session ID:** [short ID or slug]
+**Duration:** ~X hours
+**Agent(s):** [comma-separated roles]
+**Branch(es):** [branch name(s)]
+
+## What Happened
+
+[1-3 sentences: what was the goal and what actually occurred]
+
+## Learnings
+
+### L1: [Learning Title]
+
+**Cost:** [Quantified: "~45 minutes of rework", "opened a fresh PR", "stale binary 30 min"]
+**What happened:** [Concrete description of the failure or surprise]
+**Why it happened:** [Root cause, not just symptoms]
+**Rule:** `[Concrete behavioral imperative — start with an action verb]`
+
+### L2: [Next Learning Title]
+
+...repeat for each learning...
+
+## What Worked Well
+
+- [Thing that saved time or worked better than expected]
+
+## Promotion Candidates
+
+- [ ] L1 ready for `LEARNINGS.md` — [reason]
+- [ ] L2 needs one more occurrence before promotion
+```
+
+---
+
+## Quality Criteria
+
+Only capture learnings that meet **at least one** of these bars:
+
+1. **Time cost:** Would have saved >15 minutes if known in advance
+2. **Rework cost:** Caused a commit, PR, or deploy to be redone
+3. **Risk cost:** Could have broken prod or caused data/money loss
+4. **Repeatability:** Same mistake happened before (even once)
+
+**Skip sessions** where all work was routine with no surprises, errors, or detours.
+
+Every learning MUST have a quantified **Cost** and a concrete **Rule** that starts with an
+action verb.
+
+---
+
+## Lifecycle
+
+1. **Daily capture** — a process/learning agent (or the session itself) writes `sessions/` files.
+2. **Weekly digest** — synthesize patterns across sessions into `weekly/`.
+3. **Monthly summary** — generalize patterns into strategic guidance in `monthly/`.
+4. **Promotion** — high-signal items promoted to `docs/LEARNINGS.md`.
+
+### Promotion budget (priority-based distillation)
+
+`docs/LEARNINGS.md` is the **always-loaded Tier-1 rules digest** — it enters the model's
+context at the start of every session. To stop it from crowding out task context, it has a
+**hard cap of ~2,500 tokens** (a `pre-push` guard, `scripts/dev/check-learnings-budget.sh`,
+enforces it).
+
+Promotion is therefore **competitive, not additive**:
+
+- Distill each promoted item to **rule-shape** (≤ ~3–5 lines): the rule + a one-line WHY +
+  (when a deep dive matters) a link back to the `sessions/` or `archive/` narrative.
+- If a new rule would breach the cap, that is the **trigger to first dedup/merge** existing
+  rules covering the same ground; if still over, **demote** the lowest-value rule's detail
+  back to the archive. Never just grow the file.
+- **What earns a slot:** recurrence (≥2×), money/data-loss/safety risk, cross-layer/contract
+  breakage, or high time/rework cost. One-off or cosmetic trivia stays here only.
+- **Never strip the WHY.** Distillation removes the long narrative, never the context.
+- Promotion edits to `docs/LEARNINGS.md` require **ebadger's approval** (excluded from auto-merge).
+
+---
+
+## Auto-Merge Rules
+
+Learning PRs may be auto-merged **only** when they touch learning markdown alone:
+
+- ✅ Only `.md` files under `docs/learnings/sessions/`, `weekly/`, `monthly/`, or `archive/`
+- ✅ No code, spec, config, or other path changes in the same commit
+- ❌ Mixed commits → create a normal PR, do NOT auto-merge
+- ❌ `docs/learnings/README.md` changes → normal PR only
+- ❌ `docs/LEARNINGS.md` promotions → normal PR only (require ebadger's approval)
+
+This scope matches `docs/LEARNINGS.md` Workflow Rule §5.

--- a/docs/learnings/archive/README.md
+++ b/docs/learnings/archive/README.md
@@ -1,0 +1,3 @@
+# Retired learning files + pre-distillation narrative snapshots — see ../README.md.
+# When a rule is demoted from docs/LEARNINGS.md to stay under the cap, its full
+# narrative lands here.

--- a/docs/learnings/monthly/README.md
+++ b/docs/learnings/monthly/README.md
@@ -1,0 +1,1 @@
+# Monthly strategic summaries generalizing weekly patterns — see ../README.md.

--- a/docs/learnings/sessions/README.md
+++ b/docs/learnings/sessions/README.md
@@ -1,0 +1,2 @@
+# Per-session learning files live here — see ../README.md for the format.
+# Naming: YYYY-MM-DD-session-name-slug.md

--- a/docs/learnings/weekly/README.md
+++ b/docs/learnings/weekly/README.md
@@ -1,0 +1,1 @@
+# Weekly digests synthesizing patterns across sessions — see ../README.md.

--- a/scripts/dev/check-learnings-budget.sh
+++ b/scripts/dev/check-learnings-budget.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# check-learnings-budget.sh -- Enforce the docs/LEARNINGS.md size cap.
+#
+# Why: docs/LEARNINGS.md is mandatory reading at the start of EVERY session, so it
+# is loaded into the model's context every single time. If it grows without bound
+# it crowds out task context and buries the durable rules among one-off incident
+# detail. It is therefore a *capped Tier-1 rules digest*; detailed narratives live
+# in docs/learnings/ (read on demand). See LEARNINGS.md "How this file is maintained".
+#
+# Cap: 2,500 tokens. Counts REAL tokens with tiktoken when available
+# (python3 + `pip install tiktoken`); otherwise falls back to a character proxy.
+#
+# Usage: check-learnings-budget.sh [path-to-markdown]   # defaults to docs/LEARNINGS.md
+#
+# Exit: 0 = within budget (or unenforceable -> fail-open with a note);
+#       1 = over budget (blocks the push).
+# Escape hatch (rare, deliberate): SKIP_LEARNINGS_BUDGET=1
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+FILE="${1:-$REPO_ROOT/docs/LEARNINGS.md}"
+
+TOKEN_CAP=2500
+CHAR_CAP=9800   # ~2,500 tokens at the measured ~3.8 chars/token (loose dependency-free backstop)
+
+# Print remediation guidance for "$1" (a measurement string) and block the push.
+block() {
+  echo "" >&2
+  echo "x LEARNINGS budget BLOCKED: $1" >&2
+  echo "  LEARNINGS.md is the always-loaded Tier-1 rules digest, not an append-only log." >&2
+  echo "  Get back under the cap via priority-based distillation:" >&2
+  echo "    1. Move the full incident narrative to docs/learnings/ (sessions/ or archive/)." >&2
+  echo "    2. Leave only a distilled rule + one-line WHY (+ archive link) in LEARNINGS.md." >&2
+  echo "    3. Dedup/merge overlapping rules; demote the lowest-value detail to the archive." >&2
+  echo "  Override (only if you are certain): SKIP_LEARNINGS_BUDGET=1 git push ..." >&2
+  echo "" >&2
+  exit 1
+}
+
+if [ "${SKIP_LEARNINGS_BUDGET:-}" = "1" ]; then
+  echo "check-learnings-budget: SKIP_LEARNINGS_BUDGET=1 -- skipping." >&2
+  exit 0
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "check-learnings-budget: $FILE not found -- skipping (fail-open)." >&2
+  exit 0
+fi
+
+# Prefer an exact token count via tiktoken.
+PY=""
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+fi
+
+if [ -n "$PY" ]; then
+  tokens=$("$PY" - "$FILE" <<'PYEOF' 2>/dev/null || true
+import sys
+try:
+    import tiktoken
+except Exception:
+    sys.exit(3)
+data = open(sys.argv[1], encoding="utf-8").read()
+print(len(tiktoken.get_encoding("cl100k_base").encode(data)))
+PYEOF
+)
+  tokens=$(printf '%s' "${tokens:-}" | tr -cd '0-9')
+  if [ -n "$tokens" ]; then
+    if [ "$tokens" -gt "$TOKEN_CAP" ]; then
+      block "docs/LEARNINGS.md is $tokens tokens (cap $TOKEN_CAP)."
+    fi
+    echo "check-learnings-budget: OK ($tokens / $TOKEN_CAP tokens)." >&2
+    exit 0
+  fi
+  echo "check-learnings-budget: tiktoken unavailable -- using char proxy ('pip install tiktoken' for exact token enforcement)." >&2
+fi
+
+# Fallback: dependency-free character proxy.
+chars=$(wc -m < "$FILE" 2>/dev/null | tr -cd '0-9')
+[ -n "$chars" ] || chars=$(wc -c < "$FILE" | tr -cd '0-9')
+if [ "$chars" -gt "$CHAR_CAP" ]; then
+  block "docs/LEARNINGS.md is $chars chars (proxy cap $CHAR_CAP ~ $TOKEN_CAP tokens)."
+fi
+echo "check-learnings-budget: OK ($chars chars; proxy cap $CHAR_CAP ~ $TOKEN_CAP tokens)." >&2
+exit 0

--- a/scripts/dev/install-hooks.sh
+++ b/scripts/dev/install-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# install-hooks.sh — Activate this repo's git hooks on the local machine.
+#
+# Git hooks are not installed by `git clone` and cannot be auto-activated by a
+# committed file alone. This points git at the repo-tracked .githooks/ directory
+# by setting core.hooksPath, so the hooks in version control actually run.
+# Re-run after a fresh clone. Idempotent.
+#
+# Works for worktrees too: core.hooksPath is set as a relative path, so each
+# worktree resolves it against its own checked-out .githooks/ copy.
+#
+# On Windows, run the equivalent from the repo root in any shell:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+HOOKS_DIR=".githooks"
+[ -d "$HOOKS_DIR" ] || { echo "ERROR: $REPO_ROOT/$HOOKS_DIR not found." >&2; exit 1; }
+
+# Ensure hooks are executable (matters on Linux/macOS; harmless on Windows).
+chmod +x "$HOOKS_DIR"/* 2>/dev/null || true
+
+git config core.hooksPath "$HOOKS_DIR"
+
+echo "Installed git hooks: core.hooksPath -> $HOOKS_DIR"
+echo "Active hooks:"
+for h in "$HOOKS_DIR"/*; do
+  [ -f "$h" ] || continue
+  case "$(basename "$h")" in
+    *.md|*.sample) continue ;;
+  esac
+  echo "  - $(basename "$h")"
+done
+echo "Done. The pre-push guards (PR-state + LEARNINGS cap + optional tests) are now active."

--- a/scripts/dev/pre-push-tests.sh
+++ b/scripts/dev/pre-push-tests.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# pre-push-tests.sh -- 3ric project test gate (runs on every push via .githooks/pre-push).
+#
+# Fast, cross-platform checks that need no WASM build: the 65C02 assembler encoding tests.
+# If a WASM build is already present (web/badger6502.js), also run the emulator boot smoke
+# test. The heavier web/test_*.cjs and codegen program tests need a full `web/build.ps1`
+# build and Emscripten, so they run manually / in CI, not here. The C++ Badger6502VMTest
+# suite runs in Visual Studio. This gate fails OPEN when no Node runtime is found.
+#
+# Escape hatch (routine skip): SKIP_TEST_GUARD=1 git push ...
+set -eu
+
+if [ "${SKIP_TEST_GUARD:-}" = "1" ]; then
+  echo "pre-push-tests: SKIP_TEST_GUARD=1 -- skipping tests." >&2
+  exit 0
+fi
+
+# Find a Node runtime. On the primary dev machine Node lives inside emsdk, not on PATH.
+NODE=""
+if command -v node >/dev/null 2>&1; then
+  NODE=node
+else
+  for _n in "$HOME"/emsdk/node/*/bin/node "$HOME"/emsdk/node/*/bin/node.exe; do
+    if [ -x "$_n" ]; then NODE="$_n"; break; fi
+  done
+fi
+
+if [ -z "$NODE" ]; then
+  echo "pre-push-tests: no Node runtime found -- skipping (fail-open)." >&2
+  exit 0
+fi
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+echo "pre-push-tests: running 65C02 assembler encoding tests..." >&2
+"$NODE" "$REPO_ROOT/codegen/tools/asm6502.test.mjs" || exit 1
+
+# Only runnable once the WASM emulator has been built at least once.
+if [ -f "$REPO_ROOT/web/badger6502.js" ]; then
+  echo "pre-push-tests: WASM build present -- running emulator boot smoke test..." >&2
+  "$NODE" "$REPO_ROOT/web/test_boot.cjs" || exit 1
+fi
+
+echo "pre-push-tests: OK." >&2
+exit 0

--- a/scripts/dev/pre-push-tests.sh.example
+++ b/scripts/dev/pre-push-tests.sh.example
@@ -1,0 +1,53 @@
+#!/bin/sh
+# pre-push-tests.sh.example -- Optional project test gate for .githooks/pre-push.
+#
+# HOW TO USE: copy this file to scripts/dev/pre-push-tests.sh, make it executable
+# (chmod +x), and fill in your project's test command. The pre-push hook runs it
+# automatically on every push and BLOCKS the push if it exits non-zero.
+#
+# Why a separate, pluggable script (instead of hardcoding a test command in the
+# hook): the *mechanism* "run the right tests before every push" is universal, but
+# the command is per-stack (dotnet test / npm test / pytest / go test / cargo test).
+# Keep the hook generic; put the stack-specific command here.
+#
+# The hook exports REFS_FILE -- a path to the file of pushed refs, one line each:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# Use it to scope tests to what actually changed (e.g. only run the heavy suite when
+# files under a critical path changed). Ignore it to always run.
+set -eu
+
+# --- Example A: always run the project's test command -----------------------
+# Replace this with your stack's command. Honor SKIP_TEST_GUARD for routine skips.
+if [ "${SKIP_TEST_GUARD:-}" = "1" ]; then
+  echo "pre-push-tests: SKIP_TEST_GUARD=1 -- skipping tests." >&2
+  exit 0
+fi
+
+# Pick ONE and delete the rest:
+#   dotnet test --configuration Debug -v minimal
+#   npm test --silent
+#   pytest -q
+#   go test ./...
+#   cargo test --quiet
+echo "pre-push-tests: (example) no test command configured -- edit scripts/dev/pre-push-tests.sh." >&2
+
+# --- Example B: a NON-bypassable gate for a critical path -------------------
+# For a cash-/safety-/data-critical surface, add a second gate with NO skip switch
+# that only runs when that path changed. Compute the changed-file set from REFS_FILE
+# and run an executable eval/golden-scenario suite. Example skeleton:
+#
+#   if [ -n "${REFS_FILE:-}" ] && [ -f "$REFS_FILE" ]; then
+#     while read -r _l _lsha _r _rsha; do
+#       case "$_rsha" in 0000000000000000000000000000000000000000)
+#         _base=$(git merge-base "$_lsha" origin/main 2>/dev/null || true)
+#         _range="${_base:+$_base..}${_lsha}" ;;
+#       *) _range="${_rsha}..${_lsha}" ;;
+#       esac
+#       if git diff --name-only "$_range" 2>/dev/null | grep -Eq '^src/critical/'; then
+#         echo "pre-push-tests: critical path changed -- running eval suite (NO skip)..." >&2
+#         <your eval command> || exit 1
+#       fi
+#     done < "$REFS_FILE"
+#   fi
+
+exit 0

--- a/specs/CODEGEN.md
+++ b/specs/CODEGEN.md
@@ -1,0 +1,69 @@
+# 3ric — Codegen Tooling Spec (CODEGEN.md)
+
+> The Node.js toolchain that assembles 65C02 programs for 3ric, validates them headlessly on
+> the WASM emulator, and emits a card-ready `.PRG`. The design of record lives in
+> [`codegen/SPEC.md`](../codegen/SPEC.md); this sub-spec is the layer summary + its
+> cross-layer contracts. Read `codegen/SPEC.md` before changing the toolchain.
+
+---
+
+## Purpose
+
+Give a program author (human or AI) a fast, deterministic loop: write 65C02 source →
+assemble → run on the same emulator the browser uses → assert on serial / text screen /
+graphics / registers → produce a `.PRG` that also `BRUN`s on real hardware.
+
+## Contracts / Interfaces
+
+**Tools (`codegen/tools/`):**
+
+| Tool | Role |
+|------|------|
+| `asm6502.mjs` | Dependency-free two-pass 65C02 assembler (`assemble()` + CLI). **Dual-use:** the exact same file is a Node CLI *and* a browser ES module (the web assembler imports it) — the CLI tail is guarded by a `process`/node check and its `node:url` import is dynamic. |
+| `asm6502.test.mjs` | Assembler encoding tests (`node asm6502.test.mjs`) — the fast, no-build gate wired into `pre-push`. |
+| `harness.cjs` | Boots the WASM emulator, loads a program, runs it, captures serial/text/registers, detects halt. |
+| `run6502.mjs` | CLI: assemble/load → run → apply checks → emit `.PRG` + verdict (exit 0 only if it halted cleanly and every check passed). |
+| `gen_platform_ref.mjs` | Regenerates `platform/platform-ref.{md,json}` from `vm.h` + `badger6502.dbg`. |
+
+**Platform reference (`codegen/platform/`)** — the generator's machine/human contract:
+`prompt-system.md` (assembler dialect, entry/exit conventions), `platform-ref.md` +
+`platform-ref.json` (memory map, soft switches, zero page, ROM entry points). These are
+**generated** from the VM — regenerate after any `vm.h` `MM_*` or ROM-symbol change.
+
+**Assembler dialect:** `$hex` / `%bin` / decimal / char literals; labels; directives
+`.org`/`*=`, `.byte`, `.word`, `.res`, `.asciiz`; full 65C02 ISA + addressing modes;
+zero-page forcing; branch resolution. A source's own origin directive is authoritative.
+
+**Validation channels** (a program declares which it uses): serial (`drainOutput()`), text
+screen (decode `$0400`, 40×24 interleaved), graphics (`renderFrame()` RGBA), CPU/memory
+(final `regA/X/Y`, `status`, `peek`). Halt detection: BRK-to-monitor, WAI, idle loop, timeout.
+
+## Behaviour / Rules
+
+- The harness runs the **same `badger6502.js/.wasm`** the browser uses — build it first
+  (`pwsh web/build.ps1`). Keep the toolchain **dependency-free** (no npm packages).
+- `asm6502.mjs` must stay browser-safe: no static `node:*` imports at module top level, no
+  reliance on `process` outside the guarded CLI tail — breaking this breaks the in-browser
+  assembler (`WEB-CLIENT.md`).
+- `platform-ref.*` is generated, not hand-edited; edit `vm.h`/symbols then regenerate.
+
+## Data flow
+
+`.s source → asm6502.assemble() → bytes + symbols → harness loads into RAM at --org → run →
+capture serial/text/gfx/regs → checks PASS/FAIL → optional .PRG (+ manifest)`.
+
+## Dependencies
+
+- **Upstream:** the WASM build (`WEB-CLIENT.md`) and the VM memory map/ROM symbols
+  (`EMULATOR.md`, `ROM-SOFTWARE.md`).
+- **Downstream:** the `.PRG` programs (`ROM-SOFTWARE.md`) and the browser assembler, which
+  stages `asm6502.mjs` + sample `.s` sources.
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `asm6502` assembler + encoding tests | Shipped | dual-use; `asm6502.test.mjs`. |
+| `harness` + `run6502` validation loop | Shipped | serial/text/gfx/register checks + `.PRG`. |
+| `gen_platform_ref` platform reference | Shipped | from `vm.h` + `badger6502.dbg`. |
+| Sample programs | Shipped | `codegen/programs/hello.s`; games under `emulator/AICodeGen/`. |

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -1,0 +1,85 @@
+# 3ric — Emulator Core Spec (EMULATOR.md)
+
+> The 65C02 virtual machine at the heart of 3ric, in C++. The same sources power the Windows
+> hosts (`Console`, WinUI) and — behind `__EMSCRIPTEN__`/`PLATFORM_WEB` guards — the browser
+> build (see `WEB-CLIENT.md`). Source of truth for the machine's behavior; update it in the
+> same commit as the code.
+
+---
+
+## Purpose
+
+Faithfully emulate the 3ric machine: a WDC 65C02 CPU, 36 KB RAM, Microsoft BASIC + a 512 KB
+ROM (monitor/DOS), Apple-II-style text/lo-res/hi-res video, keyboard, a 6551 ACIA serial
+port, a 6522 VIA (I/O + bit-banged SPI micro-SD), and a Disk II 5.25″ floppy. It is the
+**reference implementation of the target hardware** — the emulator is correct when it
+behaves like the real machine will.
+
+## Contracts / Interfaces
+
+**Projects (`emulator/Badger6502VM.sln`):**
+
+| Project | Role |
+|---------|------|
+| `Badger6502VMLib` | The VM core: `vm`, `cpu`, `Instructions`, `acia`, `via`, `PS2Keyboard`, `badgervmpal` (video). Windows-only: `symbols`, `Disassemble`. |
+| `WozLib` | Disk II emulation: `DriveEmulator`, `WozDisk`, `WozFile` (`.woz` images). |
+| `MockMicroSD` | Bit-banged SPI SD card (`SDCard`) over a memory-mapped image (`MappedFile`). |
+| `Badger6502VMTest` | MSTest (native C++) CPU unit tests — one file per instruction family. |
+| `Console`, `Badger6502Emulator`(+Package) | Win32 console and WinUI hosts. |
+| `WozFileTestApp`, `dsk2woz2`, `picodisk` | WOZ tooling / disk conversion / Pico target. |
+
+**Memory map — the cross-layer contract** (`vm.h`, `MM_*`; mirrored by the 22V10 GAL, the
+web bridge, and `codegen/platform-ref.*`):
+
+```
+$0000–$8FFF  RAM (36 KB)          $2000–$5FFF  hi-res video pages
+$9000–$BFFF  Microsoft BASIC ROM  $C000        keyboard data / $C010 strobe clear
+$C050–$C057  display soft switches (GRAPHICS/TEXT/…/LORES/HIRES)
+$C080–$C08F  language-card bank switches
+$C100–$C10F  ACIA (6551 serial)   $C200–$C20F  VIA1 (SPI micro-SD)
+$C300–$C30F  ROM disk / char-gen  $C400 audio  $C600–$C6FF Disk II boot PROM
+$C0E0–$C0EF  Disk II data/control $C800–$CFFF  RAM2
+$D000–$FFFF  ROM (monitor / OS / DOS shell); reset vector at $FFFC/$FFFD
+```
+
+Soft switches are dispatched by `VM::DoSoftSwitches(address, write)`; memory-access
+callbacks (`CallbackWriteMemory`, `CallbackSetSoftSwitches`) let hosts hook I/O (the web
+bridge uses this to clock the SD card and advance the drive).
+
+## Behaviour / Rules
+
+- CPU is driven **cooperatively**: hosts call `Step()` per instruction and tick the
+  VIAs/keyboard/drive by the returned cycle count. The blocking `VM::Run()` is not used by
+  the web build.
+- `reset()` loads PC from `$FFFC/$FFFD`. ROM load recipe (mirrored by every host): write the
+  first `0x10000` bytes of `badger6502.bin` into `GetData()`, `seedBasicRom()` (copy
+  `$9000..$BFFF`), `loadFont()`, then `reset()`.
+- **Portability rule:** the shared VM/WozLib/SD sources must compile and behave identically
+  on Windows and Emscripten. Platform-specific code lives behind `__EMSCRIPTEN__` /
+  `PLATFORM_WEB` (or MSVC) guards only — never a silent behavioral fork.
+- **No fabricated emulation.** An unimplemented opcode/device/soft-switch must be observable
+  (assert/log/explicit unimplemented), never a plausible-looking fake value.
+- This clone's `$E000` BASIC is **generic Microsoft BASIC, not Applesoft** — a deliberate,
+  known limitation (see `ROM-SOFTWARE.md`).
+
+## Data flow
+
+`6502 ROM/program → CPU Step() → memory/soft-switch access → device (video/ACIA/VIA/SD/Disk
+II) → framebuffer + serial + register state → host (native window or web bridge → canvas)`.
+
+## Dependencies
+
+- **Upstream:** the 512 KB ROM + `fontrom.dat` (`ROM-SOFTWARE.md`); WOZ/SD images.
+- **Downstream:** the web bridge/client (`WEB-CLIENT.md`), the codegen harness
+  (`CODEGEN.md`), and the hardware, which must match this behavior (`HARDWARE.md`).
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| 65C02 CPU + full ISA/addressing | Shipped | Covered by `Badger6502VMTest` (MSTest). |
+| Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract. |
+| Text / lo-res / hi-res video | Shipped | `badgervmpal`; color/fringe logic shared with hosts. |
+| Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |
+| VIA1 + bit-banged SPI micro-SD | Shipped | `via` + `MockMicroSD`. |
+| Disk II 5.25″ floppy (WozLib) | Shipped | `$C600` boot PROM + `$C0E0–$C0EF`. |

--- a/specs/HARDWARE.md
+++ b/specs/HARDWARE.md
@@ -1,0 +1,64 @@
+# 3ric — Hardware Spec (HARDWARE.md)
+
+> The physical machine 3ric is: KiCad schematics + PCB, the 22V10 GAL programmable logic
+> that does address decoding and color generation, and digital-logic models. The emulator
+> (`EMULATOR.md`) is the executable reference for this hardware; the two must agree —
+> especially on the memory map. Much of this layer is in progress and documented in the
+> YouTube build series.
+
+---
+
+## Purpose
+
+Define the real 3ric computer at the board and chip level: CPU, RAM/ROM, the video circuit,
+I/O (VIA/ACIA), the Disk II and micro-SD interfaces, and the glue logic that decodes the
+address bus. The goal is a buildable Apple-II-class 65C02 machine whose behavior matches the
+emulator.
+
+## Contracts / Interfaces
+
+| Artifact | Path | Role |
+|----------|------|------|
+| KiCad project | `kicad/3ric/`, `kicad/libraries/` | Schematics + PCB layout + symbol/footprint libraries. |
+| Schematic PDF | `schematic_pdf/3ric.pdf`, `diylayout/3RIC.pdf` | Human-readable schematic snapshots. |
+| DIY layout | `diylayout/3RIC.diy` | DIYLC board-layout artwork. |
+| 22V10 GAL logic | `22v10/3ricDecoder.PLD`, `22v10/EB6502 DECODER.PLD`, `22v10/A2COLOR.PLD`, `22v10/3ricDecoder.si` | Address decode + Apple-II color; the **decoder mirrors the `MM_*` memory map**. |
+| Logisim models | `logisim/address_decode.circ`, `logisim/apple2color.circ` | Digital-logic simulations of the decode + color circuits. |
+| Memory-map check | `test/memory_map_test/memory_map_test.sln` | Validates address-map decoding. |
+
+**The load-bearing contract:** the 22V10 address decoder (`3ricDecoder.PLD` /
+`EB6502 DECODER.PLD`) and the color GAL (`A2COLOR.PLD`) must decode exactly the regions in
+the emulator's `MM_*` map (`emulator/Badger6502VMLib/vm.h`) — RAM, BASIC ROM, the `$C0xx`
+device/soft-switch page (keyboard, ACIA `$C1xx`, VIA1 `$C2xx`, ROM disk `$C3xx`, audio
+`$C4xx`, Disk II PROM `$C6xx`), RAM2, and ROM `$D000–$FFFF`.
+
+## Behaviour / Rules
+
+- **Hardware and emulator are one contract.** A change to address decoding, soft switches,
+  or the device map on either side is a cross-layer event: update the GAL/schematic *and*
+  the emulator `MM_*` map *and* regenerate `codegen/platform/platform-ref.*` — ideally in
+  one commit, or with an explicit tracked gap if the physical build lags.
+- Prefer changes you can explain on camera and that keep the emulator as the faithful
+  reference (see `docs/MISSION.md`).
+
+## Data flow
+
+`CPU address/data bus → 22V10 decoder → chip selects (RAM / ROM / BASIC / $C0xx devices) →
+device responds; video circuit + A2COLOR GAL → composite/color output`. The emulator models
+this same routing in `VM::DoSoftSwitches` and the device handlers.
+
+## Dependencies
+
+- **Upstream:** the target machine definition — i.e. the emulator's memory map and device
+  behavior (`EMULATOR.md`), and the ROM that must run on it (`ROM-SOFTWARE.md`).
+- **Downstream:** none in software; the physical board is the end artifact.
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Schematics (KiCad) | In progress | `kicad/3ric/`; snapshots in `schematic_pdf/`, `diylayout/`. |
+| 22V10 address-decode GAL | In progress | `3ricDecoder.PLD` / `EB6502 DECODER.PLD`; mirrors `MM_*`. |
+| Apple-II color GAL | In progress | `A2COLOR.PLD` + `logisim/apple2color.circ`. |
+| Address-map validation | Present | `test/memory_map_test`. |
+| PCB fabrication / bring-up | Tracked in build series | Emulator is the reference until hardware is verified. |

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,32 @@
+# Specs (`specs/`)
+
+**Specs are the source of truth. Code follows specs, not the other way around.**
+
+This is the single most load-bearing convention in the whole operating model: every
+stored-data feature is specified across *all* the layers it touches **before** it is built,
+and the spec is updated **in the same commit** as the code. That is what keeps an AI
+workforce — which has no persistent memory between sessions — from drifting.
+
+## How specs are organized
+
+- `SYSTEM.md` — the **umbrella**: a short overview of the whole system that links to every
+  sub-spec. Start here; read sub-specs lazily.
+- One sub-spec **per layer** (copy `_TEMPLATE.md`). A typical set:
+  - `DATABASE.md` — data store: schema, constraints, indexes, migrations.
+  - `API.md` — endpoints, request/response contracts, validation, auth.
+  - `WEB-CLIENT.md` — client/UI: pages, components, interactions, caching.
+  - (add more layers as your architecture requires)
+
+## The rules (canonical in `docs/LEARNINGS.md` §1–4)
+
+1. **Layer checklist.** Before committing, verify every layer the change could touch.
+2. **Data flow, not documents.** Specify every link:
+   `User action → request → server logic → write → read → response → render`.
+3. **Specs before code.** Update the spec first; code implements the spec.
+4. **Commit atomically.** A feature spanning multiple specs/layers updates them all in one
+   commit, so history is consistent at every point.
+
+After implementing, update the **Implementation Status** section of the relevant sub-spec.
+
+> The `compliance-hooks` extension nudges a cross-layer check whenever you edit a file that
+> looks like a layer/spec file (see `.github/extensions/compliance-hooks/`).

--- a/specs/ROM-SOFTWARE.md
+++ b/specs/ROM-SOFTWARE.md
@@ -1,0 +1,64 @@
+# 3ric — ROM & Software Spec (ROM-SOFTWARE.md)
+
+> The 512 KB system ROM (monitor, DOS shell, BASIC), the character/font ROM, and the 6502
+> programs that run on 3ric. This is the software the CPU actually executes; the emulator
+> (`EMULATOR.md`) and hardware (`HARDWARE.md`) exist to run it.
+
+---
+
+## Purpose
+
+Provide the machine's firmware and application software: power-on monitor, a FAT32 DOS
+shell, Microsoft BASIC, and a growing library of 65C02 programs (games, demos) that load
+from a micro-SD card, a Disk II floppy, or the in-browser assembler.
+
+## Contracts / Interfaces
+
+- **System ROM:** `emulator/Data/badger6502.bin` (512 KB; first 64 KB mapped `$D000–$FFFF`
+  plus banked regions). Contains the monitor, the DOS/FAT32 shell, the Disk II boot PROM
+  (`$C600`), and Microsoft BASIC (`$9000–$BFFF`). Reset vector at `$FFFC/$FFFD`. Built with
+  cc65/ca65; debug symbols in `badger6502.dbg` (consumed by `codegen/gen_platform_ref.mjs`).
+- **Font ROM:** `emulator/Data/fontrom.dat`, loaded by the text renderer.
+- **ROM entry points (contract for programs; curated in `codegen/platform/platform-ref.*`):**
+  `COUT $FDED`, `COUT1 $FDF0`, `CROUT $FD8E`, `PRBYTE $FDDA`, `HOME $FC58`, `KEYIN $FD1B`;
+  DOS shell `dos $EC5C` (mount + `>` prompt), verbs `BSAVE/BLOAD/BRUN/DIR/CAT/CD`, FAT32
+  `fat32_file_read/write`.
+- **`.PRG` programs:** assembled by the codegen toolchain (`CODEGEN.md`). Sources: tracked
+  `.s` files (`codegen/programs/hello.s`, `emulator/AICodeGen/<name>/<name>.s`); assembled
+  `.prg` images are git-ignored (regenerated). Run on hardware/SD via `BRUN NAME.PRG <org>`,
+  or in the browser via **Load .PRG** / **Assemble & Run**.
+- **Disk & card images:** demo `.woz` (staged from `emulator/WozFileTestApp/testdata/`);
+  `emulator/Data/sd.zip` → `web/data/sd.sparse` FAT32 image (`WEB-CLIENT.md`).
+
+## Behaviour / Rules
+
+- **Known limitation — no Applesoft.** The `$E000` BASIC is generic Microsoft BASIC (prompts
+  `MEMORY SIZE?`). Disks whose boot auto-runs an Applesoft greeting (DOS 3.3 / Quick-DOS
+  System Masters and games chaining through them) load DOS but then trap. Self-booting
+  machine-code disks run fine. Treat this as a documented gap, not a bug to paper over.
+- **The ROM defines the memory-map contract in practice.** ROM routines assume the `MM_*`
+  layout in `vm.h`; a memory-map change means rebuilding/re-verifying the ROM and
+  regenerating `platform-ref.*`.
+- 6502 sources target the `asm6502.mjs` dialect and conventions in
+  `codegen/platform/prompt-system.md`.
+
+## Data flow
+
+`badger6502.bin → mapped $D000–$FFFF + banks; reset → monitor → (Disk II C600G | DOS EC5CG |
+BRUN) → user program runs → COUT/screen/serial output`.
+
+## Dependencies
+
+- **Upstream:** the assembler/build (cc65/ca65 for the ROM; `CODEGEN.md` for programs).
+- **Downstream:** the emulator loads and executes it (`EMULATOR.md`); the platform reference
+  is derived from its symbols (`CODEGEN.md`).
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| System ROM (monitor / DOS shell / FAT32) | Shipped | `badger6502.bin`; boots to monitor. |
+| Microsoft BASIC | Shipped | `$9000–$BFFF`; not Applesoft (known gap). |
+| Font ROM | Shipped | `fontrom.dat`. |
+| Disk II boot PROM | Shipped | `$C600`; boots self-booting WOZ images. |
+| 6502 program library | Ongoing | `codegen/programs/`, `emulator/AICodeGen/` (games/demos). |

--- a/specs/SYSTEM.md
+++ b/specs/SYSTEM.md
@@ -1,0 +1,84 @@
+# 3ric — System Overview (SYSTEM.md)
+
+> The umbrella spec. Keep this short — it is read at the start of every session. It
+> describes the whole machine at a glance and **links to every sub-spec**; the detail lives
+> in the sub-specs, read lazily.
+
+---
+
+## What this system is
+
+3ric is a from-scratch **Apple-II-class 65C02 personal computer**: real hardware (KiCad
+schematics, a custom PCB, and 22V10 GAL address-decode logic) plus a cycle-honest **C++
+emulator** of the same machine. The emulator also compiles to **WebAssembly**, so the exact
+same VM core boots the real 512 KB ROM in any browser — text/lo-res/hi-res video on a
+canvas, keyboard input, a Disk II 5.25″ floppy, and a bit-banged micro-SD card. A small
+Node **codegen** toolchain assembles 65C02 programs and validates them headlessly on the
+same WASM core. The "why" lives in `docs/MISSION.md`.
+
+## Architecture at a glance
+
+```
+   6502 ROM + software (badger6502.bin, fontrom.dat, *.s / *.prg)
+                         │  executed by
+                         ▼
+   Emulator core — 65C02 VM in C++  (emulator/Badger6502VMLib)
+     ├─ WozLib       — Disk II 5.25" floppy (.woz)        ┐ shared sources,
+     ├─ MockMicroSD  — bit-banged SPI FAT32 card          ├ guarded for both
+     └─ video / keyboard / ACIA (serial) / VIA (I/O)      ┘ native + WASM
+                 │                              │
+   native hosts (Windows/WinUI,        Emscripten bridge (web/web_bridge.cpp)
+   Console) via Badger6502VM.sln                │
+                                        Browser client (web/index.html) → GitHub Pages
+                                                ▲
+   Codegen (codegen/): 65C02 assembler + headless harness + platform-ref
+                         │  targets the same VM + memory map as
+                         ▼
+   Hardware (kicad/, 22v10/, logisim/, diylayout/): schematics, PCB, GAL decode
+```
+
+- **Stack:** C++17 VM core → Emscripten/WebAssembly browser build; Node.js ESM tooling
+  (65C02 assembler + headless emulator harness); 6502 assembly ROM/software; KiCad + 22V10
+  GAL hardware.
+- **Environments:** dev = Windows + Visual Studio 2022 (native) and emsdk 6.0.1 + Node +
+  Python 3 (WASM), local browser via `web/serve.ps1` (`http://localhost:8011`); prod =
+  GitHub Pages (<https://ebadger.github.io/3ric/>). See `status/SYSTEM-STATUS.md`.
+
+## Sub-specs (read only the layer you'll touch)
+
+| Layer | Spec | Covers |
+|-------|------|--------|
+| Emulator core (C++ VM) | [`EMULATOR.md`](./EMULATOR.md) | 65C02 CPU, memory map, soft switches, VIA/ACIA/keyboard/video, WozLib, MockMicroSD |
+| Web / WASM client | [`WEB-CLIENT.md`](./WEB-CLIENT.md) | Emscripten build, embind bridge API, canvas UI, in-browser assembler, Pages deploy |
+| Codegen tooling | [`CODEGEN.md`](./CODEGEN.md) | `asm6502` assembler, `run6502`/`harness`, platform-ref generation, validation channels |
+| ROM & software | [`ROM-SOFTWARE.md`](./ROM-SOFTWARE.md) | 512 KB ROM (monitor/DOS/BASIC), fonts, 6502 programs, `.PRG` format |
+| Hardware | [`HARDWARE.md`](./HARDWARE.md) | KiCad schematics/PCB, 22V10 GAL address decode, logisim/diylayout models |
+
+> Create each new sub-spec from [`_TEMPLATE.md`](./_TEMPLATE.md).
+
+## Cross-cutting concerns
+
+- **The memory map is a shared contract.** `emulator/Badger6502VMLib/vm.h` (the `MM_*` map
+  + soft switches + ROM entry points) is mirrored by the 22V10 GAL decode, the web bridge,
+  and `codegen/platform/platform-ref.*`. A change to any of these is a **cross-layer event**
+  — update all in one commit and regenerate the platform ref.
+- **Native ↔ WASM parity.** The Windows and browser builds share the VM/WozLib/SD sources;
+  divergence is only allowed behind `__EMSCRIPTEN__` / `PLATFORM_WEB` guards.
+- **The critical path:** the emulator must execute 6502 code faithfully enough that **the
+  ROM boots to the monitor, the in-browser assembler runs programs, and disk/SD images
+  load** — because the public GitHub Pages demo is the primary way the machine is
+  experienced. This is what the `Badger6502VMTest` MSTest suite, the `web/test_*.cjs` smoke
+  tests, and the `pre-push` assembler-test gate exist to protect.
+
+## Implementation status (summary)
+
+| Area | Status |
+|------|--------|
+| 65C02 CPU + memory map + soft switches | Shipped |
+| Text / lo-res / hi-res video rendering | Shipped |
+| Keyboard (`$C000`/`$C010`) + ACIA serial | Shipped |
+| Disk II 5.25″ WOZ boot (self-booting machine-code disks) | Shipped |
+| Micro-SD FAT32 + ROM DOS shell | Shipped |
+| WebAssembly browser build + in-browser assembler | Shipped |
+| DOS 3.3 / Applesoft-dependent disks | Not supported (this clone's BASIC is generic MS-BASIC, not Applesoft) |
+| Hardware (KiCad/PCB/GAL) | In progress (documented in the build series) |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -1,0 +1,71 @@
+# 3ric — Web / WASM Client Spec (WEB-CLIENT.md)
+
+> The Emscripten/WebAssembly port and the browser UI that make 3ric playable at
+> <https://ebadger.github.io/3ric/> with no install. It compiles the **same** VM core
+> (`EMULATOR.md`) to WASM and renders it to an HTML canvas. Everything here is additive to
+> the shared sources — see `web/README.md` for the deep dive.
+
+---
+
+## Purpose
+
+Boot the real 512 KB ROM in any browser: render Apple-II text/lo-res/hi-res video to a
+`<canvas>`, feed keystrokes through the memory-mapped keyboard, run Disk II and micro-SD
+images, and assemble/run 65C02 source client-side — all 100% client-side so GitHub Pages can
+host it as static files.
+
+## Contracts / Interfaces
+
+- **Build:** `web/build.ps1` compiles `Badger6502VMLib` (vm, cpu, Instructions, acia, via,
+  PS2Keyboard, badgervmpal) + `WozLib` (DriveEmulator, WozDisk, WozFile) + `MockMicroSD`
+  (SDCard, MappedFile) + `web/web_bridge.cpp` with `-DPLATFORM_WEB`. Excludes `symbols.cpp`
+  and `Disassemble.cpp`. Key flags: `-std=c++17 -O2 -lembind -sMODULARIZE=1
+  -sEXPORT_NAME=createBadgerVM -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,node`. Output:
+  `web/badger6502.js` + `web/badger6502.wasm` (git-ignored — regenerated).
+- **Bridge API (embind, `web_bridge.cpp`):** `loadData(addr, bytes)`, `seedBasicRom()`,
+  `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
+  `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial), `renderFrame()` (RGBA
+  framebuffer), `pc/sp/regA/regX/regY/status`, `sdReadCount()`.
+- **Compat shims (`web_compat.h`):** map MSVC-isms (`OutputDebugString`, `sprintf_s`,
+  `fopen_s`, `_ASSERT`, …) onto Emscripten so `WozLib`/`MockMicroSD` compile unchanged.
+- **UI (`index.html`):** `requestAnimationFrame` driver, keyboard, disk/SD/clock controls,
+  and the in-browser **Assembler** panel (imports `assemble()` from the staged
+  `asm6502.mjs`). Honors optional `window.ASSET_BASE` / `?assets=` for CDN/R2 offload and
+  `?src=` / `?prg=` deep links.
+- **SD image:** `make_sd_sparse.py` streams `emulator/Data/sd.zip` (2 GB, mostly-zero FAT32)
+  into `data/sd.sparse` (~11.5 MB `SDSP` container), fetched lazily.
+
+## Behaviour / Rules
+
+- The CPU is stepped per animation frame (`run(maxSteps)`), bounded by a wall-clock budget so
+  the tab stays responsive; the **Speed** selector scales cycles/frame (0.5×–8×, Max).
+- **Parity is the rule:** the WASM build must behave like the native build. Do not add
+  behavior in the bridge that isn't in the shared core unless it's a genuinely
+  presentation-only concern (canvas, clock pacing) — and never behind an unguarded fork.
+- Assets are relative so the site works under `/<repo>/` on Pages; the mandatory first-load
+  payload is ~1.26 MB, with `disk.woz`/`sd.sparse` fetched only on demand.
+
+## Data flow
+
+`build.ps1 → badger6502.js/.wasm + data/ → index.html loads WASM → boot recipe (loadData /
+seedBasicRom / loadFont / reset) → run() per frame → renderFrame()→canvas, drainOutput()→
+log; keyDown()→$C000; Boot Disk/Mount SD → insertDisk()/loadSD() → C600G / EC5CG`.
+
+## Dependencies
+
+- **Upstream:** the VM core (`EMULATOR.md`), the ROM/font/disk/SD data (`ROM-SOFTWARE.md`),
+  and `codegen/tools/asm6502.mjs` (staged for the in-browser assembler — `CODEGEN.md`).
+- **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`); the public
+  users of the demo.
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| WASM build of the VM core + WozLib + SD | Shipped | `web/build.ps1`, Emscripten 6.0.1. |
+| Canvas video + keyboard | Shipped | text/lo-res/hi-res, `$C000` input. |
+| Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
+| In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. |
+| Adjustable CPU clock | Shipped | frontend-only pacing. |
+| Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk). |
+| GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/specs/_TEMPLATE.md
+++ b/specs/_TEMPLATE.md
@@ -1,0 +1,42 @@
+# 3ric — {{LAYER_NAME}} Spec
+
+> Copy this file to `specs/<LAYER>.md` (e.g. `DATABASE.md`, `API.md`, `WEB-CLIENT.md`) and
+> fill it in. One sub-spec per layer. Keep it the source of truth — update it in the same
+> commit as the code that implements it.
+
+---
+
+## Purpose
+
+{{What this layer is responsible for, in one or two sentences.}}
+
+## Contracts / Interfaces
+
+{{The precise, checkable contract this layer exposes — table schemas, endpoint shapes,
+component props, message formats. Field names, types, casing, nullability. This is what the
+other layers depend on; changing it is a cross-layer event.}}
+
+## Behaviour / Rules
+
+{{Validation rules, invariants, edge cases, error states. Be explicit about what happens on
+the unhappy path — empty states, failures, timeouts.}}
+
+## Data flow
+
+{{Trace the links this layer participates in:
+`... → this layer → ...`. Name the upstream and downstream layers.}}
+
+## Dependencies
+
+- Upstream: {{what this layer reads/depends on}}
+- Downstream: {{what depends on this layer}}
+
+## Implementation Status
+
+| Item | Status | Notes |
+|------|--------|-------|
+| {{item}} | Not started / In progress / Shipped | {{PR #, caveats}} |
+
+> Update this table after implementing. A documented-but-unbuilt item is a **tracked gap**,
+> not a feature — and the client must render an explicit empty state for it, never fabricate
+> data (see `docs/LEARNINGS.md`).

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -1,0 +1,84 @@
+# 3ric — System Status
+
+> The **current runtime reality** of the system: how to build it, run it, and verify it's
+> healthy. Read at session start. Keep it lean and *current* — stale status is worse than
+> no status. Move historical detail to `status/CHANGELOG.md` and deep runbooks to
+> `docs/runbooks/`.
+
+_Last updated: 2026-07-10 — ebadger (via Copilot, initial template instantiation)_
+
+---
+
+## Environments
+
+| Environment | Where | URL | Notes |
+|-------------|-------|-----|-------|
+| Dev (native emulator) | Windows + Visual Studio 2022 | — | Open `emulator/Badger6502VM.sln`; run the `Console` or WinUI host. |
+| Dev (WASM, local) | emsdk 6.0.1 + Node + Python 3 | `http://localhost:8011/index.html` | `web/build.ps1` then `web/serve.ps1`. |
+| Production | GitHub Pages (static) | <https://ebadger.github.io/3ric/> | 100% client-side; deployed by `.github/workflows/deploy-pages.yml` on push to `main`. |
+| Production (optional self-host) | Raspberry Pi + Cloudflare Tunnel / R2 | — | `web/Caddyfile`; `ASSET_BASE` offloads the heavy `sd.sparse`/`.wasm`. See `web/README.md`. |
+
+## How to run it (dev)
+
+**Native emulator (Windows):** open `emulator/Badger6502VM.sln` in Visual Studio 2022 and
+build/run the `Console` or WinUI (`Badger6502Emulator`) host.
+
+**Browser / WebAssembly build:**
+
+```powershell
+pwsh web/build.ps1     # Emscripten 6.0.1 -> web/badger6502.js + .wasm, stages data/
+pwsh web/serve.ps1     # python -m http.server 8011 ; open http://localhost:8011/index.html
+```
+
+Prereqs on this machine (see `web/README.md`): emsdk **6.0.1** at `C:\Users\ebadger\emsdk`,
+Node at `C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe` (not on `PATH`), Python 3.
+
+## How to verify it's healthy
+
+```powershell
+$node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
+& $node codegen/tools/asm6502.test.mjs   # assembler encoding tests (no WASM build needed)
+& $node web/test_boot.cjs                # ROM boots, sane PC, video RAM written
+& $node web/test_render.cjs              # framebuffer has lit pixels
+& $node web/test_keyboard.cjs            # monitor echoes typed commands
+& $node web/test_screen_text.cjs         # decode the 40x24 text screen to ASCII
+& $node web/test_sd.cjs                  # mount SD + DIR lists the FAT32 root
+& $node web/test_disk.cjs                # boot a WOZ floppy via C600G into a hi-res title
+```
+
+C++ CPU unit tests (`emulator/Badger6502VMTest`, MSTest): **Test → Run All Tests** in
+Visual Studio. Expected: a booted ROM sits at the monitor `*` prompt; the smoke tests all
+print `PASS` / exit 0.
+
+## Credentials & secrets
+
+**None.** 3ric is a 100% client-side static site — no database, no API server, no runtime
+secrets. Nothing to configure and nothing to commit. (The only "secret" is the standard
+`GITHUB_TOKEN` the Pages workflow uses, provided automatically by Actions.)
+
+## Key scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/dev/install-hooks.sh` | Activate the git `pre-push` guards (run once per clone). |
+| `scripts/dev/check-learnings-budget.sh` | Enforce the `docs/LEARNINGS.md` token cap. |
+| `scripts/dev/pre-push-tests.sh` | Project test gate — runs the 65C02 assembler tests (+ boot smoke test if a WASM build is present). |
+| `web/build.ps1` | Compile the VM core + WozLib + MockMicroSD + bridge to WASM; stage data. |
+| `web/serve.ps1` | Local static server for the browser build (port 8011). |
+| `codegen/tools/run6502.mjs` | Assemble → run → check a 6502 program; emit a card-ready `.PRG`. |
+| `codegen/tools/gen_platform_ref.mjs` | Regenerate `codegen/platform/platform-ref.*` from `vm.h` + `badger6502.dbg`. |
+
+## Current state / known gaps
+
+- **Emulator:** boots the unmodified 512 KB ROM to the monitor; text/lo-res/hi-res color
+  video; keyboard; ACIA serial; Disk II WOZ boot; micro-SD FAT32 DOS shell; adjustable CPU
+  clock. Shared VM core runs identically on Windows and in the browser.
+- **In-browser assembler:** assembles 65C02 source client-side with the project's own
+  `asm6502.mjs` and runs it like `BRUN`; ships ~11 sample programs; deep-linkable via `?src=`.
+- **Disk gap:** DOS 3.3 / Quick-DOS and games that chain through an Applesoft auto-run
+  greeting don't run — this clone's `$E000` BASIC is generic Microsoft BASIC, not Applesoft.
+  Self-booting machine-code disks work.
+- **CI:** `deploy-pages.yml` rebuilds and publishes to GitHub Pages on every push to `main`
+  that touches the emulator/web/codegen sources it lists.
+- **Hardware:** schematics, PCB, and 22V10 GAL logic are in progress and tracked through the
+  YouTube build series; the emulator is the reference implementation of the target machine.


### PR DESCRIPTION
## What this does

Applies the **AIProjectTemplate** "AI-workforce operating layer" (governance-as-code, capped memory, model-diverse review, specs-as-source-of-truth) to **3ric** and specializes every placeholder to this project — a from-scratch Apple-II-class 65C02 computer: C++17 VM core → Emscripten/WebAssembly browser build, Node.js ESM tooling (65C02 assembler + headless emulator harness), 6502 assembly ROM/software, and KiCad + 22V10 GAL hardware; CI deploys the browser build to GitHub Pages.

Nothing in the existing app is changed — the deploy-pages workflow and all source dirs are untouched. This PR only **adds** the operating layer.

## Authored fresh for 3ric

| File | Purpose |
|------|---------|
| `.github/copilot-instructions.md` | Entry point every session reads: session-start reading, 3ric layers, stack, code style |
| `docs/MISSION.md` | The "why" — personal learn-by-building retro-computing project, documented as a build series |
| `specs/SYSTEM.md` | Architecture diagram, sub-spec map, cross-layer memory-map contract, critical path |
| `status/SYSTEM-STATUS.md` | Build / run / verify commands, key scripts, "no secrets" |
| `specs/EMULATOR.md`, `WEB-CLIENT.md`, `CODEGEN.md`, `ROM-SOFTWARE.md`, `HARDWARE.md` | One concise real sub-spec per layer |
| `docs/LEARNINGS.md` | Capped Tier-1 rules digest with 3ric-specific seed rules (**1,452 / 2,500 tokens**) |

## Operating-layer machinery (copied + token-stamped)

- **Governance & review:** `docs/ROLES.md`, `docs/CODE-REVIEW-PANEL.md`, `.github/agents/` (gpt + gemini reviewers, templates), `.github/instructions/`, `.github/ISSUE_TEMPLATE/`, PR template.
- **Compliance hooks:** `.github/extensions/compliance-hooks/` — `SPEC_PATTERNS` retuned to 3ric's layer dirs (`specs/`, `emulator/`, `web/`, `codegen/`, `romgen/`, `22v10/`, `*.s`).
- **Mechanical guards:** `.githooks/pre-push` + `scripts/dev/pre-push-tests.sh` wire a test gate to the Node 65C02 assembler suite (fail-open), plus the LEARNINGS token-budget guard. Activate locally with `scripts/dev/install-hooks.sh`.
- **`.gitattributes`:** scoped LF rules for the hook/scripts/extension only — deliberately **not** global `*.mjs`, so 3ric's existing codegen/web files aren't renormalized.

## Verification

- `node --check` on `extension.mjs` → syntax OK
- `node codegen/tools/asm6502.test.mjs` (the pre-push gate) → **ALL PASS**
- `docs/LEARNINGS.md` → 1,452 / 2,500 tokens (tiktoken cl100k_base)
- No stray `{{PLACEHOLDER}}` tokens outside the intentional `_TEMPLATE.md` / `template-lens-agent.md` skeletons

## Follow-ups (optional, not blocking)

- Run `scripts/dev/install-hooks.sh` in each working clone to activate the pre-push guards locally.
- Reviewer model pins (`gpt-5.5`, `gemini-3.1-pro-preview`) are current; bump in `.github/agents/*` when they age.
- Flesh out additional lenses/sub-specs only as the machine grows — the skeletons are ready.