### PR TITLE
Wire llms.txt discoverability (in-page links, robots.txt, sitemap.xml)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/gallery.html web/gallery.json web/llms.txt web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/gallery.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,11 @@
+# 3ric — AI code-generation guide (pointer)
+
+The machine-readable 65C02 code-generation guide for AI coding tools is published at:
+
+    https://ebadger.github.io/3ric/llms.txt
+
+Its source lives in this repository at `web/llms.txt` (the canonical copy — edit that one).
+This root file is a discovery breadcrumb for tools that look for `llms.txt` at the repo root.
+
+To contribute a program with an AI coding tool (GitHub Copilot, Cursor, ChatGPT, Claude, …),
+see `CONTRIBUTING.md`.

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -45,6 +45,13 @@ host it as static files.
   gives AI coding tools a 65C02 codegen quickstart plus links to the platform reference
   (`codegen/platform/*`), a worked example, the live editor, and the gallery submission flow
   (`CONTRIBUTING.md`). Static text; staged into `_site/` by the deploy workflow.
+- **Discoverability of `llms.txt`:** `index.html` advertises it via a
+  `<link rel="alternate" type="text/markdown" href="llms.txt">` plus a visible footer link
+  (mirrored in `gallery.html`), and committed `robots.txt` + `sitemap.xml` list it for
+  crawlers. NOTE: on a GitHub *project* page the served root is `…/3ric/`, not the domain
+  root, so `robots.txt`/`sitemap.xml` there are advisory (crawlers honour the domain-root
+  `robots.txt`) and become authoritative only under a custom domain — the in-page links and
+  the human copy-paste prompt (`CONTRIBUTING.md`) are the discovery paths that work today.
 
 ## Behaviour / Rules
 
@@ -88,9 +95,9 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 - **Upstream:** the VM core (`EMULATOR.md`), the ROM/font/disk/SD data (`ROM-SOFTWARE.md`),
   and `codegen/tools/asm6502.mjs` (staged for the in-browser assembler — `CODEGEN.md`).
 - **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`) — its **Stage
-  site** step stages `gallery.html` + `gallery.json` + `llms.txt` (alongside `index.html` and
-  `programs/`) into `_site/`; the public users of the demo, and AI coding tools that fetch
-  `llms.txt`.
+  site** step stages `gallery.html` + `gallery.json` + `llms.txt` + `robots.txt` +
+  `sitemap.xml` (alongside `index.html` and `programs/`) into `_site/`; the public users of
+  the demo, and AI coding tools that fetch `llms.txt`.
 
 ## Implementation Status
 
@@ -103,7 +110,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |
 | AI-contributor entry point (`llms.txt`) | Shipped | machine-readable 65C02 codegen quickstart + links; published at the site root, staged by the deploy workflow. |
-| Adjustable CPU clock | Shipped | frontend-only pacing. |
+| `llms.txt` discoverability | Shipped | `<link rel="alternate">` + footer links in `index.html`/`gallery.html`; `robots.txt` + `sitemap.xml` staged (advisory on the project-page root; authoritative under a custom domain). |
 | Adjustable CPU clock | Shipped | frontend-only pacing; native **1× ≈ 1.57 MHz** (25.175 MHz VGA dot clock ÷ 16) default. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -71,7 +71,8 @@
     3ric Program Gallery &middot;
     <a href="index.html">Emulator</a> &middot;
     <a href="https://github.com/ebadger/3ric">Source</a> &middot;
-    <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a>
+    <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a> &middot;
+    <a href="llms.txt">For AI tools</a>
   </footer>
   <script>
     (function () {

--- a/web/index.html
+++ b/web/index.html
@@ -88,6 +88,7 @@
   }
   #ide .remix.show { display: block; }
 </style>
+<link rel="alternate" type="text/markdown" title="llms.txt — 65C02 codegen guide for AI tools" href="llms.txt" />
 </head>
 <body>
   <header>
@@ -169,6 +170,9 @@
     resulting <code>.PRG</code> to <code>BRUN</code> on hardware. Hit <strong>Share</strong>
     to copy a one-click link to your program (a short <code>?src=</code> for the built-in
     samples, or your source inlined in <code>?code=</code>).
+    <br />Building with an AI tool? Point it at <a href="llms.txt"><code>llms.txt</code></a>
+    &mdash; a machine-readable 65C02 codegen guide &mdash; or see
+    <a href="https://github.com/ebadger/3ric/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING</a>.
   </footer>
 
   <script src="badger6502.js"></script>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,12 @@
+# 3ric — https://ebadger.github.io/3ric/
+#
+# NOTE: This is a GitHub *project* page, so web crawlers read the authoritative
+# robots rules from the DOMAIN root (https://ebadger.github.io/robots.txt), not
+# this file. This copy documents intent and becomes authoritative if 3ric moves
+# to its own custom domain.
+User-agent: *
+Allow: /
+
+# Machine-readable 65C02 code-generation guide for AI coding tools:
+#   https://ebadger.github.io/3ric/llms.txt
+Sitemap: https://ebadger.github.io/3ric/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ebadger.github.io/3ric/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ebadger.github.io/3ric/gallery.html</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ebadger.github.io/3ric/llms.txt</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## What & why

PR #28 published [`web/llms.txt`](https://ebadger.github.io/3ric/llms.txt) — the machine-readable 65C02 codegen guide — at the site root, but **nothing advertised it**. This wires discovery so AI coding tools and crawlers can actually find it, answering "how will the LLMs find `llms.txt`?"

## Changes

| File | Change |
|------|--------|
| `web/index.html` | `<link rel="alternate" type="text/markdown" href="llms.txt">` in `<head>` + a visible footer link to `llms.txt` and `CONTRIBUTING.md` — machine-discoverable *and* human-visible on the landing page |
| `web/gallery.html` | "For AI tools" footer link to `llms.txt` |
| `web/robots.txt` *(new)* | allow-all, `Sitemap:` reference, comment pointing to `llms.txt` |
| `web/sitemap.xml` *(new)* | lists `/`, `gallery.html`, `llms.txt` under the site base |
| `llms.txt` *(new, repo root)* | thin pointer to the published guide + `CONTRIBUTING.md` for in-repo agents that check the repo root — duplicates no technical facts, so it can't drift |
| `.github/workflows/deploy-pages.yml` | stage `web/robots.txt` + `web/sitemap.xml` |
| `specs/WEB-CLIENT.md` | spec-first: discoverability Contracts bullet + Status row + staging list; drive-by dedup (below) |

## Honest scope

On a GitHub **project page** the served root is `…github.io/3ric/`, not the domain root — so `robots.txt`/`sitemap.xml` under `/3ric/` are **advisory only** (crawlers read the *domain-root* robots.txt) and become authoritative only under a custom domain. The spec and `robots.txt` say so plainly. What works **today** is the in-page `<link>` + footer links and the human copy-paste prompt from #28; this PR maximizes discoverability within those constraints and lays the groundwork for a custom domain later.

## Drive-by fix

Removed a **pre-existing duplicate** "Adjustable CPU clock" row from the `WEB-CLIENT.md` status table (two rows had merged in from earlier PRs). Kept the more detailed one. Tightly coupled to the Status-table edit in this PR.

## Validation

- `sitemap.xml` is well-formed XML (parsed via `[xml]`); every `<loc>` maps to a real staged file under the site base.
- `index.html`/`gallery.html` `href="llms.txt"` links resolve on the deployed site root; external `CONTRIBUTING.md` link uses `rel="noopener noreferrer"`.
- `gallery.html` inline script still parses (unaffected by the footer edit).
- Deploy stages `robots.txt` + `sitemap.xml` (and still `llms.txt`).
- Pre-push gate (learnings budget + 65C02 assembler suite) → **ALL PASS**.

## Second-model review

- **Reviewed range:** `69d7909...0a1eb7c` (staged diff, 7 files, +56/−6)
- **GPT-5.5:** LGTM — 0 findings
- **Gemini 3.1 Pro:** LGTM — 0 findings
- **Resolved:** 0 fixed / 0 overridden

Verbatim reviewer output + scorecards posted as a PR comment below.

🤖 Generated with GitHub Copilot CLI. Do not merge without ebadger's review.
