### PR TITLE
Add dual-license (MIT + CC-BY-SA), NOTICE, FUNDING, and a real README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,11 @@
+# Renders the "Sponsor" button on the 3ric repository.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# GitHub Sponsors: works once Sponsors is enabled for the owner account.
+github: [ebadger]
+
+# Uncomment and fill in any of these as you set them up:
+# patreon: <your-patreon-handle>
+# ko_fi: <your-ko-fi-handle>
+# buy_me_a_coffee: <your-bmac-handle>
+# custom: ["https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2023-2026 ebadger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+3ric is dual-licensed. The MIT License above covers the project's original
+SOFTWARE. The project's original HARDWARE designs and DOCUMENTATION are licensed
+under Creative Commons Attribution-ShareAlike 4.0 International (see
+LICENSE-CC-BY-SA-4.0.txt). Bundled third-party components keep their own
+licenses, and some bundled data (the ROM's Microsoft BASIC, Apple II disk
+images) is third-party copyrighted material not licensed by this project.
+See NOTICE for the full breakdown.

--- a/LICENSE-CC-BY-SA-4.0.txt
+++ b/LICENSE-CC-BY-SA-4.0.txt
@@ -1,0 +1,427 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the "Licensor." The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,79 @@
+3ric — Licensing & Attribution Notice
+=====================================
+
+3ric is dual-licensed, and it also bundles third-party components and data that
+keep their own licenses. This file is the authoritative map of what is covered
+by what. When in doubt, the license shipped alongside a specific file or
+subdirectory governs that file.
+
+
+1. Original 3ric work by ebadger
+--------------------------------
+
+Copyright (c) 2023-2026 ebadger.
+
+  a. SOFTWARE  ->  MIT License (see LICENSE)
+     The original source code of the project, including but not limited to:
+       - emulator/      (the C++ 65C02 VM core, WozLib, MockMicroSD, hosts)
+                        EXCEPT third-party subtrees listed in section 2
+       - web/           (Emscripten bridge, browser client, in-browser assembler)
+       - codegen/       (asm6502 assembler, run6502/harness, platform-ref tools)
+       - scripts/       (developer/CI scripts)
+       - original 6502 assembly programs authored for this project
+         (e.g. codegen/programs/, emulator/AICodeGen/, web/programs/*.prg)
+
+  b. HARDWARE DESIGNS and DOCUMENTATION  ->  Creative Commons
+     Attribution-ShareAlike 4.0 International (see LICENSE-CC-BY-SA-4.0.txt)
+       - kicad/, 22v10/, logisim/, diylayout/, schematic_pdf/
+         (schematics, PCB, 22V10 GAL address decode, digital-logic models)
+                        EXCEPT third-party subtrees listed in section 2
+       - docs/, specs/, status/, and the README/prose documentation
+         throughout the repository
+
+
+2. Bundled third-party components (each under its own license)
+--------------------------------------------------------------
+
+These are included for convenience and are NOT licensed by ebadger. They remain
+under the license shipped with them:
+
+  - emulator/picodisk/sdlib/
+      no-OS-FatFS SD SPI library. Apache License 2.0.
+      See emulator/picodisk/sdlib/LICENSE.
+
+  - emulator/picodisk/sdlib/FatFs_SPI/ff15/
+      FatFs - Generic FAT Filesystem Module by ChaN. FatFs License (BSD-style,
+      1-clause). See emulator/picodisk/sdlib/FatFs_SPI/ff15/LICENSE.txt.
+
+  - kicad/libraries/KiCad-RP-Pico-main/
+      TPCWare KiCad Library (Raspberry Pi Pico footprint/3D model).
+      Creative Commons Attribution-ShareAlike 4.0. See the LICENSE in that
+      directory.
+
+Other vendored libraries or footprints, if added later, likewise retain their
+own licenses; add them to this section.
+
+
+3. Provenance disclosures (third-party copyrighted material, NOT licensed here)
+-------------------------------------------------------------------------------
+
+The following are third-party copyrighted works. They are neither owned nor
+licensed by this project; they are present only to make the emulator useful for
+study and demonstration. Do not assume any redistribution rights from the 3ric
+licenses above.
+
+  - Microsoft BASIC in the ROM (emulator/Data/badger6502.bin)
+      The 512 KB ROM image includes a Microsoft 6502 BASIC interpreter. Its
+      copyright is held by Microsoft; its redistribution status is unsettled.
+      The 3ric MIT/CC-BY-SA licenses do NOT grant any rights to it.
+
+  - Apple II disk images and program binaries used as test/demo data
+      (e.g. emulator/Data/loderun.bin and the .woz images under
+      emulator/WozFileTestApp/testdata/)
+      These are or may be commercial Apple II software (for example
+      "Lode Runner") retained by their respective copyright holders. They are
+      included as fixtures for the Disk II / WOZ subsystem and carry no license
+      from this project.
+
+If you redistribute or repackage 3ric, review sections 2 and 3 and strip or
+replace any material you do not have the right to include.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,172 @@
-# 3ric — Apple-II-clone 65C02 computer
+<h1 align="center">3ric</h1>
 
-**▶ Try the emulator in your browser: <https://ebadger.github.io/3ric/>**
-(runs entirely client-side via WebAssembly — no install and no GitHub account
-needed). Click the canvas and type; use **Boot Disk** for the demo floppy or
-**Mount SD** for the DOS shell. See [`web/`](web/) for how the WebAssembly port
-works, and `.github/workflows/deploy-pages.yml` for the build/deploy pipeline.
+<p align="center">
+  <strong>A from-scratch, Apple-II-class 65C02 personal computer — real hardware plus a
+  cycle-honest emulator that also runs in your browser.</strong>
+</p>
 
-See the build documented via [Youtube Videos](https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq)
+<p align="center">
+  <a href="https://ebadger.github.io/3ric/"><img alt="Live demo" src="https://img.shields.io/badge/%E2%96%B6_try_it-live_in_your_browser-2ea44f"></a>
+  <a href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq"><img alt="Build series" src="https://img.shields.io/badge/build_series-YouTube-red"></a>
+  <img alt="CPU" src="https://img.shields.io/badge/CPU-65C02-8957e5">
+  <img alt="Runs in WebAssembly" src="https://img.shields.io/badge/runs_in-WebAssembly-654ff0">
+  <a href="LICENSE"><img alt="Code license: MIT" src="https://img.shields.io/badge/code-MIT-blue"></a>
+  <a href="LICENSE-CC-BY-SA-4.0.txt"><img alt="Hardware & docs: CC BY-SA 4.0" src="https://img.shields.io/badge/hardware_%26_docs-CC--BY--SA--4.0-lightgrey"></a>
+</p>
+
+---
+
+## ▶ Try it now — no install, no account
+
+**<https://ebadger.github.io/3ric/>** runs the *entire machine* client-side via
+WebAssembly. Click the canvas and start typing at the monitor `*` prompt. Then:
+
+- **Boot Disk** — boot the demo 5.25″ floppy (a self-booting machine-code disk).
+- **Mount SD** — mount the micro-SD card and use the ROM's DOS shell (`DIR`, etc.).
+- **Assemble & Run** — open the built-in 65C02 editor, write assembly, and run it like
+  `BRUN` — all in the browser. Programs are shareable via a `?src=` deep link.
+
+<!-- TODO(media): drop an animated GIF of the emulator booting + a program running here,
+     e.g. ![3ric booting](docs/media/hero.gif). Keep it < ~5 MB for fast README loads. -->
+
+## What is 3ric?
+
+3ric is a personal *learn-by-building* project: an 8-bit computer designed at the chip level
+— KiCad schematics, a custom PCB, and 22V10 GAL address-decode logic — paired with a C++
+emulator of the exact same machine. The emulator compiles to WebAssembly, so the **same VM
+core** that models the real hardware also boots the unmodified 512 KB ROM in any browser.
+The whole journey is documented in a [YouTube build series][youtube].
+
+> **Why it exists:** to understand, build, document, and demonstrate how an Apple-II-class
+> computer works end to end — and to let anyone poke at it with zero friction. See
+> [`docs/MISSION.md`](docs/MISSION.md).
+
+## Features
+
+- **65C02 CPU** with a faithful memory map and soft switches, adjustable clock speed.
+- **Video**: 40×24 text, lo-res, and hi-res color, rendered to a canvas.
+- **Input & I/O**: keyboard (`$C000`/`$C010`), 6551-style ACIA serial, 6522 VIA.
+- **Disk II 5.25″ floppy** via `.woz` images (self-booting machine-code disks).
+- **Micro-SD storage**: a bit-banged SPI FAT32 card with a ROM DOS shell.
+- **In-browser 65C02 assembler/editor** — assemble & run, download a `.PRG`, share `?src=`
+  links; ships ~11 sample programs.
+- **AI-generated 6502 games** (Snake, Life, Minesweeper, 2048, Star Swarm, and more) built
+  through the project's own codegen pipeline — see [`emulator/AICodeGen/`](emulator/AICodeGen/).
+- **Runs everywhere the same way**: one shared C++ VM core drives both the native Windows
+  build and the browser (WebAssembly) build.
+
+## Write your first program in the browser
+
+1. Open the [live emulator][demo] and pick a sample from the editor's program menu.
+2. Edit the assembly, hit **Assemble & Run**, and watch it execute on the machine.
+3. Use **Download .PRG** to save it, or copy the `?src=` link to share the exact program.
+
+Prebuilt samples live in [`web/programs/`](web/programs/); their source and design notes
+are under [`emulator/AICodeGen/`](emulator/AICodeGen/) and [`codegen/`](codegen/).
+
+## Build from source
+
+Full, current instructions are in [`status/SYSTEM-STATUS.md`](status/SYSTEM-STATUS.md).
+
+**Native emulator (Windows):** open `emulator/Badger6502VM.sln` in Visual Studio 2022 and
+build/run the `Console` or WinUI (`Badger6502Emulator`) host.
+
+**Browser / WebAssembly build** (emsdk 6.0.1, Node, Python 3):
+
+```powershell
+pwsh web/build.ps1     # Emscripten -> web/badger6502.js + .wasm, stages data/
+pwsh web/serve.ps1     # serves http://localhost:8011/index.html
+```
+
+**Verify it's healthy** (headless smoke tests — no WASM build needed for the first one):
+
+```powershell
+$node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
+& $node codegen/tools/asm6502.test.mjs   # assembler encoding tests
+& $node web/test_boot.cjs                # ROM boots to a sane state
+```
+
+## How it works
+
+```mermaid
+flowchart TD
+    ROM["6502 ROM + software<br/>(badger6502.bin, fontrom.dat, .s / .prg)"]
+    VM["Emulator core — 65C02 VM in C++<br/>(WozLib floppy · MockMicroSD · video/keyboard/ACIA/VIA)"]
+    NATIVE["Native hosts<br/>(Windows / Console)"]
+    WASM["Emscripten bridge → WebAssembly"]
+    BROWSER["Browser client (index.html)<br/>→ GitHub Pages"]
+    CODEGEN["Codegen<br/>(asm6502 + headless harness)"]
+    HW["Hardware<br/>(KiCad · 22V10 GAL · logisim)"]
+
+    ROM --> VM
+    VM --> NATIVE
+    VM --> WASM --> BROWSER
+    CODEGEN -->|assembles & tests on the same VM| VM
+    HW -. mirrors the same memory map .-> VM
+```
+
+The **memory map is a shared contract**: `emulator/Badger6502VMLib/vm.h` is mirrored by the
+22V10 GAL decode, the web bridge, and the codegen platform reference. The architecture and
+each layer are documented in [`specs/`](specs/) — start with
+[`specs/SYSTEM.md`](specs/SYSTEM.md).
+
+## Repository layout
+
+| Path | What's there |
+|------|--------------|
+| [`emulator/`](emulator/) | C++ 65C02 VM core, WozLib, MockMicroSD, native hosts, ROM data, AI codegen programs |
+| [`web/`](web/) | Emscripten bridge, browser client, in-browser assembler, Pages build/deploy |
+| [`codegen/`](codegen/) | `asm6502` assembler, `run6502`/harness, platform-ref generation |
+| [`specs/`](specs/) | Layer specifications (the source of truth — specs before code) |
+| [`status/`](status/) | How to build/run/verify; current state and known gaps |
+| [`docs/`](docs/) | Mission, workflow rules & learnings, roles |
+| [`kicad/`](kicad/), [`22v10/`](22v10/), [`logisim/`](logisim/), [`diylayout/`](diylayout/), [`schematic_pdf/`](schematic_pdf/) | Hardware: schematics, PCB, GAL address decode, digital-logic models |
+| [`romgen/`](romgen/), [`scripts/`](scripts/), [`test/`](test/) | ROM assembly tooling, dev/CI scripts, tests |
+
+## Known gaps
+
+- **DOS 3.3 / Applesoft disks don't run.** This clone's `$E000` BASIC is generic Microsoft
+  BASIC, not Applesoft, so games that chain through an Applesoft auto-run greeting won't
+  boot. Self-booting machine-code disks work.
+- **Hardware is in progress** — schematics, PCB, and the 22V10 GAL logic are being built and
+  documented in the video series; the emulator is the reference implementation.
+
+## Contributing
+
+Contributions and experiments are welcome — especially new 6502 programs for the in-browser
+editor. A few house rules keep the machine trustworthy:
+
+- **Specs before code.** Update the relevant spec in [`specs/`](specs/) in the same change.
+- **Trace every layer** a change touches (ROM/software → C++ VM core → web bridge/WASM), and
+  keep the **native and browser builds behavior-identical**.
+- **Open a PR** — changes land via pull request, not direct pushes to `main`.
+
+The full workflow rules live in [`docs/LEARNINGS.md`](docs/LEARNINGS.md); bug reports use the
+templates under [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
+
+## The build series
+
+3ric is built in public. Watch the design and construction, episode by episode:
+**[YouTube build series][youtube]**.
+
+## Support
+
+If this project helps you learn or you just enjoy the build, you can support it via the
+**Sponsor** button on this repository (see [`.github/FUNDING.yml`](.github/FUNDING.yml)).
+Sponsorship funds parts, boards, and more build videos.
+
+## License
+
+3ric is **dual-licensed**:
+
+- **Software** — [MIT](LICENSE).
+- **Hardware designs & documentation** — [Creative Commons Attribution-ShareAlike 4.0
+  International](LICENSE-CC-BY-SA-4.0.txt).
+
+Bundled third-party components keep their own licenses, and some bundled data (the ROM's
+Microsoft BASIC, Apple II disk images used as test fixtures) is third-party copyrighted
+material **not** licensed by this project. See [`NOTICE`](NOTICE) for the full breakdown
+before redistributing.
+
+[demo]: https://ebadger.github.io/3ric/
+[youtube]: https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq


### PR DESCRIPTION
## Summary

Establishes 3ric's licensing and community front door so the project can accept contributions and support: a **dual license** (MIT for software, CC-BY-SA 4.0 for hardware designs + docs), a **NOTICE** that maps what's licensed how and carves out bundled third-party material, a **FUNDING.yml** sponsor button, and a **rebuilt README**.

### What's in here
- **`LICENSE`** — MIT, covering the original 3ric software.
- **`LICENSE-CC-BY-SA-4.0.txt`** — full official CC BY-SA 4.0 text, covering original hardware designs (`kicad/`, `22v10/`, `logisim/`, `diylayout/`, `schematic_pdf/`) and documentation (`docs/`, `specs/`, `status/`, READMEs).
- **`NOTICE`** — authoritative license map + third-party carve-outs and provenance disclosures (see below).
- **`.github/FUNDING.yml`** — GitHub Sponsors button for `ebadger`, with commented template lines for Patreon/Ko-fi/custom.
- **`README.md`** — rebuilt from a 2-line stub into a real front door: live-demo CTA, features, in-browser quick-start, build-from-source, a mermaid architecture diagram, repo map, contributing rules, build series, sponsor, and license summary.

### Provenance findings surfaced in NOTICE (not relicensed)
- Bundled third-party code keeps its own license: `sdlib` (Apache-2.0), `FatFs` (ChaN's FatFs license), KiCad RP-Pico library (CC-BY-SA 4.0).
- **Microsoft BASIC** inside `emulator/Data/badger6502.bin` and **Apple II disk images / `loderun.bin`** (test/demo fixtures) are third-party copyrighted material the project license can't cover.

## Checklist

- [ ] ~~**Spec updated**~~ — N/A: no stored-data/API/client-behavior change; this is docs + license + a funding config file.
- [ ] ~~**Migration included**~~ — N/A: no schema.
- [ ] ~~**Contract verified**~~ — N/A: no server/client contract touched.
- [x] **Tests pass** — no code paths touched; `codegen/tools/asm6502.test.mjs` is **ALL PASS** (also re-run green by the `pre-push` gate).
- [x] **Only relevant files staged** — exactly 5 files (`LICENSE`, `LICENSE-CC-BY-SA-4.0.txt`, `NOTICE`, `.github/FUNDING.yml`, `README.md`).
- [x] **Second-model review** — exempt: prose + license text + a trivial config file (no code/spec/logic).

## Follow-ups for @ebadger
1. **Enable GitHub Sponsors** on your account so the Sponsor button resolves — or tell me your Patreon/Ko-fi and I'll wire it into `FUNDING.yml`.
2. **Copyright name** currently reads `ebadger` (the default I flagged before writing). Your git identity shows "Eric Badger" — say the word and I'll switch the copyright lines.
3. **Optional:** the README marks a spot for a hero GIF (`<!-- TODO(media) -->`); I can add one if you record a short boot/demo clip.
4. **Not blocking, but worth noting:** bundling `loderun.bin` and commercial Apple II `.woz` images as test fixtures is a mild takedown risk; consider swapping in freely-licensed disk images later.

## Related issues
<!-- none -->