### PR TITLE
web: file Snake under a new Lo-res dropdown group

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -114,8 +114,10 @@
             <option value="jungle">JUNGLE QUEST</option>
             <option value="life">Conway&rsquo;s Life</option>
           </optgroup>
-          <optgroup label="Text mode">
+          <optgroup label="Lo-res">
             <option value="snake">Snake</option>
+          </optgroup>
+          <optgroup label="Text mode">
             <option value="blocks">Block Drop</option>
             <option value="paddles">Paddles</option>
             <option value="bricks">Brick Buster</option>


### PR DESCRIPTION
## What

Adds a **Lo-res** optgroup to the in-browser assembler's sample dropdown (between **Hi-res** and **Text mode**) and moves **Snake** into it.

## Why

Snake now renders in mixed **lo-res** colour graphics (since `d408177` / PR #19), but the sample dropdown still listed it under the **Text mode** optgroup. Anyone looking for the graphical snake in the Hi-res/graphics groups wouldn't find it. This aligns the dropdown with how the program actually renders — and with `web/programs/README.md`, which already describes Snake as lo-res and no longer lists it among the text-mode games.

## Change

One-file UI edit in `web/index.html` — the `value="snake"` option is unchanged, so the sample loader (`fetch('programs/snake.s')`) and everything downstream behaves identically. No spec change needed (WEB-CLIENT.md only says "~11 samples", still true).

## Verification

- Confirmed the live site already serves the updated lo-res `programs/snake.s` and a byte-identical `snake.prg`; this PR only corrects the dropdown grouping.
- `pre-push` gate passed (assembler encoding tests ALL PASS).

## Second-model review
- Reviewed diff: `a3301678...a0433f79`
- GPT Reviewer (gpt-5.5): LGTM — 0 findings
- Gemini Reviewer (gemini-3.1-pro-preview): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden (no findings; HEAD unchanged, so shipped diff == reviewed diff)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>