### PR TITLE
Add a Support (GitHub Sponsors) call-to-action to the web footers

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -52,6 +52,11 @@ host it as static files.
   root, so `robots.txt`/`sitemap.xml` there are advisory (crawlers honour the domain-root
   `robots.txt`) and become authoritative only under a custom domain — the in-page links and
   the human copy-paste prompt (`CONTRIBUTING.md`) are the discovery paths that work today.
+- **Support / funding call-to-action:** the `index.html` and `gallery.html` footers link to
+  the project's GitHub Sponsors page (`https://github.com/sponsors/ebadger`), the primary
+  target declared in `.github/FUNDING.yml`, so visitors to the live emulator — the project's
+  main traffic surface — can fund it. Static markup, external link
+  (`target="_blank" rel="noopener noreferrer"`); no new runtime behaviour.
 
 ## Behaviour / Rules
 
@@ -111,6 +116,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |
 | AI-contributor entry point (`llms.txt`) | Shipped | machine-readable 65C02 codegen quickstart + links; published at the site root, staged by the deploy workflow. |
 | `llms.txt` discoverability | Shipped | `<link rel="alternate">` + footer links in `index.html`/`gallery.html`; `robots.txt` + `sitemap.xml` staged (advisory on the project-page root; authoritative under a custom domain). |
+| Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |
 | Adjustable CPU clock | Shipped | frontend-only pacing; native **1× ≈ 1.57 MHz** (25.175 MHz VGA dot clock ÷ 16) default. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -72,7 +72,8 @@
     <a href="index.html">Emulator</a> &middot;
     <a href="https://github.com/ebadger/3ric">Source</a> &middot;
     <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a> &middot;
-    <a href="llms.txt">For AI tools</a>
+    <a href="llms.txt">For AI tools</a> &middot;
+    <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support</a>
   </footer>
   <script>
     (function () {

--- a/web/index.html
+++ b/web/index.html
@@ -173,6 +173,8 @@
     <br />Building with an AI tool? Point it at <a href="llms.txt"><code>llms.txt</code></a>
     &mdash; a machine-readable 65C02 codegen guide &mdash; or see
     <a href="https://github.com/ebadger/3ric/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING</a>.
+    <br />Enjoying 3ric? <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support the project</a>
+    &mdash; sponsorship funds parts, boards, and more build videos.
   </footer>
 
   <script src="badger6502.js"></script>


### PR DESCRIPTION
## What & why

The live browser emulator is 3ric's main traffic surface, but nothing there invited visitors to fund the project. This adds a **☕ Support** call-to-action to both web footers, pointing at [GitHub Sponsors](https://github.com/sponsors/ebadger) — the target already declared in `.github/FUNDING.yml`.

## Changes

| File | Change |
|------|--------|
| `web/index.html` | Footer line: *"Enjoying 3ric? ☕ Support the project — sponsorship funds parts, boards, and more build videos."* → `github.com/sponsors/ebadger` |
| `web/gallery.html` | Appends "· ☕ Support" to the existing footer link row, same target |
| `specs/WEB-CLIENT.md` | Spec-first: "Support / funding call-to-action" Contracts bullet + Implementation Status row |

- Both links are external, `target="_blank" rel="noopener noreferrer"`; the ☕ glyph is the numeric HTML entity `&#9749;` (U+2615).
- **Static markup only** — no runtime behaviour; `gallery.html`'s inline card-builder script is untouched (still parses).

## Owner action to make it live

Enabling GitHub Sponsors on the account (github.com/sponsors → onboard + connect Stripe) is a **separate manual step**. Until then the link resolves but shows "not accepting sponsorships." The link itself is correct and future-proof.

## Validation

- Both new external links carry `rel="noopener noreferrer"`; `<a>` tags balanced and nested in `<footer>`.
- `&#9749;` glyph count = 2 (one per footer); `gallery.html` inline script parses (`new vm.Script`) — unchanged.
- Pre-push gate (learnings budget + 65C02 assembler suite) → **ALL PASS**.

## Second-model review

- **Reviewed diff:** the 3-file, +10/−1 change below (originally reviewed at `0a1eb7c...e9d6764`; rebased onto `main` after #29 merged into a single clean commit `b4e45ae` — diff content unchanged).
- **GPT-5.5:** LGTM — 0 findings
- **Gemini 3.1 Pro:** LGTM — 0 findings
- **Resolved:** 0 fixed / 0 overridden

Verbatim reviewer output + scorecards posted as a PR comment below.

🤖 Generated with GitHub Copilot CLI. Do not merge without ebadger's review.
