### PR TITLE
web: add a Community Gallery to the browser client

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/gallery.html web/gallery.json web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -35,6 +35,12 @@ host it as static files.
   link to the current editor program.
 - **SD image:** `make_sd_sparse.py` streams `emulator/Data/sd.zip` (2 GB, mostly-zero FAT32)
   into `data/sd.sparse` (~11.5 MB `SDSP` container), fetched lazily.
+- **Gallery (`gallery.html` + `gallery.json`):** a lightweight, WASM-free showcase page that
+  fetches the curated `gallery.json` manifest and renders one card per program, each opening
+  `index.html?src=programs/<name>.s` (or an inline `?code=`) so the Share/Remix loader
+  auto-runs it. Manifest entries carry `title`, `author`/`authorUrl`, `mode`, `description`,
+  `tags`, and a run target (a `src` program path or inline `code`, plus optional `org`). Both
+  files are committed (not generated), so the deploy workflow stages them into `_site/`.
 
 ## Behaviour / Rules
 
@@ -55,6 +61,13 @@ host it as static files.
   involved; the link is the whole payload. Large sources make long `?code=` links (the giant
   hi-res samples are shared via `?src=` precisely to avoid this); a future `?codez=` could
   deflate the payload if needed.
+- **Community Gallery.** `gallery.html` is the discovery front door: it reads `gallery.json`
+  and shows every program as a one-click **Run & Remix** card that opens in the editor via the
+  same `?src=` / `?code=` deep links, so each card lands on an editable, auto-running program.
+  Contribution is PR-based — add a `.s` under `codegen/programs/` (staged into `programs/` by
+  `build.ps1`) plus an entry in `gallery.json` — so every featured program credits its author
+  and turns a visitor into a contributor. The page builds card text with `textContent` only:
+  the manifest is repo-reviewed, but no entry field is ever injected as HTML.
 
 ## Data flow
 
@@ -62,12 +75,16 @@ host it as static files.
 seedBasicRom / loadFont / reset) → run() per frame → renderFrame()→canvas, drainOutput()→
 log; keyDown()→$C000; Boot Disk/Mount SD → insertDisk()/loadSD() → C600G / EC5CG`.
 
+Gallery: `gallery.html → fetch gallery.json → render cards → click Run & Remix →
+index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
+
 ## Dependencies
 
 - **Upstream:** the VM core (`EMULATOR.md`), the ROM/font/disk/SD data (`ROM-SOFTWARE.md`),
   and `codegen/tools/asm6502.mjs` (staged for the in-browser assembler — `CODEGEN.md`).
-- **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`); the public
-  users of the demo.
+- **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`) — its **Stage
+  site** step stages `gallery.html` + `gallery.json` (alongside `index.html` and `programs/`)
+  into `_site/`; the public users of the demo.
 
 ## Implementation Status
 
@@ -78,6 +95,7 @@ log; keyDown()→$C000; Boot Disk/Mount SD → insertDisk()/loadSD() → C600G /
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
 | In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. |
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
+| Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |
 | Adjustable CPU clock | Shipped | frontend-only pacing. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/web/README.md
+++ b/web/README.md
@@ -134,9 +134,39 @@ Implementation notes:
   when the source has no `.org` directive. Opening a `?src=`/`?code=` link auto-runs
   it and shows a "remixing a shared program" banner. No server is involved — the
   link is the whole payload, so very large sources make long `?code=` links.
-- `build.ps1` stages `asm6502.mjs` and the eleven sample `.s` sources into
-  `web/` and `web/programs/` (git-ignored, regenerated each build; CI does the
-  same before publishing).
+- `build.ps1` stages `asm6502.mjs` and every `codegen/programs/*.s` plus the ten
+  `emulator/AICodeGen` sample sources into `web/` and `web/programs/` (git-ignored,
+  regenerated each build; CI does the same before publishing).
+
+## Community Gallery
+
+`gallery.html` is a lightweight, WASM-free showcase of programs written for 3ric,
+linked from the emulator header. It fetches the committed **`gallery.json`** manifest
+and renders one card per program; each card's **&#9654; Run & Remix** button is just a
+`?src=`/`?code=` deep link into `index.html`, so a click loads the source into the
+editor, auto-runs it, and shows the remix banner — no separate storage or server.
+
+`gallery.json` is the single source of truth (a `{ "version", "entries": [...] }`
+document). Each entry has:
+
+| field | required | notes |
+|-------|----------|-------|
+| `title` | yes | shown as the card heading |
+| `mode` | no | badge text, e.g. `Hi-res` / `Lo-res` / `Text` / `Serial` |
+| `description` | no | one- or two-line blurb |
+| `author`, `authorUrl` | no | credit; `authorUrl` is linked only when `http(s)` |
+| `tags` | no | array of short labels |
+| `src` **or** `code` | yes | run target: a `programs/<name>.s` path, or an inline URL-safe base64 program (paste the `?code=` value from a Share link) |
+| `org` | no | hex load address, only when the source has no `.org` directive |
+
+The page builds every card with `textContent` (never `innerHTML`) and only ever
+produces `index.html?…` links, so a manifest entry can't inject markup or a
+`javascript:` URL.
+
+**Add your program:** drop the `.s` into `codegen/programs/` (every `*.s` there is
+staged into `web/programs/` automatically) and append an entry to `gallery.json`,
+then open a pull request. The gallery's *Add your program* card links straight to
+GitHub's in-browser editor for `gallery.json`.
 
 ## Headless tests (fast iteration)
 
@@ -234,8 +264,8 @@ site, 100 GB/month bandwidth).
 1. installs Python + Emscripten (`6.0.1`, matching this project),
 2. runs `web/build.ps1` (it detects Linux CI and invokes `em++` directly, and
    stages `asm6502.mjs` + the `programs/*.s` sample sources for the editor),
-3. stages `index.html` + `badger6502.js` + `.wasm` + `asm6502.mjs` + `data/` +
-   `programs/` as the site root,
+3. stages `index.html` + `gallery.html` + `gallery.json` + `badger6502.js` +
+   `.wasm` + `asm6502.mjs` + `data/` + `programs/` as the site root,
 4. uploads it as a Pages artifact and deploys.
 
 The build outputs stay git-ignored — CI regenerates them from the committed

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -161,9 +161,13 @@ $samples = @(
     (Join-Path $root "emulator\AICodeGen\paddles\paddles.s"),
     (Join-Path $root "emulator\AICodeGen\bricks\bricks.s"),
     (Join-Path $root "emulator\AICodeGen\2048\2048.s"),
-    (Join-Path $root "emulator\AICodeGen\mines\mines.s"),
-    (Join-Path $root "codegen\programs\hello.s")
+    (Join-Path $root "emulator\AICodeGen\mines\mines.s")
 )
+# Every .s under codegen\programs is also staged (this already covers hello.s). Drop a new
+# source there and add a gallery.json entry to feature it in the Community Gallery — no need
+# to edit this list by hand.
+$samples += Get-ChildItem -Path (Join-Path $root "codegen\programs") -Filter *.s -File -ErrorAction SilentlyContinue |
+    ForEach-Object { $_.FullName }
 foreach ($s in $samples) {
     if (Test-Path $s) { Copy-Item $s (Join-Path $webPrograms (Split-Path $s -Leaf)) -Force }
     else { Write-Warning "sample source missing: $s" }

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3ric — Program Gallery</title>
+<style>
+  :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: "Cascadia Code", "Consolas", ui-monospace, monospace;
+    display: flex; flex-direction: column; min-height: 100vh;
+  }
+  header { padding: 10px 16px; border-bottom: 1px solid var(--dim); display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  header h1 { font-size: 14px; margin: 0; letter-spacing: 1px; }
+  header .count { font-size: 12px; color: var(--dim); margin-left: auto; }
+  header a.nav {
+    color: var(--fg); text-decoration: none; border: 1px solid var(--dim);
+    padding: 4px 10px; font-size: 12px; border-radius: 3px;
+  }
+  header a.nav:hover { background: var(--panel); }
+  main { flex: 1; width: 100%; max-width: 1120px; margin: 0 auto; padding: 16px; }
+  .intro { font-size: 13px; line-height: 1.55; margin: 2px 0 18px; }
+  .intro a { color: var(--fg); }
+  #grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(258px, 1fr)); gap: 14px; }
+  .card {
+    border: 1px solid var(--dim); border-radius: 6px; background: var(--panel);
+    padding: 12px 13px; display: flex; flex-direction: column; gap: 9px;
+  }
+  .card .cardhead { display: flex; align-items: center; gap: 8px; }
+  .badge {
+    font-size: 10px; letter-spacing: .5px; text-transform: uppercase;
+    border: 1px solid var(--dim); border-radius: 10px; padding: 1px 7px;
+    color: var(--dim); white-space: nowrap;
+  }
+  .card h2 { font-size: 14px; margin: 0; letter-spacing: .5px; }
+  .desc { font-size: 12px; line-height: 1.5; margin: 0; flex: 1; }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .tag { font-size: 10px; color: var(--dim); }
+  .meta { font-size: 11px; color: var(--dim); }
+  .meta a { color: var(--fg); text-decoration: none; border-bottom: 1px dotted var(--dim); }
+  .run {
+    align-self: flex-start; text-decoration: none; color: var(--fg);
+    border: 1px solid var(--fg); border-radius: 4px; padding: 5px 12px; font-size: 12px;
+  }
+  .run:hover { background: rgba(51, 255, 102, .08); }
+  .card.add { border-style: dashed; }
+  .status { color: var(--dim); font-size: 12px; padding: 10px 0; }
+  .status.err { color: #ff6b6b; }
+  footer { padding: 8px 16px; border-top: 1px solid var(--dim); font-size: 11px; color: var(--dim); }
+  footer a { color: var(--dim); }
+</style>
+</head>
+<body>
+  <header>
+    <h1>3ric&nbsp;&mdash;&nbsp;Program&nbsp;Gallery</h1>
+    <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <span class="count" id="count">loading&hellip;</span>
+  </header>
+  <main>
+    <p class="intro">
+      Programs written for 3ric &mdash; the from-scratch Apple-II-class 65C02 machine that
+      runs in your browser. Pick one to <strong>run it instantly</strong> and open its source
+      in the editor, where you can tweak it and <strong>Share your own remix</strong>.
+      Made something cool? <a href="index.html">Build it in the editor</a> and add it below.
+    </p>
+    <div id="grid" role="list"></div>
+  </main>
+  <footer>
+    3ric Program Gallery &middot;
+    <a href="index.html">Emulator</a> &middot;
+    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a>
+  </footer>
+  <script>
+    (function () {
+      "use strict";
+      var REPO = "https://github.com/ebadger/3ric";
+      var EDIT_URL = REPO + "/edit/main/web/gallery.json";
+      var grid = document.getElementById("grid");
+      var countEl = document.getElementById("count");
+
+      function el(tag, cls, text) {
+        var e = document.createElement(tag);
+        if (cls) e.className = cls;
+        if (text != null) e.textContent = text;
+        return e;
+      }
+      function isHttp(u) { return typeof u === "string" && /^https?:\/\//i.test(u); }
+
+      // Mirror index.html's Share link format exactly: an unmodified sample links as the
+      // short ?src=programs/<name>.s; an inline program uses ?code=<base64url>; either
+      // carries &org=<hex> when the source has no .org directive. The scheme is always the
+      // fixed "index.html?..." target, so these hrefs can never be a javascript: URL.
+      function runHref(entry) {
+        var suffix = entry.org ? "&org=" + encodeURIComponent(String(entry.org)) : "";
+        if (entry.code) return "index.html?code=" + entry.code + suffix;
+        if (entry.src) return "index.html?src=" + entry.src + suffix;
+        return null;
+      }
+
+      function card(entry) {
+        var c = el("article", "card");
+        c.setAttribute("role", "listitem");
+        var head = el("div", "cardhead");
+        if (entry.mode) head.appendChild(el("span", "badge", entry.mode));
+        head.appendChild(el("h2", null, entry.title || "Untitled"));
+        c.appendChild(head);
+
+        if (entry.description) c.appendChild(el("p", "desc", entry.description));
+
+        if (Array.isArray(entry.tags) && entry.tags.length) {
+          var tags = el("div", "tags");
+          entry.tags.forEach(function (t) { tags.appendChild(el("span", "tag", "#" + t)); });
+          c.appendChild(tags);
+        }
+
+        if (entry.author) {
+          var meta = el("div", "meta");
+          meta.appendChild(document.createTextNode("by "));
+          if (isHttp(entry.authorUrl)) {
+            var a = el("a", null, entry.author);
+            a.href = entry.authorUrl;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            meta.appendChild(a);
+          } else {
+            meta.appendChild(document.createTextNode(entry.author));
+          }
+          c.appendChild(meta);
+        }
+
+        var href = runHref(entry);
+        if (href) {
+          var run = el("a", "run", "\u25B6 Run & Remix");
+          run.href = href;
+          c.appendChild(run);
+        }
+        return c;
+      }
+
+      function addCard() {
+        var c = el("article", "card add");
+        c.setAttribute("role", "listitem");
+        c.appendChild(el("h2", null, "\u2795 Add your program"));
+        c.appendChild(el("p", "desc",
+          "Drop your .s source into codegen/programs/ and add an entry to gallery.json, " +
+          "then open a pull request \u2014 your program shows up here, credited to you."));
+        var run = el("a", "run", "\u270E Contribute on GitHub");
+        run.href = EDIT_URL;
+        run.target = "_blank";
+        run.rel = "noopener noreferrer";
+        c.appendChild(run);
+        return c;
+      }
+
+      function setCount(n) {
+        if (countEl) countEl.textContent = n + " program" + (n === 1 ? "" : "s");
+      }
+
+      fetch("gallery.json", { cache: "no-cache" })
+        .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+        .then(function (data) {
+          var entries = (data && Array.isArray(data.entries)) ? data.entries : [];
+          var shown = 0;
+          entries.forEach(function (entry) {
+            if (entry && entry.title) { grid.appendChild(card(entry)); shown++; }
+          });
+          grid.appendChild(addCard());
+          setCount(shown);
+        })
+        .catch(function (err) {
+          grid.appendChild(el("p", "status err",
+            "Could not load the gallery (" + ((err && err.message) || err) + "). " +
+            "You can still browse the programs on GitHub."));
+          grid.appendChild(addCard());
+          if (countEl) countEl.textContent = "";
+        });
+    })();
+  </script>
+</body>
+</html>

--- a/web/gallery.json
+++ b/web/gallery.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "_readme": "Community Gallery manifest for the 3ric web client. Each entry becomes a card on gallery.html with a one-click 'Run & Remix' link into the in-browser editor. To feature your own program: add its .s source under codegen/programs/ (build.ps1 stages every codegen/programs/*.s into web/programs/) and append an entry below, then open a pull request. Fields: title (required), author, authorUrl, mode (Hi-res|Lo-res|Text|Serial), description, tags[]; and a run target of either src ('programs/<name>.s') or an inline code (URL-safe base64 for ?code=), plus an optional org (hex load address, only when the source has no .org directive).",
+  "entries": [
+    {
+      "title": "Swarm",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Hi-res",
+      "src": "programs/swarm.s",
+      "description": "Space-invaders-style fixed shooter — hold the ground line against a descending alien swarm.",
+      "tags": ["shooter", "hi-res", "game"]
+    },
+    {
+      "title": "Rocks",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Hi-res",
+      "src": "programs/rocks.s",
+      "description": "Vector asteroids-style shooter — rotate, thrust with real inertia, and blast splitting rocks.",
+      "tags": ["shooter", "hi-res", "game"]
+    },
+    {
+      "title": "Jungle",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Hi-res",
+      "src": "programs/jungle.s",
+      "description": "Jungle platformer — dash through hazards, leap pits, grab the treasure, and beat the clock.",
+      "tags": ["platformer", "hi-res", "game"]
+    },
+    {
+      "title": "Snake",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Lo-res",
+      "src": "programs/snake.s",
+      "description": "Classic snake — grow by eating food, steer with the arrows or WASD; Q quits.",
+      "tags": ["arcade", "lo-res", "game"]
+    },
+    {
+      "title": "Game of Life",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Lo-res",
+      "src": "programs/life.s",
+      "description": "Conway's Game of Life on a toroidal 40x48 colour grid; press SPACE to reseed.",
+      "tags": ["simulation", "lo-res"]
+    },
+    {
+      "title": "Blocks",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/blocks.s",
+      "description": "Falling-block stacker — clear lines in a 10x20 well before the pieces reach the top.",
+      "tags": ["puzzle", "text", "game"]
+    },
+    {
+      "title": "Bricks",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/bricks.s",
+      "description": "Brick-breaker — clear the wall with a bouncing ball and a paddle.",
+      "tags": ["arcade", "text", "game"]
+    },
+    {
+      "title": "Paddles",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/paddles.s",
+      "description": "Two-paddle tennis — first to 7 points wins.",
+      "tags": ["arcade", "text", "game"]
+    },
+    {
+      "title": "2048",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/2048.s",
+      "description": "The classic 4x4 2048 sliding-tile puzzle — combine tiles to reach 2048.",
+      "tags": ["puzzle", "text", "game"]
+    },
+    {
+      "title": "Minesweeper",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/mines.s",
+      "description": "Turn-based Minesweeper on a 16x16 board — flag the mines and clear the field.",
+      "tags": ["puzzle", "text", "game"]
+    },
+    {
+      "title": "Hello, world",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Serial",
+      "src": "programs/hello.s",
+      "description": "A tiny greeting printed via COUT ($FDED), then BRK back to the monitor — the perfect starting point for your first 3ric program.",
+      "tags": ["demo", "serial", "starter"]
+    }
+  ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,11 @@
   }
   header .filebtn:hover { background: var(--panel); }
   header .filebtn input { display: none; }
+  header a.nav {
+    color: var(--fg); text-decoration: none; border: 1px solid var(--dim);
+    padding: 4px 10px; font-size: 12px; border-radius: 3px;
+  }
+  header a.nav:hover { background: var(--panel); }
   header input.addr {
     background: var(--bg); color: var(--fg); border: 1px solid var(--dim);
     padding: 3px 6px; font-family: inherit; font-size: 12px; border-radius: 3px; width: 4.5em;
@@ -87,6 +92,7 @@
 <body>
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
+    <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
     <button id="reset">Reset</button>
     <button id="bootdisk">Boot Disk</button>
     <label class="filebtn">Insert .woz&hellip;<input type="file" id="diskfile" accept=".woz" /></label>


### PR DESCRIPTION
## Summary

Adds a **Community Gallery** to the browser client — a static, WASM-free page (`gallery.html`) that showcases 3ric programs from a curated manifest (`gallery.json`). Each card deep-links into the editor (`?src=` / `?code=`) so a click runs the program and opens it for remixing, turning visitors into contributors. Second growth slice after the Share/Remix loop (#25).

## What changed

- **`web/gallery.json`** *(new)* — curated manifest of the 11 built-in programs with a documented schema (`title`, `author`/`authorUrl`, `mode`, `description`, `tags`, and a `src` | `code` run target + optional `org`).
- **`web/gallery.html`** *(new)* — fetches the manifest and renders one card per program; each **▶ Run & Remix** button links into `index.html`, plus an **Add your program** card linking to GitHub's in-browser editor for `gallery.json`. Builds DOM via `textContent` and only ever emits `index.html?…` links (XSS-safe); handles fetch errors gracefully.
- **`web/index.html`** — a **Gallery** link in the header.
- **`.github/workflows/deploy-pages.yml`** — the *Stage site* step now publishes `gallery.html` + `gallery.json`.
- **`web/build.ps1`** — stages every `codegen/programs/*.s` so contributor programs are picked up automatically (no more hardcoded `hello.s`).
- **`specs/WEB-CLIENT.md`** + **`web/README.md`** — document the gallery, its data flow, the manifest schema, and the PR-based submission flow.

## How the loop works

`gallery.html` → fetch `gallery.json` → render cards → click **Run & Remix** → `index.html?src=programs/<name>.s` → the existing Share/Remix loader assembles + runs it and shows the remix banner. Contribute by dropping a `.s` in `codegen/programs/` (auto-staged) and adding a `gallery.json` entry — credited to you.

## Checklist

- [x] **Spec updated** — `specs/WEB-CLIENT.md` (Contracts, Behaviour, Data flow, Dependencies, Implementation Status) updated in this commit.
- ~~Migration included~~ — no data schema/migration (a static client-side manifest).
- [x] **Contract verified** — `gallery.html`'s `runHref()` matches `index.html`'s Share/loader link format exactly; all 11 `src` targets match the loader's `^programs/([\w-]+)\.s$` regex and resolve to real sources staged by `build.ps1`.
- [x] **Tests pass** — assembler gate `ALL PASS`; a validation harness checks JSON validity, entry shape, source existence, `gallery.html` script syntax, and link-builder parity (21/21 checks).
- [x] **Only relevant files staged** — 7 files, all gallery-related.
- [x] **Second-model review** — both reviewers run, findings triaged, block below.

## Second-model review
- Reviewed diff: `7c63806...1271857`
- GPT Reviewer (`gpt-5.5`): LGTM — 0 findings
- Gemini Reviewer (`gemini-3.1-pro-preview`): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden

Both reviewers independently verified XSS safety (`textContent`, the fixed `index.html?` link scheme, the `isHttp` author-URL guard), link-builder parity with the editor loader, that all 11 `src` targets resolve, deploy staging, the `build.ps1` glob, and spec/doc accuracy. Verbatim reviewer output + scorecards are posted as a PR comment.

## Related issues

<!-- none -->
