### PR TITLE
Set copyright holder to Eric Badger in LICENSE and NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2026 ebadger
+Copyright (c) 2023-2026 Eric Badger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -7,10 +7,10 @@ by what. When in doubt, the license shipped alongside a specific file or
 subdirectory governs that file.
 
 
-1. Original 3ric work by ebadger
+1. Original 3ric work by Eric Badger
 --------------------------------
 
-Copyright (c) 2023-2026 ebadger.
+Copyright (c) 2023-2026 Eric Badger.
 
   a. SOFTWARE  ->  MIT License (see LICENSE)
      The original source code of the project, including but not limited to:
@@ -34,7 +34,7 @@ Copyright (c) 2023-2026 ebadger.
 2. Bundled third-party components (each under its own license)
 --------------------------------------------------------------
 
-These are included for convenience and are NOT licensed by ebadger. They remain
+These are included for convenience and are NOT licensed by Eric Badger. They remain
 under the license shipped with them:
 
   - emulator/picodisk/sdlib/


### PR DESCRIPTION
## Summary

Follow-up to the merged licensing PR (#23): use your legal name **"Eric Badger"** in the copyright/ownership lines of `LICENSE` and `NOTICE`, per your request. The GitHub handle `ebadger` is intentionally kept where it refers to the account (`.github/FUNDING.yml`, `github.io` URLs, repo links).

Four references updated:
- `LICENSE` — MIT copyright line.
- `NOTICE` — section 1 heading, its copyright line, and the section 2 "NOT licensed by …" line.

## Checklist

- [ ] ~~**Spec updated**~~ — N/A: license/notice prose only.
- [ ] ~~**Migration included**~~ — N/A.
- [ ] ~~**Contract verified**~~ — N/A.
- [x] **Tests pass** — no code paths touched; `pre-push` gate green (`asm6502.test.mjs`: ALL PASS).
- [x] **Only relevant files staged** — `LICENSE`, `NOTICE` (2 files, 4 lines).
- [x] **Second-model review** — exempt: license/prose text only.

## Related issues
<!-- none -->