### PR TITLE
Add a BACKERS recognition wall and a Sponsor badge to the README

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,0 +1,39 @@
+# Backers 💜
+
+3ric is built in public — a from-scratch, Apple-II-class 65C02 computer with real
+hardware *and* a cycle-honest browser emulator. It's kept free and open by people who
+want to see it grow. **Sponsorships pay for parts, PCB fabrication, and more build
+videos**, and keep the zero-install WebAssembly build free for everyone to learn from.
+
+→ **[Become a sponsor](https://github.com/sponsors/ebadger)** · see also
+[`.github/FUNDING.yml`](.github/FUNDING.yml) and the
+[Support section of the README](README.md#support).
+
+Every sponsor is credited on this page (unless you'd rather stay anonymous — just say so).
+Thank you for keeping the soldering iron warm. 🙏
+
+## What your sponsorship funds
+
+- **Parts & boards** — 65C02s, GALs, RAM/ROM, connectors, and bare-PCB fab runs.
+- **Build videos** — filming, editing, and hosting the episode-by-episode series.
+- **The browser emulator** — keeping the free, no-install WebAssembly build alive and
+  improving.
+
+## Sponsors
+
+> No sponsors yet — **[be the first](https://github.com/sponsors/ebadger)**, and your name
+> (and a link, if you like) will appear right here. 🥇
+
+<!--
+  As sponsors come in, list them here — most recent first. Suggested grouping by tier;
+  keep entries factual and only add someone with their consent:
+
+  ### 💎 Board backers
+  - [Name](https://link) — optional one-line note
+
+  ### ⭐ Sponsors
+  - [Name](https://link)
+
+  ### ☕ Supporters
+  - Name
+-->

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <p align="center">
   <a href="https://ebadger.github.io/3ric/"><img alt="Live demo" src="https://img.shields.io/badge/%E2%96%B6_try_it-live_in_your_browser-2ea44f"></a>
   <a href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq"><img alt="Build series" src="https://img.shields.io/badge/build_series-YouTube-red"></a>
+  <a href="https://github.com/sponsors/ebadger"><img alt="Sponsor" src="https://img.shields.io/badge/%E2%9D%A4_sponsor-GitHub-ea4aaa"></a>
   <img alt="CPU" src="https://img.shields.io/badge/CPU-65C02-8957e5">
   <img alt="Runs in WebAssembly" src="https://img.shields.io/badge/runs_in-WebAssembly-654ff0">
   <a href="LICENSE"><img alt="Code license: MIT" src="https://img.shields.io/badge/code-MIT-blue"></a>
@@ -158,9 +159,11 @@ templates under [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
 
 ## Support
 
-If this project helps you learn or you just enjoy the build, you can support it via the
-**Sponsor** button on this repository (see [`.github/FUNDING.yml`](.github/FUNDING.yml)).
-Sponsorship funds parts, boards, and more build videos.
+If this project helps you learn or you just enjoy the build, please consider
+**[sponsoring it on GitHub][sponsor]** — or use the **Sponsor** button at the top of this
+repository (see [`.github/FUNDING.yml`](.github/FUNDING.yml)). Sponsorship funds parts,
+boards, and more build videos, and **every sponsor is credited in
+[`BACKERS.md`](BACKERS.md)**.
 
 ## License
 
@@ -177,3 +180,4 @@ before redistributing.
 
 [demo]: https://ebadger.github.io/3ric/
 [youtube]: https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq
+[sponsor]: https://github.com/sponsors/ebadger


### PR DESCRIPTION
## What & why

GitHub Sponsors is now live, so this gives sponsors something to convert toward and a public thank-you — a classic social-proof + reward loop.

## Changes

| File | Change |
|------|--------|
| `BACKERS.md` *(new)* | A recognition wall: thanks sponsors, explains what sponsorship funds (parts, PCB fab, build videos, the free browser emulator), links to the Sponsors page. Honest "be the first" placeholder (no names yet) with a commented, tier-grouped structure ready to fill in. |
| `README.md` | Adds a ❤ **Sponsor** badge to the header badge row (→ `github.com/sponsors/ebadger`); expands the **Support** section to link straight to the Sponsors page and credit sponsors in `BACKERS.md`; adds a `[sponsor]` link reference. |

## Scope / review

**Docs-only, no behavioural effect** — panel-exempt per [`docs/CODE-REVIEW-PANEL.md`](../blob/main/docs/CODE-REVIEW-PANEL.md) scope (README + narrative docs are listed as non-product prose). No spec change: no spec layer governs a repo-root thank-you file, and adding one would be net-new process machinery.

## Validation

- Relative links resolve (`README.md#support`, `.github/FUNDING.yml`, `BACKERS.md`); the `## Support` anchor exists; `[sponsor]` reference is defined **and** used.
- Sponsor badge SVG renders (shields.io → HTTP 200, `image/svg+xml`).
- Pre-push gate (learnings budget + 65C02 assembler suite) → **ALL PASS**.

## Follow-ups you drive (dashboard-only)

- Add **sponsor tiers** with tangible perks (esp. a real bare PCB at a higher tier — the strongest lever for a hardware project).
- Set a **funding goal** (e.g. "$50/mo → order a batch of boards").
- As sponsors arrive, I can wire their names into `BACKERS.md` (or automate it later).

🤖 Generated with GitHub Copilot CLI. Do not merge without ebadger's review.
