### PR TITLE
Add 8-lesson 65C02 game dev tutorial series + live-site entry points

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/gallery.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/gallery.html web/tutorials.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/codegen/programs/tut1_hello.s
+++ b/codegen/programs/tut1_hello.s
@@ -1,0 +1,45 @@
+; ============================================================================
+; Lesson 1 — HELLO, 3RIC        (tutorial: docs/tutorials/01-hello.md)
+;
+; Your very first 3ric program. It clears the screen, prints two lines, and
+; stops. Every line is explained step-by-step in the lesson.
+;
+;   Try it in the browser (nothing to install):
+;     https://ebadger.github.io/3ric/?src=programs/tut1_hello.s
+;
+;   Verify it locally with the headless emulator:
+;     node codegen/tools/run6502.mjs codegen/programs/tut1_hello.s \
+;         --expect-serial "HELLO, 3RIC" --expect-halt brk-monitor
+;
+;   On real hardware:  BRUN TUT1_HELLO.PRG 0800
+; ============================================================================
+
+        .org $0800          ; Load + run address. A .PRG starts executing here.
+
+; ---- ROM routines we borrow (addresses from the platform reference) ---------
+COUT    = $FDED             ; print the character in A to the screen (+ serial)
+HOME    = $FC58             ; clear the text screen, cursor to the top-left
+
+; ---- the program ------------------------------------------------------------
+        jsr HOME            ; start on a clean screen
+
+        ldx #0              ; X walks through the message, one byte at a time
+print:  lda msg,x           ; A = the X-th byte of msg   (LDA addr,X = "indexed")
+        beq done            ; a 0 byte marks the end of the text -> finished
+        jsr COUT            ; print the character now in A
+        inx                 ; advance to the next byte
+        bne print           ; loop back (BNE is always taken until X would wrap)
+
+done:   brk                 ; hand control back to the monitor: program finished
+
+; ---- data -------------------------------------------------------------------
+; COUT wants ASCII with the HIGH BIT SET, so 'H' ($48) is stored as $C8.
+; $8D is a carriage return (start a new line). The final $00 stops the loop.
+msg:
+        .byte $C8,$C5,$CC,$CC,$CF,$AC,$A0      ; "HELLO, "
+        .byte $B3,$D2,$C9,$C3                  ; "3RIC"
+        .byte $8D                              ; new line
+        .byte $CC,$C5,$D4,$A7,$D3,$A0          ; "LET'S "
+        .byte $CD,$C1,$CB,$C5,$A0              ; "MAKE "
+        .byte $C7,$C1,$CD,$C5,$D3,$AE          ; "GAMES."
+        .byte $8D,$00                          ; new line, end marker

--- a/codegen/programs/tut2_screen.s
+++ b/codegen/programs/tut2_screen.s
@@ -1,0 +1,115 @@
+; ============================================================================
+; Lesson 2 — DRAWING ON THE TEXT SCREEN     (tutorial: docs/tutorials/02-text-screen.md)
+;
+; The text screen is just memory at $0400. This program clears it, then draws a
+; bordered box, a centered title, and a HUD line -- all by storing bytes into
+; screen RAM directly (no COUT).
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut2_screen.s
+;   Verify:   node codegen/tools/run6502.mjs codegen/programs/tut2_screen.s \
+;                 --expect-mem 0400=A3 --expect-mem 050D=B3 --expect-halt idle
+; ============================================================================
+
+        .org $0800
+
+; ---- zero-page pointers (2 bytes each) --------------------------------------
+sptr    = $08               ; points at the base of a text row
+strp    = $0A               ; points at a string to draw
+
+; ---- ROM ---------------------------------------------------------------------
+HOME    = $FC58             ; clear the text screen to spaces
+
+; ---- screen character codes (normal video = high bit set) -------------------
+BORDER  = $A3               ; '#'  ($23 | $80)
+
+        jsr HOME
+
+; --- top and bottom border rows (fill all 40 columns) ------------------------
+        ldx #0
+        jsr setrow
+        jsr fillrow
+        ldx #23
+        jsr setrow
+        jsr fillrow
+
+; --- left and right border columns on the interior rows 1..22 ----------------
+        ldx #1
+sides:  jsr setrow
+        lda #BORDER
+        ldy #0
+        sta (sptr),y        ; left edge, column 0
+        ldy #39
+        sta (sptr),y        ; right edge, column 39
+        inx
+        cpx #23
+        bne sides
+
+; --- centered title on row 2 -------------------------------------------------
+        ldx #2
+        jsr setrow
+        lda #<title
+        sta strp
+        lda #>title
+        sta strp+1
+        lda #13             ; start column (centers the 14-char title)
+        jsr puts
+
+; --- HUD on row 21 -----------------------------------------------------------
+        ldx #21
+        jsr setrow
+        lda #<hud
+        sta strp
+        lda #>hud
+        sta strp+1
+        lda #2
+        jsr puts
+
+spin:   bra spin            ; keep the picture on screen (a game never "returns")
+
+; ============================================================================
+; Helpers
+; ============================================================================
+
+; setrow: sptr = base address of text row X (0..23), read from the row tables.
+; Rows are NOT stored back-to-back in memory, so we look the base up in a table.
+setrow: lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        rts
+
+; fillrow: fill all 40 columns of the row at sptr with the border character.
+fillrow: ldy #39
+        lda #BORDER
+fr:     sta (sptr),y
+        dey
+        bpl fr
+        rts
+
+; puts: draw the NUL-terminated string at strp onto row sptr, starting at the
+;       column passed in A. Sets the high bit so the text shows in normal video.
+puts:   clc
+        adc sptr            ; slide the row pointer right to the start column
+        sta sptr
+        bcc pnc
+        inc sptr+1
+pnc:    ldy #0
+pl:     lda (strp),y        ; next source character
+        beq pdone           ; 0 marks the end of the string
+        ora #$80            ; normal-video (high bit set)
+        sta (sptr),y        ; store into screen memory
+        iny
+        bne pl
+pdone:  rts
+
+; ---- data -------------------------------------------------------------------
+title:  .asciiz "3RIC ADVENTURE"
+hud:    .asciiz "SCORE:000  LIVES:3"
+
+; text-row base addresses (low bytes, then high bytes), rows 0..23
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut3_move.s
+++ b/codegen/programs/tut3_move.s
@@ -1,0 +1,179 @@
+; ============================================================================
+; Lesson 3 — INPUT AND THE GAME LOOP     (tutorial: docs/tutorials/03-input.md)
+;
+; Read the keyboard and walk a hero '@' around a bordered box. This is the
+; universal game loop: READ a key -> UPDATE the world -> DRAW it -> repeat.
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut3_move.s
+;   Verify:   node codegen/tools/run6502.mjs codegen/programs/tut3_move.s \
+;                 --expect-mem 0x063C=0xC0 --expect-halt idle
+;   Controls: W/A/S/D (or arrow keys) move, Q quits.
+; ============================================================================
+
+        .org $0800
+
+; ---- variables (zero page) --------------------------------------------------
+hx      = $06               ; hero column (1..38)
+hy      = $07               ; hero row    (1..22)
+sptr    = $08               ; (2) screen row pointer
+strp    = $0A               ; (2) string pointer
+
+; ---- hardware / ROM ---------------------------------------------------------
+KBD     = $C000             ; keyboard data; bit 7 = a key is ready
+KBDSTRB = $C010             ; touch to clear the key-ready strobe
+HOME    = $FC58
+
+; ---- character codes (normal video) -----------------------------------------
+HERO    = $C0               ; '@'
+SPACE   = $A0
+BORDER  = $A3               ; '#'
+
+        jsr HOME
+        jsr drawborder
+
+        ; instructions, tucked into the top border row
+        ldx #0
+        jsr setrow
+        lda #<hint
+        sta strp
+        lda #>hint
+        sta strp+1
+        lda #10
+        jsr puts
+
+        ; place the hero in the middle and draw it
+        lda #20
+        sta hx
+        lda #12
+        sta hy
+        lda #HERO
+        jsr putcell
+
+; ---- THE GAME LOOP ----------------------------------------------------------
+loop:   lda KBD             ; READ: is a key waiting?
+        bpl loop            ;   bit 7 clear -> none yet, keep polling
+        bit KBDSTRB         ;   clear the strobe so we'll see the next press
+        and #$7F            ;   drop the ready bit -> plain ASCII
+
+        cmp #'Q'            ; quit?
+        beq quit
+
+        pha                 ; remember the key
+        lda #SPACE
+        jsr putcell         ; erase the hero at its CURRENT cell
+        pla
+
+        ; UPDATE: pick a direction from the key (WASD or arrow codes)
+        cmp #'W'
+        beq up
+        cmp #'S'
+        beq down
+        cmp #'A'
+        beq left
+        cmp #'D'
+        beq right
+        cmp #$0B            ; up-arrow
+        beq up
+        cmp #$0A            ; down-arrow
+        beq down
+        cmp #$08            ; left-arrow
+        beq left
+        cmp #$15            ; right-arrow
+        beq right
+        bra redraw          ; some other key: don't move
+
+up:     lda hy
+        cmp #2
+        bcc redraw          ; already at the top interior row
+        dec hy
+        bra redraw
+down:   lda hy
+        cmp #22
+        bcs redraw          ; already at the bottom interior row
+        inc hy
+        bra redraw
+left:   lda hx
+        cmp #2
+        bcc redraw
+        dec hx
+        bra redraw
+right:  lda hx
+        cmp #38
+        bcs redraw
+        inc hx
+
+redraw: lda #HERO           ; DRAW: stamp the hero at its new cell
+        jsr putcell
+        bra loop            ; ...and around we go
+
+quit:   brk
+
+; ============================================================================
+; Helpers
+; ============================================================================
+
+; putcell: draw the character in A at (row = hy, column = hx).
+putcell: ldy hx
+        ldx hy
+        pha
+        lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        pla
+        sta (sptr),y
+        rts
+
+drawborder: ldx #0
+        jsr setrow
+        jsr fillrow
+        ldx #23
+        jsr setrow
+        jsr fillrow
+        ldx #1
+db:     jsr setrow
+        lda #BORDER
+        ldy #0
+        sta (sptr),y
+        ldy #39
+        sta (sptr),y
+        inx
+        cpx #23
+        bne db
+        rts
+
+setrow: lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        rts
+
+fillrow: ldy #39
+        lda #BORDER
+fr:     sta (sptr),y
+        dey
+        bpl fr
+        rts
+
+puts:   clc
+        adc sptr
+        sta sptr
+        bcc pnc
+        inc sptr+1
+pnc:    ldy #0
+pl:     lda (strp),y
+        beq pdone
+        ora #$80
+        sta (sptr),y
+        iny
+        bne pl
+pdone:  rts
+
+hint:   .asciiz " MOVE: WASD   QUIT: Q "
+
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut4_lores.s
+++ b/codegen/programs/tut4_lores.s
@@ -1,0 +1,202 @@
+; ============================================================================
+; Lesson 4 — COLOR WITH LO-RES GRAPHICS   (tutorial: docs/tutorials/04-lores.md)
+;
+; Switch the machine into 40x48 lo-res colour, draw a 16-colour palette, then
+; steer a colour-cycling block around the screen with the keyboard.
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut4_lores.s
+;   Verify:   node codegen/tools/run6502.mjs codegen/programs/tut4_lores.s \
+;                 --expect-mem 0x050F=0x33 --expect-mem 0x063C=0x0F --expect-halt idle
+;   Controls: W/A/S/D move, Q quits.
+; ============================================================================
+
+        .org $0800
+
+; ---- plot arguments + scratch (zero page) -----------------------------------
+px      = $06               ; plot X (0..39)
+py      = $07               ; plot Y (0..47)
+pcolor  = $08               ; plot colour (0..15)
+ptmp    = $09               ; plot scratch
+sptr    = $0A               ; (2) screen row pointer
+
+; ---- player state -----------------------------------------------------------
+plx     = $0C               ; player X
+ply     = $0D               ; player Y
+plcol   = $0E               ; player colour
+
+; ---- soft switches (touch with LDA; any access selects) ---------------------
+KBD     = $C000
+KBDSTRB = $C010
+TXTCLR  = $C050             ; graphics on (text off)
+TXTSET  = $C051             ; text on
+FULLSCR = $C052             ; full screen (no mixed text window)
+LOWSCR  = $C054             ; display page 1
+LORES   = $C056             ; lo-res graphics
+
+; ---- a few lo-res colours (index 0..15 into the palette) --------------------
+BLACK   = 0
+WHITE   = 15
+
+        lda TXTCLR          ; graphics...
+        lda FULLSCR         ; ...full screen...
+        lda LORES           ; ...lo-res...
+        lda LOWSCR          ; ...page 1
+        lda KBDSTRB         ; clear any stray key
+        jsr clrscreen       ; paint the whole field black
+
+; --- draw a 16-colour palette: cols 12..27, rows 4..7, colour = col-12 -------
+        lda #4
+        sta py
+prow:   lda #12
+        sta px
+pcol:   lda px
+        sec
+        sbc #12
+        sta pcolor          ; colour = px - 12  (0..15)
+        jsr plot
+        inc px
+        lda px
+        cmp #28
+        bne pcol
+        inc py
+        lda py
+        cmp #8
+        bne prow
+
+; --- place the player block and enter the loop -------------------------------
+        lda #20
+        sta plx
+        lda #24
+        sta ply
+        lda #WHITE
+        sta plcol
+        jsr drawplayer
+
+loop:   lda KBD
+        bpl loop
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        beq quit
+
+        pha
+        jsr eraseplayer     ; blank the old cell (plot BLACK)
+        pla
+
+        cmp #'W'
+        beq up
+        cmp #'S'
+        beq down
+        cmp #'A'
+        beq left
+        cmp #'D'
+        beq right
+        cmp #$0B
+        beq up
+        cmp #$0A
+        beq down
+        cmp #$08
+        beq left
+        cmp #$15
+        beq right
+        bra redraw
+
+up:     lda ply
+        beq redraw
+        dec ply
+        bra redraw
+down:   lda ply
+        cmp #47
+        bcs redraw
+        inc ply
+        bra redraw
+left:   lda plx
+        beq redraw
+        dec plx
+        bra redraw
+right:  lda plx
+        cmp #39
+        bcs redraw
+        inc plx
+
+redraw: inc plcol           ; cycle the colour, skipping black (0)
+        lda plcol
+        cmp #16
+        bne rdok
+        lda #1
+        sta plcol
+rdok:   jsr drawplayer
+        bra loop
+
+quit:   lda TXTSET          ; back to text so the monitor is readable
+        brk
+
+; ============================================================================
+; PLOT — light one lo-res pixel (px, py) in colour pcolor.
+;
+; Lo-res shares the text page: each screen byte is TWO stacked pixels. The low
+; nibble is the upper pixel (even Y), the high nibble the lower one (odd Y). So
+; a lo-res row Y lives in text row Y/2, and we edit just one nibble.
+; ============================================================================
+plot:   lda py
+        lsr a               ; text row = py / 2
+        tax
+        lda ROWL,x          ; sptr = base of that text row
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        ldy px
+        lda py
+        and #1
+        bne plodd
+        lda (sptr),y        ; even Y -> replace the LOW nibble
+        and #$F0
+        ora pcolor
+        sta (sptr),y
+        rts
+plodd:  lda pcolor          ; odd Y -> replace the HIGH nibble (colour << 4)
+        asl a
+        asl a
+        asl a
+        asl a
+        sta ptmp
+        lda (sptr),y
+        and #$0F
+        ora ptmp
+        sta (sptr),y
+        rts
+
+; draw / erase the player using the plot argument registers
+drawplayer: lda plx
+        sta px
+        lda ply
+        sta py
+        lda plcol
+        sta pcolor
+        jmp plot
+eraseplayer: lda plx
+        sta px
+        lda ply
+        sta py
+        lda #BLACK
+        sta pcolor
+        jmp plot
+
+; clear the whole lo-res field ($0400-$07FF) to black
+clrscreen: lda #0
+        ldx #0
+cs:     sta $0400,x
+        sta $0500,x
+        sta $0600,x
+        sta $0700,x
+        inx
+        bne cs
+        rts
+
+; text-row base addresses (low, then high), rows 0..23
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut5_bounce.s
+++ b/codegen/programs/tut5_bounce.s
@@ -5,7 +5,7 @@
 ; needed to make it go -- this is the first program with a real "game loop".
 ;
 ;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut5_bounce.s
-;   Verify:   node verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 ...
+;   Verify:   node codegen/tools/verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 ...
 ;   Controls: Q quits.
 ; ============================================================================
 

--- a/codegen/programs/tut5_bounce.s
+++ b/codegen/programs/tut5_bounce.s
@@ -1,0 +1,183 @@
+; ============================================================================
+; Lesson 5 — MOTION AND COLLISION   (tutorial: docs/tutorials/05-motion.md)
+;
+; A ball moves on its OWN every frame and bounces off the four walls. No key is
+; needed to make it go -- this is the first program with a real "game loop".
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut5_bounce.s
+;   Verify:   node verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 ...
+;   Controls: Q quits.
+; ============================================================================
+
+        .org $0800
+
+; ---- ball state -------------------------------------------------------------
+bx      = $06               ; ball X (0..39)
+by      = $07               ; ball Y (0..47)
+vx      = $08               ; X velocity: $01 (right) or $FF (left)
+vy      = $09               ; Y velocity: $01 (down)  or $FF (up)
+bcol    = $0A               ; ball colour
+
+; ---- plot arguments + scratch (kept separate from ball state) ---------------
+px      = $10
+py      = $11
+pcolor  = $12
+ptmp    = $13
+sptr    = $14               ; (2)
+
+KBD     = $C000
+KBDSTRB = $C010
+TXTCLR  = $C050
+TXTSET  = $C051
+FULLSCR = $C052
+LOWSCR  = $C054
+LORES   = $C056
+
+BLACK   = 0
+WHITE   = 15
+
+XMAX    = 39
+YMAX    = 47
+
+        lda TXTCLR
+        lda FULLSCR
+        lda LORES
+        lda LOWSCR
+        lda KBDSTRB
+        jsr clrscreen
+
+        lda #5              ; start near the top-left, heading down-right
+        sta bx
+        sta by
+        lda #$01
+        sta vx
+        sta vy
+        lda #WHITE
+        sta bcol
+
+loop:   lda KBD             ; non-blocking quit check
+        bpl move
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        beq quit
+
+move:   jsr eraseball
+
+; --- X axis: step, and reflect at the walls --------------------------------
+        lda vx
+        bmi xneg
+        lda bx              ; moving right
+        cmp #XMAX
+        bcc xinc            ; not at the wall yet
+        lda #$FF            ; hit right wall -> go left
+        sta vx
+        dec bx
+        bra ymove
+xinc:   inc bx
+        bra ymove
+xneg:   lda bx              ; moving left
+        beq xflip           ; at left wall (0)
+        dec bx
+        bra ymove
+xflip:  lda #$01
+        sta vx
+        inc bx
+
+; --- Y axis: same idea, top and bottom -------------------------------------
+ymove:  lda vy
+        bmi yneg
+        lda by              ; moving down
+        cmp #YMAX
+        bcc yinc
+        lda #$FF            ; hit bottom -> go up
+        sta vy
+        dec by
+        bra draw
+yinc:   inc by
+        bra draw
+yneg:   lda by              ; moving up
+        beq yflip           ; at top (0)
+        dec by
+        bra draw
+yflip:  lda #$01
+        sta vy
+        inc by
+
+draw:   jsr drawball
+        jsr delay
+        bra loop
+
+quit:   lda TXTSET
+        brk
+
+; ---- draw / erase the ball via the plot argument registers ------------------
+drawball: lda bx
+        sta px
+        lda by
+        sta py
+        lda bcol
+        sta pcolor
+        jmp plot
+eraseball: lda bx
+        sta px
+        lda by
+        sta py
+        lda #BLACK
+        sta pcolor
+        jmp plot
+
+; ---- PLOT: one lo-res pixel (px,py) in pcolor (see Lesson 4) -----------------
+plot:   lda py
+        lsr a
+        tax
+        lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        ldy px
+        lda py
+        and #1
+        bne plodd
+        lda (sptr),y
+        and #$F0
+        ora pcolor
+        sta (sptr),y
+        rts
+plodd:  lda pcolor
+        asl a
+        asl a
+        asl a
+        asl a
+        sta ptmp
+        lda (sptr),y
+        and #$0F
+        ora ptmp
+        sta (sptr),y
+        rts
+
+; ---- a short delay so the eye can follow the ball ---------------------------
+delay:  ldx #$40
+dl1:    ldy #$FF
+dl2:    dey
+        bne dl2
+        dex
+        bne dl1
+        rts
+
+clrscreen: lda #0
+        ldx #0
+cs:     sta $0400,x
+        sta $0500,x
+        sta $0600,x
+        sta $0700,x
+        inx
+        bne cs
+        rts
+
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut6_catch.s
+++ b/codegen/programs/tut6_catch.s
@@ -1,0 +1,248 @@
+; ============================================================================
+; Lesson 6 — RANDOMNESS AND SCORING   (tutorial: docs/tutorials/06-random.md)
+;
+; Catch the food! Steer the white block onto the yellow food pixel; each catch
+; scores a point and drops new food at a random spot. Uses MIXED mode: lo-res
+; graphics up top with a 4-line TEXT window at the bottom for the score.
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut6_catch.s
+;   Verify:   node verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 "<keys>" ...
+;   Controls: W/A/S/D move, Q quits.
+; ============================================================================
+
+        .org $0800
+
+; ---- game state -------------------------------------------------------------
+hx      = $06               ; player X (0..39)
+hy      = $07               ; player Y (0..39, mixed mode)
+fx      = $08               ; food X
+fy      = $09               ; food Y
+score   = $0A               ; 0..99
+seed    = $0B               ; RNG state (never 0)
+tmp     = $0C
+
+; ---- plot arguments + scratch -----------------------------------------------
+px      = $10
+py      = $11
+pcolor  = $12
+ptmp    = $13
+sptr    = $14               ; (2)
+
+KBD     = $C000
+KBDSTRB = $C010
+TXTCLR  = $C050
+TXTSET  = $C051
+MIXSET  = $C053             ; mixed: lo-res + 4 text rows at the bottom
+LOWSCR  = $C054
+LORES   = $C056
+
+BLACK   = 0
+YELLOW  = 13
+WHITE   = 15
+
+PMAX    = 39                ; playfield is 40 wide and (mixed) 40 tall
+
+        lda TXTCLR
+        lda MIXSET
+        lda LORES
+        lda LOWSCR
+        lda KBDSTRB
+        jsr clrscreen
+
+        lda #$A5            ; any non-zero RNG seed
+        sta seed
+        lda #0
+        sta score
+        jsr drawhud         ; "SCORE: 0" in the text window
+
+        lda #20             ; player starts in the middle
+        sta hx
+        sta hy
+        jsr newfood         ; first food
+        jsr drawplayer
+
+loop:   lda KBD
+        bpl loop
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        beq quit
+
+        pha
+        jsr eraseplayer
+        pla
+        cmp #'W'
+        beq up
+        cmp #'S'
+        beq down
+        cmp #'A'
+        beq left
+        cmp #'D'
+        beq right
+        cmp #$0B
+        beq up
+        cmp #$0A
+        beq down
+        cmp #$08
+        beq left
+        cmp #$15
+        beq right
+        bra after
+
+up:     lda hy
+        beq after
+        dec hy
+        bra after
+down:   lda hy
+        cmp #PMAX
+        bcs after
+        inc hy
+        bra after
+left:   lda hx
+        beq after
+        dec hx
+        bra after
+right:  lda hx
+        cmp #PMAX
+        bcs after
+        inc hx
+
+after:  lda hx              ; did we land on the food?
+        cmp fx
+        bne nocatch
+        lda hy
+        cmp fy
+        bne nocatch
+        inc score           ; caught it!
+        jsr drawhud
+        jsr newfood
+
+nocatch: jsr drawfood       ; keep food lit (player may have sat on its cell)
+        jsr drawplayer
+        bra loop
+
+quit:   lda TXTSET
+        brk
+
+; ---- place new random food, never on the player -----------------------------
+newfood: jsr randc
+        sta fx
+        jsr randc
+        sta fy
+        lda fx
+        cmp hx
+        bne nfok
+        lda fy
+        cmp hy
+        beq newfood         ; landed on player -> try again
+nfok:   rts
+
+; randc: a pseudo-random coordinate in 0..39 (rejection sampling)
+randc:  jsr rng
+        and #$3F            ; 0..63
+        cmp #40
+        bcs randc           ; >=40 -> reject and reroll
+        rts
+
+; rng: 8-bit Galois LFSR (tap $B8). Returns next value in A and seed.
+rng:    lda seed
+        lsr a
+        bcc rnods
+        eor #$B8
+rnods:  sta seed
+        rts
+
+; ---- drawing helpers --------------------------------------------------------
+drawplayer: lda hx
+        sta px
+        lda hy
+        sta py
+        lda #WHITE
+        sta pcolor
+        jmp plot
+eraseplayer: lda hx
+        sta px
+        lda hy
+        sta py
+        lda #BLACK
+        sta pcolor
+        jmp plot
+drawfood: lda fx
+        sta px
+        lda fy
+        sta py
+        lda #YELLOW
+        sta pcolor
+        jmp plot
+
+; ---- HUD: "SCORE: NN" written into the bottom text window (row 20) ----------
+drawhud: ldx #0
+dh1:    lda label,x         ; copy the "SCORE: " label
+        beq dh2
+        ora #$80            ; normal video = high bit set
+        sta $0650,x
+        inx
+        bra dh1
+dh2:    lda score           ; split score into tens + ones
+        ldx #0
+dh3:    cmp #10
+        bcc dh4
+        sec
+        sbc #10
+        inx
+        bra dh3
+dh4:    sta tmp             ; A = ones, X = tens
+        txa
+        ora #$B0            ; '0' + tens, normal video
+        sta $0657
+        lda tmp
+        ora #$B0
+        sta $0658
+        rts
+label:  .asciiz "SCORE: "
+
+; ---- PLOT: one lo-res pixel (px,py) in pcolor (see Lesson 4) -----------------
+plot:   lda py
+        lsr a
+        tax
+        lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        ldy px
+        lda py
+        and #1
+        bne plodd
+        lda (sptr),y
+        and #$F0
+        ora pcolor
+        sta (sptr),y
+        rts
+plodd:  lda pcolor
+        asl a
+        asl a
+        asl a
+        asl a
+        sta ptmp
+        lda (sptr),y
+        and #$0F
+        ora ptmp
+        sta (sptr),y
+        rts
+
+clrscreen: lda #0
+        ldx #0
+cs:     sta $0400,x
+        sta $0500,x
+        sta $0600,x
+        sta $0700,x
+        inx
+        bne cs
+        rts
+
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut6_catch.s
+++ b/codegen/programs/tut6_catch.s
@@ -6,7 +6,7 @@
 ; graphics up top with a 4-line TEXT window at the bottom for the score.
 ;
 ;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut6_catch.s
-;   Verify:   node verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 "<keys>" ...
+;   Verify:   node codegen/tools/verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 "<keys>" ...
 ;   Controls: W/A/S/D move, Q quits.
 ; ============================================================================
 
@@ -114,7 +114,12 @@ after:  lda hx              ; did we land on the food?
         cmp fy
         bne nocatch
         inc score           ; caught it!
-        jsr drawhud
+        lda score           ; keep the 2-digit HUD valid: cap the score at 99
+        cmp #100
+        bcc sc_ok
+        lda #99
+        sta score
+sc_ok:  jsr drawhud
         jsr newfood
 
 nocatch: jsr drawfood       ; keep food lit (player may have sat on its cell)

--- a/codegen/programs/tut7_invaders.s
+++ b/codegen/programs/tut7_invaders.s
@@ -195,7 +195,9 @@ mf_rev: lda #$01            ; hit left -> drop, go right
 
 ; ============================================================================
 ; HITCHECK — if the bullet overlaps any live alien, kill it and score.
-; Aliens are 2 px wide, so the bullet matches ax OR ax+1.
+; Aliens are 2 px wide, so the bullet matches ax OR ax+1. The bullet also climbs
+; 2 rows/frame, so it can jump clean over a row: we match by OR by+1 as well, or
+; an alien on an odd row (which happens after the fleet drops) could never be hit.
 ; ============================================================================
 hitcheck: lda bactive
         beq hc_done
@@ -214,9 +216,13 @@ hc_c:   jsr alienidx        ; X = row*5+col, A = alive[X]
         cmp bx
         bne hc_next
 hc_xok: jsr alieny          ; A = ay
-        cmp by
+        cmp by              ; ay == the bullet's row?
+        beq hc_hit
+        sec
+        sbc #1              ; bullet climbs 2 rows/frame, so it can skip a row:
+        cmp by              ; also count the row it jumped over (ay-1 == by)
         bne hc_next
-        jsr alienidx        ; X = this alien's index
+hc_hit: jsr alienidx        ; X = this alien's index
         lda #0
         sta alive,x         ; kill it
         sta bactive

--- a/codegen/programs/tut7_invaders.s
+++ b/codegen/programs/tut7_invaders.s
@@ -1,0 +1,436 @@
+; ============================================================================
+; Lesson 7 — SPACE INVADERS (capstone)   (tutorial: docs/tutorials/07-invaders.md)
+;
+; The whole series in one program: a marching alien fleet, a cannon you drive,
+; a bullet, collision, score, and win/lose states. Lo-res + a text HUD.
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut7_invaders.s
+;   Controls: A/D move, SPACE fire, R restart (after win/lose), Q quit.
+;
+; Fleet layout: 5 columns x 3 rows = 15 aliens, each 2 lo-res pixels wide.
+; ============================================================================
+
+        .org $0800
+
+; ---- game state (zero page) -------------------------------------------------
+cannonx = $06              ; cannon X (0..39)
+state   = $07              ; 0 = playing, 1 = win, 2 = lose
+bx      = $08              ; bullet X
+by      = $09              ; bullet Y
+bactive = $0A              ; bullet on screen? (0/1)
+fleetx  = $0B              ; X of column 0
+fleety  = $0C              ; Y of row 0
+fleetdir = $0D             ; $01 = right, $FF = left
+count   = $0E              ; aliens still alive
+score   = $0F
+tick    = $10              ; frame counter for fleet cadence
+arow    = $11              ; loop scratch (alien row)
+acol    = $12              ; loop scratch (alien col)
+
+; ---- plot arguments + scratch -----------------------------------------------
+px      = $14
+py      = $15
+pcolor  = $16
+ptmp    = $17
+sptr    = $18              ; (2)
+msgptr  = $1A             ; (2) message pointer for win/lose text
+
+KBD     = $C000
+KBDSTRB = $C010
+TXTCLR  = $C050
+TXTSET  = $C051
+MIXSET  = $C053
+LOWSCR  = $C054
+LORES   = $C056
+
+BLACK   = 0
+GREEN   = 12
+YELLOW  = 13
+WHITE   = 15
+
+CANNONY = 39               ; bottom lo-res row (mixed mode)
+FLEETPD = 64               ; frames between fleet steps (bigger = slower)
+
+        lda TXTCLR
+        lda MIXSET
+        lda LORES
+        lda LOWSCR
+        lda KBDSTRB
+
+; ---- (re)start a fresh game -------------------------------------------------
+restart: ldx #14           ; all 15 aliens alive
+rs1:    lda #1
+        sta alive,x
+        dex
+        bpl rs1
+        lda #15
+        sta count
+        lda #0
+        sta score
+        sta bactive
+        sta tick
+        sta state
+        lda #6
+        sta fleetx
+        lda #2
+        sta fleety
+        lda #1
+        sta fleetdir
+        lda #20
+        sta cannonx
+
+; ---- main game loop ---------------------------------------------------------
+play:   jsr input
+        jsr movebullet
+        jsr movefleet
+        jsr hitcheck
+
+        lda count           ; all dead -> win
+        bne notwin
+        jmp win
+notwin: lda fleety          ; fleet reached the cannon -> lose
+        clc
+        adc #6
+        cmp #38
+        bcc draw
+        jmp lose
+
+draw:   jsr clrscreen
+        jsr drawaliens
+        jsr drawcannon
+        jsr drawbullet
+        jsr drawhud
+        jsr delay
+        jmp play
+
+quit:   lda TXTSET
+        brk
+
+; ============================================================================
+; INPUT — non-blocking. A/D move, SPACE fire, Q quit, R restart.
+; ============================================================================
+input:  lda KBD
+        bpl in_done
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        beq in_quit
+        cmp #'A'
+        beq in_left
+        cmp #$08
+        beq in_left
+        cmp #'D'
+        beq in_right
+        cmp #$15
+        beq in_right
+        cmp #' '
+        beq in_fire
+        bra in_done
+in_left: lda cannonx
+        beq in_done
+        dec cannonx
+        rts
+in_right: lda cannonx
+        cmp #39
+        bcs in_done
+        inc cannonx
+        rts
+in_fire: lda bactive         ; only one bullet at a time
+        bne in_done
+        lda #1
+        sta bactive
+        lda cannonx
+        sta bx
+        lda #38
+        sta by
+in_done: rts
+in_quit: jmp quit
+
+; ============================================================================
+; MOVEBULLET — travel up 2 rows/frame; drop it when it leaves the top.
+; ============================================================================
+movebullet: lda bactive
+        beq mb_done
+        lda by
+        sec
+        sbc #2
+        bcs mb_ok
+        lda #0              ; underflowed past the top edge
+        sta bactive
+        rts
+mb_ok:  sta by
+mb_done: rts
+
+; ============================================================================
+; MOVEFLEET — every FLEETPD frames step sideways; at an edge, drop and reverse.
+; ============================================================================
+movefleet: inc tick
+        lda tick
+        cmp #FLEETPD
+        bcs mf_go
+        rts
+mf_go:  lda #0
+        sta tick
+        lda fleetdir
+        bmi mf_left
+        lda fleetx          ; heading right
+        clc
+        adc #13             ; right edge of the formation
+        cmp #38
+        bcc mf_right
+        lda #$FF            ; hit right -> drop, go left
+        sta fleetdir
+        inc fleety
+        rts
+mf_right: inc fleetx
+        rts
+mf_left: lda fleetx          ; heading left
+        beq mf_rev
+        dec fleetx
+        rts
+mf_rev: lda #$01            ; hit left -> drop, go right
+        sta fleetdir
+        inc fleety
+        rts
+
+; ============================================================================
+; HITCHECK — if the bullet overlaps any live alien, kill it and score.
+; Aliens are 2 px wide, so the bullet matches ax OR ax+1.
+; ============================================================================
+hitcheck: lda bactive
+        beq hc_done
+        lda #0
+        sta arow
+hc_r:   lda #0
+        sta acol
+hc_c:   jsr alienidx        ; X = row*5+col, A = alive[X]
+        beq hc_next
+        jsr alienx          ; A = ax
+        sta ptmp            ; reuse ptmp as ax
+        cmp bx
+        beq hc_xok
+        clc
+        adc #1              ; ax+1 (2 px wide)
+        cmp bx
+        bne hc_next
+hc_xok: jsr alieny          ; A = ay
+        cmp by
+        bne hc_next
+        jsr alienidx        ; X = this alien's index
+        lda #0
+        sta alive,x         ; kill it
+        sta bactive
+        dec count
+        inc score
+        rts
+hc_next: inc acol
+        lda acol
+        cmp #5
+        bne hc_c
+        inc arow
+        lda arow
+        cmp #3
+        bne hc_r
+hc_done: rts
+
+; helpers: compute index / positions from arow,acol -> return in A (X for idx)
+alienidx: lda arow          ; index = arow*5 + acol
+        asl a
+        asl a
+        clc
+        adc arow
+        clc
+        adc acol
+        tax
+        lda alive,x
+        rts
+alienx: lda acol            ; ax = fleetx + acol*3
+        asl a
+        clc
+        adc acol
+        clc
+        adc fleetx
+        rts
+alieny: lda arow            ; ay = fleety + arow*3
+        asl a
+        clc
+        adc arow
+        clc
+        adc fleety
+        rts
+
+; ============================================================================
+; DRAWING
+; ============================================================================
+drawaliens: lda #0
+        sta arow
+da_r:   lda #0
+        sta acol
+da_c:   jsr alienidx
+        beq da_next
+        jsr alienx
+        sta px              ; left pixel
+        jsr alieny
+        sta py
+        lda #GREEN
+        sta pcolor
+        jsr plot
+        inc px              ; right pixel (2 px wide)
+        jsr plot
+da_next: inc acol
+        lda acol
+        cmp #5
+        bne da_c
+        inc arow
+        lda arow
+        cmp #3
+        bne da_r
+        rts
+
+drawcannon: lda cannonx
+        sta px
+        lda #CANNONY
+        sta py
+        lda #WHITE
+        sta pcolor
+        jmp plot
+
+drawbullet: lda bactive
+        beq db_done
+        lda bx
+        sta px
+        lda by
+        sta py
+        lda #YELLOW
+        sta pcolor
+        jmp plot
+db_done: rts
+
+; HUD: "SCORE: NN" in the text window (text row 20 = $0650)
+drawhud: ldx #0
+dh1:    lda hudlbl,x
+        beq dh2
+        ora #$80
+        sta $0650,x
+        inx
+        bra dh1
+dh2:    lda score
+        ldx #0
+dh3:    cmp #10
+        bcc dh4
+        sec
+        sbc #10
+        inx
+        bra dh3
+dh4:    sta ptmp
+        txa
+        ora #$B0
+        sta $0657
+        lda ptmp
+        ora #$B0
+        sta $0658
+        rts
+
+; ============================================================================
+; WIN / LOSE — show a message, then wait for R (restart) or Q (quit).
+; ============================================================================
+win:    lda #1
+        sta state
+        ldx #<wintxt
+        ldy #>wintxt
+        jmp endmsg
+lose:   lda #2
+        sta state
+        ldx #<losetxt
+        ldy #>losetxt
+        jmp endmsg
+
+; endmsg: message pointer in X(lo)/Y(hi); paint it and wait for R/Q.
+endmsg: stx msgptr
+        sty msgptr+1
+        jsr clrscreen
+        jsr drawaliens
+        ldy #0
+em1:    lda (msgptr),y
+        beq em2
+        ora #$80
+        sta $0650,y
+        iny
+        bra em1
+em2:    jsr drawhud
+ew1:    lda KBD
+        bpl ew1
+        bit KBDSTRB
+        and #$7F
+        cmp #'R'
+        beq ew_r
+        cmp #'Q'
+        beq ew_q
+        bra ew1
+ew_r:   jmp restart
+ew_q:   jmp quit
+
+; ============================================================================
+; PLOT — one lo-res pixel (px,py) in pcolor (see Lesson 4)
+; ============================================================================
+plot:   lda py
+        lsr a
+        tax
+        lda ROWL,x
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        ldy px
+        lda py
+        and #1
+        bne plodd
+        lda (sptr),y
+        and #$F0
+        ora pcolor
+        sta (sptr),y
+        rts
+plodd:  lda pcolor
+        asl a
+        asl a
+        asl a
+        asl a
+        sta ptmp
+        lda (sptr),y
+        and #$0F
+        ora ptmp
+        sta (sptr),y
+        rts
+
+delay:  ldx #$20
+dl1:    ldy #$FF
+dl2:    dey
+        bne dl2
+        dex
+        bne dl1
+        rts
+
+clrscreen: lda #0
+        ldx #0
+cs:     sta $0400,x
+        sta $0500,x
+        sta $0600,x
+        sta $0700,x
+        inx
+        bne cs
+        rts
+
+hudlbl: .asciiz "SCORE: "
+wintxt: .asciiz "YOU WIN!  R=PLAY AGAIN"
+losetxt: .asciiz "INVADED!  R=PLAY AGAIN"
+
+; per-alien alive flags (row-major, 5 cols x 3 rows); mutated at runtime
+alive:  .byte 1,1,1,1,1
+        .byte 1,1,1,1,1
+        .byte 1,1,1,1,1
+
+ROWL:   .byte $00,$80,$00,$80,$00,$80,$00,$80
+        .byte $28,$A8,$28,$A8,$28,$A8,$28,$A8
+        .byte $50,$D0,$50,$D0,$50,$D0,$50,$D0
+ROWH:   .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07
+        .byte $04,$04,$05,$05,$06,$06,$07,$07

--- a/codegen/programs/tut8_hires.s
+++ b/codegen/programs/tut8_hires.s
@@ -1,0 +1,198 @@
+; ============================================================================
+; Lesson 8 — HI-RES, AND WHERE TO GO NEXT   (tutorial: docs/tutorials/08-hires.md)
+;
+; A peek at the 3ric's 280x192 high-resolution mode: build the (famously weird)
+; row-address table, draw three white rulers, and scatter a seeded starfield.
+;
+;   Try it:   https://ebadger.github.io/3ric/?src=programs/tut8_hires.s
+;   Verify:   node codegen/tools/run6502.mjs codegen/programs/tut8_hires.s \
+;                 --expect-mem 0x2000=0x7F --expect-mem 0x2228=0x7F \
+;                 --expect-mem 0x3FD0=0x7F --expect-halt idle
+;   Controls: Q quits.
+; ============================================================================
+
+        .org $0800
+
+; ---- scratch (zero page) ----------------------------------------------------
+ptr     = $06               ; (2) screen destination pointer
+col     = $09
+row     = $0A
+seed    = $0B               ; RNG state (never 0)
+tmpa    = $0C               ; build_rows scratch
+tmpb    = $0D
+
+; ---- big tables live in free RAM (not in the program image) -----------------
+SCREEN  = $2000             ; hi-res page 1 ($2000-$3FFF)
+ROWL    = $6000             ; 192 bytes: low  byte of each pixel row's address
+ROWH    = $6100             ; 192 bytes: high byte of each pixel row's address
+
+KBD     = $C000
+KBDSTRB = $C010
+TXTCLR  = $C050
+TXTSET  = $C051
+FULLSCR = $C052
+LOWSCR  = $C054
+HIRES   = $C057
+
+        lda TXTCLR          ; graphics...
+        lda FULLSCR         ; ...full screen...
+        lda LOWSCR          ; ...page 1...
+        lda HIRES           ; ...hi-res
+        jsr build_rows      ; fill the 192-entry row-address table
+        jsr clearhgr        ; blank the hi-res page
+
+        lda #$5A            ; any non-zero RNG seed
+        sta seed
+
+        lda #0              ; three white rulers: top, middle, bottom
+        jsr hline
+        lda #96
+        jsr hline
+        lda #191
+        jsr hline
+
+        jsr starfield
+
+spin:   lda KBD             ; rest here (detected as idle); Q returns to text
+        bpl spin
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        bne spin
+        lda TXTSET
+        brk
+
+; ============================================================================
+; hline — draw a full-width white line across pixel row A.
+; Each hi-res byte holds 7 pixels; $7F lights all seven (bit 7 = palette).
+; ============================================================================
+hline:  tay
+        lda ROWL,y
+        sta ptr
+        lda ROWH,y
+        sta ptr+1
+        ldy #39
+        lda #$7F
+hl1:    sta (ptr),y
+        dey
+        bpl hl1
+        rts
+
+; ============================================================================
+; starfield — scatter 96 seeded random dots. Choosing (row, col, bit) with the
+; RNG means we never have to divide an X coordinate by 7.
+; ============================================================================
+starfield: ldx #96
+sf1:    phx
+        jsr rndrow
+        sta row
+        jsr rndcol
+        sta col
+        ldy row
+        lda ROWL,y
+        sta ptr
+        lda ROWH,y
+        sta ptr+1
+        jsr rndbit          ; A = a single-bit mask
+        ldy col
+        ora (ptr),y         ; OR it in so we don't erase neighbours
+        sta (ptr),y
+        plx
+        dex
+        bne sf1
+        rts
+
+rndrow: jsr rng             ; 0..191
+        cmp #192
+        bcs rndrow
+        rts
+rndcol: jsr rng             ; 0..39
+        and #$3F
+        cmp #40
+        bcs rndcol
+        rts
+rndbit: jsr rng             ; a mask with one of bits 0..6 set
+        and #7
+        cmp #7
+        beq rndbit
+        tax
+        lda BITMASK,x
+        rts
+
+; rng: 8-bit Galois LFSR (tap $B8)
+rng:    lda seed
+        lsr a
+        bcc rn1
+        eor #$B8
+rn1:    sta seed
+        rts
+
+; ============================================================================
+; build_rows — ROWL/ROWH[y] = address of pixel row y (y = 0..191).
+; Hi-res rows are interleaved in memory; this reproduces the classic Apple-II
+; formula so we never compute it again at draw time. (From the shipped swarm.s.)
+; ============================================================================
+build_rows: ldx #0
+br_loop: txa
+        and #7
+        asl a
+        asl a
+        clc
+        adc #$20
+        sta tmpa            ; high base
+        txa
+        lsr a
+        lsr a
+        lsr a
+        and #7
+        sta tmpb
+        lsr a
+        clc
+        adc tmpa
+        sta ROWH,x
+        lda #0
+        sta tmpa
+        lda tmpb
+        and #1
+        beq br_nolo
+        lda #$80
+        sta tmpa
+br_nolo: txa
+        lsr a
+        lsr a
+        lsr a
+        lsr a
+        lsr a
+        lsr a
+        beq br_lowdone
+        tay
+br_add28: lda tmpa
+        clc
+        adc #$28
+        sta tmpa
+        dey
+        bne br_add28
+br_lowdone: lda tmpa
+        sta ROWL,x
+        inx
+        cpx #192
+        bne br_loop
+        rts
+
+; clearhgr — zero the whole hi-res page ($2000-$3FFF)
+clearhgr: lda #>SCREEN
+        sta ptr+1
+        lda #0
+        sta ptr
+        ldx #$20            ; 32 pages
+ch_pg:  ldy #0
+        lda #0
+ch_by:  sta (ptr),y
+        iny
+        bne ch_by
+        inc ptr+1
+        dex
+        bne ch_pg
+        rts
+
+BITMASK: .byte $01,$02,$04,$08,$10,$20,$40

--- a/codegen/tools/verify_keys.cjs
+++ b/codegen/tools/verify_keys.cjs
@@ -1,0 +1,69 @@
+// verify_keys.cjs — headless *interactive* verifier for the tutorial programs.
+// Boots the 3ric WASM emulator through the shared harness, assembles a .s, runs
+// it, injects a scripted string of keypresses (one per frame, honoring the
+// keyboard strobe), then prints the hero position + text screen and checks
+// byte-level memory assertions.
+//
+// Companion to run6502.mjs for programs that need input. The web keyboard bridge
+// uppercases letters (web_bridge.cpp keyDown -> toupper), so pass keys in
+// uppercase (e.g. WASD). Needs a WASM build first (web/badger6502.js, produced by
+// web/build.ps1).
+//
+// Usage:
+//   node codegen/tools/verify_keys.cjs <src.s> <orgHex> <keys> [addr=val ...]
+// Example:
+//   node codegen/tools/verify_keys.cjs codegen/programs/tut3_move.s 0x0800 "DDSSWW" 0x06=0x18
+//
+// keys is a plain string; each character is typed in order. Addresses and values
+// accept 0x.. hex; each assertion compares a single byte.
+
+const fs = require("fs");
+const path = require("path");
+const { pathToFileURL } = require("url");
+const { boot } = require("./harness.cjs");
+
+(async () => {
+  const [, , srcArg, orgArg, keys, ...asserts] = process.argv;
+  if (!srcArg) {
+    console.error("usage: node codegen/tools/verify_keys.cjs <src.s> <orgHex> <keys> [addr=val ...]");
+    process.exit(2);
+  }
+
+  const src = fs.readFileSync(srcArg, "utf8");
+  const asm = await import(pathToFileURL(path.join(__dirname, "asm6502.mjs")).href);
+  const org = orgArg ? parseInt(orgArg) : undefined;
+  const out = asm.assemble(src, org != null ? { org } : {});
+  const entry = out.org, bytes = out.bytes;
+
+  const session = await boot();
+  session.load(bytes, entry);
+  const vm = session.vm;
+  vm.drainOutput();
+  vm.setPC(entry);
+
+  const step = (n = 8, c = 20000) => { for (let i = 0; i < n; i++) vm.run(c); };
+  step(12); // let the first frame draw
+
+  for (const ch of keys || "") {
+    for (let t = 0; t < 200 && (vm.peek(0xc000) & 0x80) !== 0; t++) vm.run(2000); // wait for the strobe to clear
+    vm.keyDown(ch.charCodeAt(0));
+    step(8, 20000); // let the loop consume the key + redraw
+  }
+  step(6);
+
+  const hx = vm.peek(0x06), hy = vm.peek(0x07);
+  console.log(`hero: hx=${hx} (0x${hx.toString(16)})  hy=${hy} (0x${hy.toString(16)})`);
+  console.log("screen:");
+  for (const line of session.textScreen()) console.log("  | " + line);
+
+  let ok = true;
+  for (const a of asserts) {
+    const m = a.match(/^(.+)=(.+)$/);
+    const addr = parseInt(m[1]), val = parseInt(m[2]) & 0xff, got = vm.peek(addr);
+    const pass = got === val;
+    ok = ok && pass;
+    console.log(`  ${pass ? "PASS" : "FAIL"}  mem[0x${addr.toString(16)}]==0x${val.toString(16)} (got 0x${got.toString(16)})`);
+  }
+  console.log(ok ? "VERDICT: PASS" : "VERDICT: FAIL");
+  process.exit(ok ? 0 : 1);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/codegen/tools/verify_run.cjs
+++ b/codegen/tools/verify_run.cjs
@@ -1,0 +1,62 @@
+// verify_run.cjs — headless verifier for the *autonomous* tutorial demos (e.g.
+// the bouncing ball) that never halt on their own. Boots the 3ric WASM emulator
+// through the shared harness, assembles a .s, runs a FIXED cycle budget, then
+// prints a little state and checks byte-level memory assertions. The core is
+// cycle-honest, so a fixed budget is deterministic: "observe once, then lock the
+// values" gives a stable regression test.
+//
+// Companion to run6502.mjs: use run6502 when the program halts (brk / idle) and
+// this when it runs forever. Both need a WASM build first (web/badger6502.js,
+// produced by web/build.ps1).
+//
+// Usage:
+//   node codegen/tools/verify_run.cjs <src.s> <orgHex> <cycles> [addr=val ...]
+// Example:
+//   node codegen/tools/verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 0x08=0xFF
+//
+// Addresses and values accept 0x.. hex; each assertion compares a single byte.
+
+const fs = require("fs");
+const path = require("path");
+const { pathToFileURL } = require("url");
+const { boot } = require("./harness.cjs");
+
+(async () => {
+  const [, , srcArg, orgArg, cyclesArg, ...asserts] = process.argv;
+  if (!srcArg) {
+    console.error("usage: node codegen/tools/verify_run.cjs <src.s> <orgHex> <cycles> [addr=val ...]");
+    process.exit(2);
+  }
+
+  const src = fs.readFileSync(srcArg, "utf8");
+  const asm = await import(pathToFileURL(path.join(__dirname, "asm6502.mjs")).href);
+  const org = orgArg ? parseInt(orgArg) : undefined;
+  const out = asm.assemble(src, org != null ? { org } : {});
+  const entry = out.org, bytes = out.bytes;
+
+  const session = await boot();
+  session.load(bytes, entry);
+  const vm = session.vm;
+  vm.drainOutput();
+  vm.setPC(entry);
+
+  const total = cyclesArg ? parseInt(cyclesArg) : 2000000;
+  const chunk = 20000;
+  for (let done = 0; done < total; done += chunk) vm.run(chunk);
+
+  const peek = (a) => vm.peek(a);
+  console.log(`state: $06=${peek(0x06)} $07=${peek(0x07)} $08=0x${peek(0x08).toString(16)} $09=0x${peek(0x09).toString(16)}`);
+  console.log("screen:");
+  for (const line of session.textScreen()) console.log("  | " + line);
+
+  let ok = true;
+  for (const a of asserts) {
+    const m = a.match(/^(.+)=(.+)$/);
+    const addr = parseInt(m[1]), val = parseInt(m[2]) & 0xff, got = vm.peek(addr);
+    const pass = got === val;
+    ok = ok && pass;
+    console.log(`  ${pass ? "PASS" : "FAIL"}  mem[0x${addr.toString(16)}]==0x${val.toString(16)} (got 0x${got.toString(16)})`);
+  }
+  console.log(ok ? "VERDICT: PASS" : "VERDICT: FAIL");
+  process.exit(ok ? 0 : 1);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/docs/tutorials/01-hello.md
+++ b/docs/tutorials/01-hello.md
@@ -1,0 +1,156 @@
+# Lesson 1 — Hello, 3ric
+
+> **You'll build:** your first 65C02 program — it clears the screen and prints two lines.
+> **New ideas:** the assemble-and-run loop, the CPU's registers, printing with a ROM
+> routine, and a simple loop.
+> **Program:** [`codegen/programs/tut1_hello.s`](../../codegen/programs/tut1_hello.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut1_hello.s>
+
+---
+
+## 1. The idea
+
+A 3ric program is just a list of bytes placed in memory that the CPU then executes, one
+instruction at a time. To get *anything* on screen we need three things:
+
+- **Registers** — the CPU's tiny built-in variables. We'll use **A** (the *accumulator* —
+  where values pass through) and **X** (an *index/counter*). Each holds one byte, `0`–`255`.
+- **A way to print** — the machine's ROM already contains a routine called **`COUT`** (at
+  address `$FDED`) that takes whatever byte is in **A** and prints it as a character. We
+  just hand it a letter and call it.
+- **A loop** — to print a whole word we step through its letters one at a time, printing
+  each, until we hit a marker that says "stop."
+
+That's the entire program: *put a letter in A, call `COUT`, move to the next letter,
+repeat.*
+
+> **Hex, quickly.** Addresses and bytes are written in hexadecimal with a `$` prefix.
+> `$FDED` is just a memory address; `$C8` is just the number 200. You never have to do hex
+> math by hand — the assembler does it for you.
+
+## 2. The code
+
+Here's the whole program. Read the comments top to bottom — every instruction is
+introduced the first time it appears.
+
+```asm
+        .org $0800          ; Load + run address. A .PRG starts executing here.
+
+COUT    = $FDED             ; print the character in A to the screen (+ serial)
+HOME    = $FC58             ; clear the text screen, cursor to the top-left
+
+        jsr HOME            ; start on a clean screen
+
+        ldx #0              ; X walks through the message, one byte at a time
+print:  lda msg,x           ; A = the X-th byte of msg   (LDA addr,X = "indexed")
+        beq done            ; a 0 byte marks the end of the text -> finished
+        jsr COUT            ; print the character now in A
+        inx                 ; advance to the next byte
+        bne print           ; loop back (BNE is always taken until X would wrap)
+
+done:   brk                 ; hand control back to the monitor: program finished
+
+msg:
+        .byte $C8,$C5,$CC,$CC,$CF,$AC,$A0      ; "HELLO, "
+        .byte $B3,$D2,$C9,$C3                  ; "3RIC"
+        .byte $8D                              ; new line
+        .byte $CC,$C5,$D4,$A7,$D3,$A0          ; "LET'S "
+        .byte $CD,$C1,$CB,$C5,$A0              ; "MAKE "
+        .byte $C7,$C1,$CD,$C5,$D3,$AE          ; "GAMES."
+        .byte $8D,$00                          ; new line, end marker
+```
+
+### Line by line
+
+- **`.org $0800`** — a *directive* (an instruction to the assembler, not the CPU). It says
+  "assemble this to run at address `$0800`." On the 3ric, a program is loaded at its `.org`
+  and execution begins there, so **the load address is the entry point**. `$0800` is a
+  convenient chunk of free RAM.
+- **`COUT = $FDED`** / **`HOME = $FC58`** — *equates*: names for addresses so the code reads
+  in English instead of hex. These two live in the ROM; their addresses come from the
+  [platform reference](../../codegen/platform/platform-ref.md).
+- **`jsr HOME`** — *Jump to SubRoutine*. It calls the ROM's screen-clear routine and comes
+  back. `jsr` is how you call reusable code.
+- **`ldx #0`** — *LoaD X* with the number `0`. The **`#`** means "the literal value 0"
+  (this is *immediate* addressing). Without `#`, `ldx 0` would mean "load X from *memory
+  address* 0" — a completely different thing. This is the most common beginner mix-up.
+- **`print:`** — a *label*, a name for this spot in the code so we can branch back to it.
+- **`lda msg,x`** — *LoaD A* from address `msg` **plus X**. When `X = 0` it reads the first
+  byte of the message; when `X = 1`, the second; and so on. This `addr,X` form is *indexed*
+  addressing — the workhorse of table and string handling.
+- **`beq done`** — *Branch if EQual (to zero)*. `lda` sets the CPU's "zero" flag when the
+  value it loaded was `0`, so this reads as "if we just loaded the `$00` end-marker, jump to
+  `done`."
+- **`jsr COUT`** — print the character currently in A.
+- **`inx`** — *INcrement X* (add 1). Now `msg,x` points at the next letter.
+- **`bne print`** — *Branch if Not Equal (to zero)*. `inx` leaves the zero flag clear for
+  every value except when X rolls from 255 back to 0, so in practice this always loops back
+  to `print`. The loop ends via the `beq done` above, not here.
+- **`brk`** — stops the program and returns to the ROM **monitor**. It's the standard "I'm
+  done" signal on the 3ric. (Don't use `rts` at the top level — there's no caller to return
+  to.)
+
+### Why the funny numbers?
+
+`COUT` expects each character as **ASCII with the high bit set**. Normal ASCII `'H'` is
+`$48`; setting the top bit gives `$48 + $80 = $C8`. So the message is spelled out in
+high-bit bytes. `$8D` is a carriage return (`$0D | $80`) — it starts a new line. The
+trailing **`$00`** is our own end-marker that `beq done` watches for.
+
+You don't have to memorize the codes — later lessons let the assembler compute them for you
+— but seeing them once makes the "high bit set" rule concrete.
+
+## 3. Run it
+
+**In the browser (easiest):** open
+<https://ebadger.github.io/3ric/?src=programs/tut1_hello.s>. The page loads the source into
+the **Assemble & Run** editor, assembles it in your browser with the very same assembler the
+project uses, and runs it. You should see:
+
+```
+HELLO, 3RIC
+LET'S MAKE GAMES.
+```
+
+Edit the text in the editor and press **Assemble & Run** again to see your change instantly.
+
+**Headless (if you've cloned the repo):** the toolchain can run the program and *check* its
+output, which is exactly how this lesson's code was verified:
+
+```sh
+node codegen/tools/run6502.mjs codegen/programs/tut1_hello.s \
+    --expect-serial "HELLO, 3RIC" --expect-halt brk-monitor
+```
+
+`VERDICT: PASS` means the program halted cleanly and printed what we expected.
+
+## 4. What just happened
+
+After the two lines print, `brk` returns to the monitor, which prints a line like:
+
+```
+0812-    A=00 X=1E Y=00 P=32 S=EC
+*
+```
+
+That's not your program — it's the **monitor** reporting the CPU's registers at the moment
+you stopped, then showing its `*` prompt. Notice `X=1E` (that's 30 in decimal): X counted up
+once per byte as the loop walked the whole 30-byte message. Seeing the registers "freeze" at
+`brk` is a handy debugging habit we'll use again.
+
+## 5. Make it yours
+
+1. **Change the greeting.** Replace `"3RIC"` with your name. You'll need the high-bit codes:
+   take normal ASCII and add `$80`, or just reuse the letters already in the message.
+2. **Add a third line.** Insert another `$8D` and a few more letter bytes before the final
+   `$00`.
+3. **Print it twice.** Wrap the loop so it runs the whole message a second time. (Hint: keep
+   a second counter, or reset `X` and jump back to `print` once.)
+4. **Break it on purpose.** Delete the final `$00` and run it. What happens, and why? (Think
+   about what `beq done` is now waiting for.)
+
+## Next
+
+You printed characters by *asking the ROM* to do it. In
+**[Lesson 2 — Drawing on the text screen](02-text-screen.md)** you'll skip `COUT` and write
+letters straight into screen memory yourself — the foundation of drawing anything, anywhere.

--- a/docs/tutorials/02-text-screen.md
+++ b/docs/tutorials/02-text-screen.md
@@ -1,0 +1,152 @@
+# Lesson 2 — Drawing on the text screen
+
+> **You'll build:** a titled, bordered "game screen" with a score/lives HUD — drawn by
+> writing straight into screen memory.
+> **New ideas:** the text screen *is* memory at `$0400`; rows are interleaved; zero-page
+> pointers; indirect-indexed addressing; ending with a loop instead of `BRK`.
+> **Program:** [`codegen/programs/tut2_screen.s`](../../codegen/programs/tut2_screen.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut2_screen.s>
+
+---
+
+## 1. The idea
+
+In Lesson 1 we asked the ROM to print for us. Games can't afford that — they draw thousands
+of cells per second, anywhere on screen. So we write **directly to screen memory**.
+
+The text screen lives at **`$0400`–`$07FF`**. Each byte is one of the 40×24 character
+cells. Store a character code into one of those bytes and it appears instantly.
+
+Two things you must know to place a character:
+
+- **Normal video means the high bit is set.** Just like `COUT`, screen memory shows `'A'`
+  as `$C1` (`$41 | $80`), not `$41`. (Codes `$00`–`$7F` show as inverse/flashing — a bonus
+  at the end.)
+- **Rows are not stored back-to-back.** Row 0 is the 40 bytes `$0400`–`$0427`. You'd expect
+  row 1 at `$0428` — but it's actually at **`$0480`**. The rows are *interleaved* for
+  hardware reasons. Rather than fight the formula, we keep a small **table** of each row's
+  start address and look it up.
+
+## 2. The code
+
+The program clears the screen, draws the border, then stamps the title and HUD. The full
+listing (including the 24-entry row tables) is in the source file; here are the important
+pieces.
+
+**A zero-page pointer to a row.** `setrow` copies a row's base address out of the tables
+into `sptr` (two bytes in zero page). Once `sptr` holds an address, `sta (sptr),y` stores
+into "the byte `Y` columns into that row" — this is **indirect-indexed** addressing, the
+tool you'll use for almost all drawing.
+
+```asm
+sptr    = $08               ; a 2-byte pointer living in zero page
+
+setrow: lda ROWL,x          ; X = row number (0..23); look up its base address
+        sta sptr            ;   low byte
+        lda ROWH,x
+        sta sptr+1          ;   high byte
+        rts
+```
+
+**Filling a row** walks the 40 columns with `Y` as the column index:
+
+```asm
+fillrow: ldy #39
+        lda #BORDER         ; '#', already high-bit ($A3)
+fr:     sta (sptr),y        ; screen[row base + Y] = '#'
+        dey
+        bpl fr              ; ...down to column 0 (BPL = "branch while >= 0")
+        rts
+```
+
+**Drawing a string** (`puts`) slides `sptr` right to the start column, then copies bytes
+until the `0` terminator, setting the high bit on each so the text is normal video:
+
+```asm
+puts:   clc
+        adc sptr            ; sptr = row base + start column (passed in A)
+        sta sptr
+        bcc pnc
+        inc sptr+1
+pnc:    ldy #0
+pl:     lda (strp),y        ; next character of the string
+        beq pdone           ; 0 ends it
+        ora #$80            ; force normal video
+        sta (sptr),y        ; place it on screen
+        iny
+        bne pl
+pdone:  rts
+```
+
+The strings themselves are readable text — `puts` adds the high bit, so we don't hand-encode
+like we did in Lesson 1:
+
+```asm
+title:  .asciiz "3RIC ADVENTURE"     ; .asciiz = the bytes, then a 0 terminator
+hud:    .asciiz "SCORE:000  LIVES:3"
+```
+
+### New instructions and ideas
+
+- **`sta (sptr),y` (indirect-indexed).** Take the 16-bit address stored in the zero-page
+  pair `sptr`/`sptr+1`, add `Y`, and store there. This is how you point at *any* address
+  computed at run time. (In Lesson 1, `lda msg,x` used a *fixed* address `msg`; here the
+  address is a variable.)
+- **`<label` / `>label`.** The low and high byte of an address. `lda #<title` /
+  `lda #>title` loads `title`'s address into a pointer.
+- **`bpl` / `dey`.** `dey` counts `Y` down; `bpl` ("branch if plus") loops while `Y` is still
+  0 or more, so the fill runs column 39 → 0.
+- **The row tables** `ROWL`/`ROWH` are just 24 low bytes and 24 high bytes — the interleaved
+  start address of every text row, looked up with `lda ROWL,x`.
+
+### Why it ends with a loop, not `brk`
+
+Lesson 1 finished with `brk`, which hands control back to the monitor — and the monitor
+immediately prints its register dump *over your screen*. A program that draws something
+wants the picture to **stay up**, so instead we spin in place:
+
+```asm
+spin:   bra spin            ; loop here forever; the drawing remains on screen
+```
+
+The headless runner reports this as `halt: idle` — a normal, clean stop. Every visual
+program from here on ends this way, and in Lesson 3 that idle loop becomes the **game loop**.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut2_screen.s>. You should see a boxed
+screen with `3RIC ADVENTURE` centered near the top and `SCORE:000  LIVES:3` near the bottom.
+
+To verify headlessly, assert a few screen bytes (note the `0x` prefixes):
+
+```sh
+node codegen/tools/run6502.mjs codegen/programs/tut2_screen.s \
+    --expect-mem 0x0400=0xA3 --expect-mem 0x050D=0xB3 --expect-halt idle
+```
+
+`mem[$0400]==$A3` confirms the top-left border cell; `mem[$050D]==$B3` confirms the `'3'` of
+the title landed at row 2, column 13.
+
+## 4. What just happened
+
+You computed addresses at run time and wrote characters into them — the whole basis of
+drawing. `setrow` + `(sptr),y` is a *put-character-anywhere* primitive; `fillrow` and `puts`
+are built on top of it. Everything visual in this series (even the lo-res blocks in Lesson 4)
+is the same move: figure out the address of a cell, store a byte.
+
+## 5. Make it yours
+
+1. **Rename the game.** Change the `title` string. If it isn't 14 characters, adjust the
+   start column (`lda #13`) so it stays centered: `col = (40 − length) / 2`.
+2. **Move the HUD.** Draw it on a different row by changing the `ldx #21` before the HUD
+   block. (Watch the row tables do the work.)
+3. **Add a subtitle** on row 4 — a second string, a second `puts` call.
+4. **Try inverse video.** Store a letter code *without* the high bit (e.g. `$01` for an
+   inverse `A`, or `$20` for a solid inverse block) and see it flip to a black-on-white
+   cell. Make an inverse title bar out of solid blocks.
+
+## Next
+
+The screen is drawn, but nothing moves. In
+**[Lesson 3 — Input and the game loop](03-input.md)** we read the keyboard and turn that
+`spin` loop into a real game loop that walks a hero around this box.

--- a/docs/tutorials/03-input.md
+++ b/docs/tutorials/03-input.md
@@ -1,0 +1,159 @@
+# Lesson 3 — Input and the game loop
+
+> **You'll build:** a hero `@` you walk around the box with the keyboard.
+> **New ideas:** reading the keyboard at `$C000`/`$C010`; the read→update→draw loop;
+> comparing keys and branching; erase-then-draw; keeping inside bounds.
+> **Program:** [`codegen/programs/tut3_move.s`](../../codegen/programs/tut3_move.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut3_move.s>
+
+---
+
+## 1. The idea
+
+Every game, from Pong to Zelda, runs the same loop forever:
+
+```
+READ input  →  UPDATE the world  →  DRAW the result  →  (repeat)
+```
+
+Lesson 2's `spin: bra spin` was that loop with the middle scooped out. Now we fill it in.
+
+**Reading the keyboard** is two memory locations:
+
+- **`$C000`** holds the last key. Its **bit 7** is a "a key is ready" flag: `1` when a fresh
+  key is waiting, `0` when you've already consumed it. The low 7 bits are the ASCII code.
+- **`$C010`** is the *strobe clear*. Touching it (any read) lowers bit 7 so you can detect
+  the **next** press instead of reading the same key over and over.
+
+So "get a key" is: wait until bit 7 of `$C000` is set, clear the strobe, and strip bit 7 to
+get plain ASCII.
+
+## 2. The code
+
+### The loop
+
+```asm
+loop:   lda KBD             ; READ: bit 7 set means a key is waiting
+        bpl loop            ;   not yet -> poll again (BPL = "branch if bit 7 clear")
+        bit KBDSTRB         ;   clear the strobe (ready for the next press)
+        and #$7F            ;   drop bit 7 -> plain ASCII in A
+```
+
+`bpl` ("branch if plus") tests bit 7: while it's clear the key isn't ready, so we loop. Once
+a key arrives we clear the strobe with `bit KBDSTRB` (any access to `$C010` does it) and mask
+off the ready bit.
+
+### Dispatch on the key
+
+We compare the key against each control and branch to a handler. `cmp #'W'` subtracts `'W'`
+from A just to set the flags; `beq up` takes the branch when they matched.
+
+```asm
+        cmp #'W'
+        beq up
+        cmp #'S'
+        beq down
+        cmp #'A'
+        beq left
+        cmp #'D'
+        beq right
+        ; ...arrow-key codes handled the same way...
+        bra redraw          ; unrecognized key: don't move
+```
+
+### Update with bounds, then draw
+
+Before moving, we make sure the hero stays inside the border. `cmp #2` / `bcc` reads as "if
+`hy` is below 2, skip" — a compare-and-branch is how you do "if less than" on the 6502.
+
+```asm
+up:     lda hy
+        cmp #2
+        bcc redraw          ; hy < 2  ->  already at the top, don't move
+        dec hy
+        bra redraw
+```
+
+Each frame we **erase the hero at its old cell, then draw it at the new one** — otherwise it
+would leave a trail:
+
+```asm
+        pha                 ; keep the key while we erase
+        lda #SPACE
+        jsr putcell         ; blank the old cell
+        pla
+        ; ...update hx/hy...
+redraw: lda #HERO
+        jsr putcell         ; stamp the hero at the new cell
+        bra loop
+```
+
+### The drawing primitive
+
+`putcell` is Lesson 2's idea boiled down to one routine: *put the character in A at
+`(hy, hx)`.* It looks the row base up in the tables and stores through the `sptr` pointer.
+
+```asm
+putcell: ldy hx
+        ldx hy
+        pha
+        lda ROWL,x          ; sptr = base of row hy
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        pla
+        sta (sptr),y        ; screen[row hy, column hx] = A
+        rts
+```
+
+Only `hx`/`hy` change from frame to frame; `putcell` turns them into the right screen
+address every time.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut3_move.s> and drive the `@` with
+**W/A/S/D** (arrow keys work too). It won't walk through the border. Press **Q** to quit
+back to the monitor.
+
+Because keypresses are interactive, this program is verified two ways. The starting frame is
+checked headlessly:
+
+```sh
+node codegen/tools/run6502.mjs codegen/programs/tut3_move.s \
+    --expect-mem 0x063C=0xC0 --expect-halt idle
+```
+
+`mem[$063C]==$C0` confirms the `@` starts at row 12, column 20. The *movement* is checked by
+a script that types keys and asserts the hero's `(hx, hy)` afterward — typing `DDDDSSWW`
+lands it at column 24, row 12, exactly where it should be.
+
+## 4. What just happened
+
+You built the skeleton every later lesson hangs things on:
+
+- **poll** for input (`$C000` / `$C010`),
+- **decide** what it means (`cmp` + branch),
+- **change state** with bounds (`hx`, `hy`),
+- **redraw** the changed cells,
+- **loop**.
+
+Notice we only redraw the two cells that changed (erase old, draw new) — never the whole
+screen. That "touch only what moved" habit is what keeps 1 MHz games smooth.
+
+## 5. Make it yours
+
+1. **Diagonals.** Add handlers so `Q`/`E`/`Z`/`C` move two axes at once. (Careful: you're
+   already using `Q` to quit — pick free keys.)
+2. **Wrap around.** Instead of stopping at the border, make leaving the right edge reappear
+   on the left (set `hx` to 1 instead of blocking at 38).
+3. **Leave a trail.** Skip the erase step and watch the hero paint the screen. Add a key
+   that clears it (`jsr HOME` then redraw the border).
+4. **Speed vs. wait.** Right now the loop *blocks* until a key is pressed. In Lesson 5 the
+   loop will run every frame whether or not a key is down — peek ahead and think about why a
+   game needs that.
+
+## Next
+
+Text is great, but games want color. In
+**[Lesson 4 — Color with lo-res graphics](04-lores.md)** we flip the machine into lo-res
+mode and write a `PLOT` routine that lights up colored blocks.

--- a/docs/tutorials/04-lores.md
+++ b/docs/tutorials/04-lores.md
@@ -1,0 +1,163 @@
+# Lesson 4 — Color with lo-res graphics
+
+> **You'll build:** a 16-color palette and a color-cycling block you steer around the screen.
+> **New ideas:** soft switches to change video mode; the lo-res memory layout (two pixels per
+> byte); a reusable `PLOT` routine; 16 colors.
+> **Program:** [`codegen/programs/tut4_lores.s`](../../codegen/programs/tut4_lores.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut4_lores.s>
+
+---
+
+## 1. The idea
+
+So far we've been in text mode. The 3ric can also show **lo-res graphics**: a 40×48 grid of
+chunky blocks in **16 colors**. Same screen memory (`$0400`), different interpretation.
+
+**Switching modes** is done with *soft switches* — special addresses in the `$C05x` range.
+You don't store a value; you just *touch* the address (any read) and the hardware flips. Four
+touches put us in full-screen lo-res:
+
+```asm
+        lda TXTCLR          ; $C050 graphics on (text off)
+        lda FULLSCR         ; $C052 full screen (no text window)
+        lda LORES           ; $C056 lo-res
+        lda LOWSCR          ; $C054 show page 1
+```
+
+**The lo-res memory layout** is the one thing to wrap your head around. Lo-res *reuses* the
+text page, and each screen byte holds **two stacked pixels**:
+
+- the **low nibble** (bottom 4 bits) is the **upper** pixel,
+- the **high nibble** (top 4 bits) is the **lower** pixel.
+
+Because two vertical pixels share one byte, a lo-res row `Y` lives in **text row `Y / 2`**.
+To light one pixel we look up that text row, then change *just one nibble* of the byte —
+leaving its neighbor alone. A nibble holds `0`–`15`: the color.
+
+## 2. The code
+
+### PLOT — the one routine that matters
+
+```asm
+plot:   lda py
+        lsr a               ; text row = py / 2
+        tax
+        lda ROWL,x          ; sptr = base of that text row
+        sta sptr
+        lda ROWH,x
+        sta sptr+1
+        ldy px
+        lda py
+        and #1
+        bne plodd
+        lda (sptr),y        ; even Y -> keep high nibble, set LOW nibble
+        and #$F0
+        ora pcolor
+        sta (sptr),y
+        rts
+plodd:  lda pcolor          ; odd Y -> keep low nibble, set HIGH nibble
+        asl a               ; color << 4 moves it into the high nibble
+        asl a
+        asl a
+        asl a
+        sta ptmp
+        lda (sptr),y
+        and #$0F
+        ora ptmp
+        sta (sptr),y
+        rts
+```
+
+The pattern is **read-modify-write**: load the byte, mask off the half we're changing (`and
+#$F0` keeps the high nibble; `and #$0F` keeps the low), OR in the new color, store it back.
+`lsr a` divides `py` by 2 to find the text row; `and #1` tells us which nibble.
+
+With `plot` in hand, everything else is just *calling it in loops*.
+
+### Drawing the palette
+
+Sixteen colors, drawn as a 16-wide × 4-tall band, color equal to the column offset:
+
+```asm
+        lda #4
+        sta py
+prow:   lda #12
+        sta px
+pcol:   lda px
+        sec
+        sbc #12
+        sta pcolor          ; color = px - 12  (0..15)
+        jsr plot
+        inc px
+        lda px
+        cmp #28
+        bne pcol
+        inc py
+        lda py
+        cmp #8
+        bne prow
+```
+
+### The player, reusing Lesson 3's loop
+
+The game loop is exactly Lesson 3's — poll the key, erase, move, redraw — but now "draw"
+means `plot` a colored block, and every step cycles the color:
+
+```asm
+redraw: inc plcol           ; cycle the color, skipping black (0)
+        lda plcol
+        cmp #16
+        bne rdok
+        lda #1
+        sta plcol
+rdok:   jsr drawplayer
+        bra loop
+```
+
+> **A subtle gotcha.** We clear the keyboard strobe with **`bit KBDSTRB`**, not `lda
+> KBDSTRB`. Both touch `$C010`, but `lda` would overwrite the key we *just* read into `A`.
+> `bit` clears the strobe while leaving `A` alone. (This one bites everybody once.)
+
+`clrscreen` blanks the field by storing `0` across all four pages of `$0400`–`$07FF` — black
+is color `0`, so zero-fill is a clear screen.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut4_lores.s>. You'll see the palette
+strip near the top and a white block in the middle. **W/A/S/D** moves it and it changes color
+as it goes; **Q** returns to text and the monitor.
+
+Headless verification checks two plotted bytes:
+
+```sh
+node codegen/tools/run6502.mjs codegen/programs/tut4_lores.s \
+    --expect-mem 0x050F=0x33 --expect-mem 0x063C=0x0F --expect-halt idle
+```
+
+`mem[$050F]==$33` is a palette cell where both stacked pixels are color 3 (`$3` in each
+nibble); `mem[$063C]==$0F` is the white (`$F`) player block. (In the harness's *text* decode
+these bytes look like gibberish — that's just color data being shown as characters.)
+
+## 4. What just happened
+
+You changed the machine's video mode with a few memory touches, and you wrote the single
+primitive — `plot(x, y, color)` — that every lo-res game is built from. Notice how little new
+there is: the loop, the erase/redraw, the bounds checks all came straight from Lesson 3. Only
+the *drawing* changed.
+
+## 5. Make it yours
+
+1. **Bigger player.** Draw the player as a 2×2 block (four `plot` calls at `x,y`, `x+1,y`,
+   `x,y+1`, `x+1,y+1`). Remember to erase all four.
+2. **Paint mode.** Remove the erase step and hold a direction to draw lines — an
+   Etch-A-Sketch.
+3. **Pick your color.** Instead of auto-cycling, map number keys `1`–`8` to set `plcol`
+   directly.
+4. **A framed arena.** Before the loop, `plot` a border of color 5 (grey) around the field,
+   and add bounds so the player can't cross it (compare against 1 and 38 like Lesson 3).
+
+## Next
+
+The player only moves when you press a key. Real action games move things *every frame*. In
+**[Lesson 5 — Motion and collision](05-motion.md)** we give a ball its own velocity and make
+it bounce off the walls on its own.

--- a/docs/tutorials/05-motion.md
+++ b/docs/tutorials/05-motion.md
@@ -107,7 +107,7 @@ Because the ball never stops on its own, we verify it with a **fixed cycle budge
 waiting for a halt (that's what `verify_run.cjs` does — run exactly *N* cycles, then look):
 
 ```sh
-node verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 \
+node codegen/tools/verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 \
     0x06=0x0C 0x07=0x1C 0x08=0xFF 0x09=0xFF
 ```
 

--- a/docs/tutorials/05-motion.md
+++ b/docs/tutorials/05-motion.md
@@ -1,0 +1,140 @@
+# Lesson 5 — Motion and collision
+
+> **You'll build:** a ball that moves by itself and bounces off all four walls.
+> **New ideas:** the *game loop*; velocity; reflecting off boundaries; a delay for timing.
+> **Program:** [`codegen/programs/tut5_bounce.s`](../../codegen/programs/tut5_bounce.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut5_bounce.s>
+
+---
+
+## 1. The idea
+
+Every game up to now moved something *only when you pressed a key*. Action games are
+different: things move **on their own, every frame**. That "do a little bit, over and over,
+forever" heartbeat is the **game loop**.
+
+To move on its own, the ball needs a **velocity** as well as a position. We store four bytes:
+
+```asm
+bx = $06   ; position X, Y
+by = $07
+vx = $08   ; velocity X: $01 = right, $FF = left
+vy = $09   ; velocity Y: $01 = down,  $FF = up
+```
+
+We use `$01` and `$FF` for the velocities because on the 6502 adding `$FF` is the same as
+subtracting 1 (it wraps). So "move" is just `pos = pos + vel` — one add handles both
+directions. The trick is stopping the ball from wrapping *past* a wall, which is where
+**collision** comes in.
+
+## 2. The code
+
+### The loop skeleton
+
+```asm
+loop:   lda KBD             ; non-blocking quit check (don't wait!)
+        bpl move
+        bit KBDSTRB
+        and #$7F
+        cmp #'Q'
+        beq quit
+
+move:   jsr eraseball       ; 1. rub out the old ball
+        ;   ... update X, then Y (below) ...
+draw:   jsr drawball        ; 2. draw it at the new spot
+        jsr delay           ; 3. pause so the eye can follow
+        bra loop            ; 4. forever
+```
+
+Notice the key check uses `bpl move` and falls straight through — it **never waits**. If no
+key is down we just keep animating. That's the difference between an *event* loop (Lesson 3)
+and a *game* loop.
+
+### Bouncing off a wall
+
+For each axis: if we're heading toward a wall and already at it, flip the velocity and step
+*away*; otherwise step normally. Here's X:
+
+```asm
+        lda vx
+        bmi xneg            ; heading left?
+        lda bx              ; heading right:
+        cmp #XMAX
+        bcc xinc            ;   not at the wall -> just move
+        lda #$FF            ;   at right wall -> reverse
+        sta vx
+        dec bx
+        bra ymove
+xinc:   inc bx
+        bra ymove
+xneg:   lda bx              ; heading left:
+        beq xflip           ;   at left wall (0) -> reverse
+        dec bx
+        bra ymove
+xflip:  lda #$01
+        sta vx
+        inc bx
+```
+
+The Y axis is the identical shape with `YMAX` (47) instead of `XMAX` (39). Reflecting a ball
+is exactly this: when it reaches an edge, negate the velocity on that axis. Horizontal and
+vertical bounces are independent, which is why a corner hit reverses *both*.
+
+### Timing
+
+Computers are fast — without a pause the ball would blur across the screen in an instant.
+`delay` just burns time in a nested countdown:
+
+```asm
+delay:  ldx #$40
+dl1:    ldy #$FF
+dl2:    dey
+        bne dl2
+        dex
+        bne dl1
+        rts
+```
+
+Change `#$40` to make the ball slower or faster. This is a crude timer; later you'd sync to
+the video frame, but a delay loop is perfect for learning.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut5_bounce.s>. A white dot sails from the
+top-left, bounces around the box, and keeps going until you press **Q**.
+
+Because the ball never stops on its own, we verify it with a **fixed cycle budget** instead of
+waiting for a halt (that's what `verify_run.cjs` does — run exactly *N* cycles, then look):
+
+```sh
+node verify_run.cjs codegen/programs/tut5_bounce.s 0x0800 2000000 \
+    0x06=0x0C 0x07=0x1C 0x08=0xFF 0x09=0xFF
+```
+
+After 2,000,000 cycles the ball has bounced off the **right** wall (`vx` is now `$FF` =
+left) and the **bottom** (`vy` is now `$FF` = up), sitting at (12, 28) heading up-left.
+Checking the velocity bytes flipped is a neat way to prove the collision code actually fired.
+
+## 4. What just happened
+
+You wrote your first real game loop: erase → update → draw → delay → repeat. You gave an
+object a velocity and made it obey the walls. Every arcade game — Pong, Breakout, Asteroids —
+is this same loop with more objects and smarter rules.
+
+## 5. Make it yours
+
+1. **Speed and angle.** Start `vx`/`vy` at different times, or change the delay, to feel how
+   timing changes the game.
+2. **Leave a trail.** Delete the `jsr eraseball` call and watch the ball paint the whole
+   screen like a bouncing-lines screensaver.
+3. **A paddle.** Bring back Lesson 3's input to move a 1-pixel-wide paddle along the bottom
+   row with A/D, and make the ball reverse `vy` only when it hits the paddle's column —
+   you've started Breakout.
+4. **Two balls.** Add `bx2/by2/vx2/vy2` and a second draw/update. How little code does a
+   second ball actually take?
+
+## Next
+
+A ball that bounces forever is hypnotic but it's not a *game* yet — nothing is random and
+there's no score. In **[Lesson 6 — Randomness and scoring](06-random.md)** we add a random
+target to catch and an on-screen score, mixing lo-res graphics with a text HUD.

--- a/docs/tutorials/06-random.md
+++ b/docs/tutorials/06-random.md
@@ -104,7 +104,7 @@ the game fully testable. We drive the player left 18 and up 19 to reach it and c
 score ticks to 1:
 
 ```sh
-node verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 \
+node codegen/tools/verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 \
     "AAAAAAAAAAAAAAAAAAWWWWWWWWWWWWWWWWWWW" 0x06=0x02 0x07=0x01 0x0A=0x01
 ```
 

--- a/docs/tutorials/06-random.md
+++ b/docs/tutorials/06-random.md
@@ -1,0 +1,135 @@
+# Lesson 6 — Randomness and scoring
+
+> **You'll build:** a catch-the-food game with random targets and a live score.
+> **New ideas:** mixed graphics+text mode; a pseudo-random number generator; collision by
+> comparison; drawing a decimal number.
+> **Program:** [`codegen/programs/tut6_catch.s`](../../codegen/programs/tut6_catch.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut6_catch.s>
+
+---
+
+## 1. The idea
+
+Two things separate a *toy* from a *game*: a goal that isn't the same every time (randomness)
+and feedback that you're winning (a score). This lesson adds both.
+
+We also want the score *visible*. The 3ric can show a **mixed** screen — lo-res graphics on
+top with a **four-line text window** across the bottom — by touching one soft switch:
+
+```asm
+        lda TXTCLR          ; graphics on
+        lda MIXSET          ; $C053 mixed: lo-res + 4 text rows at the bottom
+        lda LORES
+        lda LOWSCR
+```
+
+Now the top of the screen (lo-res rows 0–39) is our playfield and text rows 20–23 are a HUD.
+
+## 2. The code
+
+### Random numbers with an LFSR
+
+There's no "random" instruction, so we make our own with a **linear-feedback shift register**
+— shift the bits and, on certain shifts, flip a fixed pattern. It cycles through 255 values in
+a scrambled order that *looks* random:
+
+```asm
+rng:    lda seed
+        lsr a               ; shift right
+        bcc rnods           ; if the bit that fell off was 1...
+        eor #$B8            ; ...flip the "tap" bits
+rnods:  sta seed
+        rts
+```
+
+Seed it with any non-zero value and each call returns the next number. It's completely
+deterministic (great for testing) but unpredictable enough for a game.
+
+We need a coordinate in 0–39, but `rng` gives 0–255. **Rejection sampling** is the honest
+way: mask to 0–63 and just re-roll anything too big.
+
+```asm
+randc:  jsr rng
+        and #$3F            ; 0..63
+        cmp #40
+        bcs randc           ; >=40 -> throw it away, roll again
+        rts
+```
+
+### Collision is just a comparison
+
+Two 1-pixel objects collide when their coordinates match. After moving the player we check:
+
+```asm
+after:  lda hx
+        cmp fx
+        bne nocatch
+        lda hy
+        cmp fy
+        bne nocatch
+        inc score           ; hx==fx AND hy==fy -> caught!
+        jsr drawhud
+        jsr newfood
+nocatch:
+```
+
+`newfood` rolls a fresh `fx,fy` and retries if it lands on the player, so the target never
+appears under you.
+
+### Drawing the score
+
+Text cells want the **high bit set** for normal (bright) video, so we `ora #$80` on letters
+and `ora #$B0` on digits (`$B0` is `'0'` with the high bit already on). To print the number we
+split it into tens and ones by subtracting 10 until we can't:
+
+```asm
+dh3:    cmp #10
+        bcc dh4
+        sec
+        sbc #10
+        inx                 ; count the tens
+        bra dh3
+dh4:    ...                 ; A = ones digit, X = tens digit
+```
+
+We write the label and digits straight into text-row 20 at `$0650`.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut6_catch.s>. Steer the white block with
+**W/A/S/D** onto the yellow food; each catch bumps **SCORE** and drops new food. **Q** quits.
+
+The RNG is seeded to a fixed value, so the *first* food always lands at (2, 1) — which makes
+the game fully testable. We drive the player left 18 and up 19 to reach it and confirm the
+score ticks to 1:
+
+```sh
+node verify_keys.cjs codegen/programs/tut6_catch.s 0x0800 \
+    "AAAAAAAAAAAAAAAAAAWWWWWWWWWWWWWWWWWWW" 0x06=0x02 0x07=0x01 0x0A=0x01
+```
+
+The harness even shows `SCORE: 01` in the decoded text window — the HUD really is being drawn.
+
+## 4. What just happened
+
+You turned a mover into a *game*: a random goal, collision, and a score the player can see.
+The LFSR is a workhorse you'll reuse for enemy placement, item drops, and screen effects. And
+mixed mode — graphics plus a text HUD — is exactly how countless arcade and 8-bit games laid
+out their screens.
+
+## 5. Make it yours
+
+1. **Countdown.** Add a second number to the HUD and decrement it every N moves; end the game
+   at zero (jump to `quit`).
+2. **Rotten food.** Occasionally (say when `rng` is even) make the food red and *subtract* a
+   point if caught.
+3. **Two foods.** Track `fx2,fy2` and draw both; catching either scores.
+4. **Better randomness.** Re-seed `seed` from a fast-changing source — for example, read the
+   keyboard-strobe or a counter that increments every loop — so the first food differs each run.
+
+## Next
+
+You now have every building block a small game needs: modes, drawing, input, motion,
+collision, randomness, and score. In **[Lesson 7 — Space Invaders](07-invaders.md)** we put
+them all together into the capstone: a formation of aliens, a cannon, a bullet, and win/lose
+states.

--- a/docs/tutorials/07-invaders.md
+++ b/docs/tutorials/07-invaders.md
@@ -1,0 +1,166 @@
+# Lesson 7 — Space Invaders (capstone)
+
+> **You'll build:** a playable lo-res Space Invaders — a marching fleet, a cannon, a bullet,
+> collision, score, and win/lose screens.
+> **New ideas:** a game *state machine*; storing a fleet as data (origin + per-alien flags);
+> edge-detect-and-reverse movement; tying every earlier lesson together.
+> **Program:** [`codegen/programs/tut7_invaders.s`](../../codegen/programs/tut7_invaders.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut7_invaders.s>
+
+---
+
+## 1. The idea
+
+This is the whole series in one program. Nothing here is *new* except how the pieces fit
+together:
+
+| From | We reuse |
+| --- | --- |
+| Lesson 3 | non-blocking keyboard input |
+| Lesson 4 | `plot` + lo-res color |
+| Lesson 5 | the game loop and per-frame motion |
+| Lesson 6 | mixed mode, a text HUD, collision-by-compare |
+
+The design work is **data layout** and a tiny **state machine** (playing → win/lose →
+restart). Get those right and the code almost writes itself.
+
+## 2. The design
+
+### The fleet is data, not code
+
+We never hard-code where the aliens are. We store a **formation origin** and let math place
+each alien:
+
+```asm
+fleetx  = $0B   ; X of the left column
+fleety  = $0C   ; Y of the top row
+alive:  .byte 1,1,1,1,1   ; 5 columns x 3 rows, row-major
+        .byte 1,1,1,1,1
+        .byte 1,1,1,1,1
+```
+
+Alien `(row, col)` lives at `ax = fleetx + col*3`, `ay = fleety + row*3`, and it's on screen
+only if `alive[row*5 + col]` is non-zero. To move the *entire* fleet we change **two bytes**
+(`fleetx`, `fleety`); to kill one alien we clear **one byte**. That's the power of separating
+data from drawing — three little helpers turn `(row,col)` into an index or a position:
+
+```asm
+alienidx: lda arow          ; index = arow*5 + acol
+        asl a
+        asl a
+        clc
+        adc arow
+        clc
+        adc acol
+        tax
+        lda alive,x
+        rts
+```
+
+### Marching: step, and reverse at the edge
+
+Every `FLEETPD` frames the fleet steps sideways. When the formation reaches a wall it drops
+one row and reverses — the signature Space Invaders move:
+
+```asm
+        lda fleetx          ; heading right
+        clc
+        adc #13             ; right edge of the formation
+        cmp #38
+        bcc mf_right        ; room left -> just step right
+        lda #$FF            ; at the wall -> reverse...
+        sta fleetdir
+        inc fleety          ; ...and drop a row
+```
+
+`FLEETPD` is the difficulty knob: smaller = faster fleet. Classic games shrink it as aliens
+die; try that in the exercises.
+
+### Firing and collision
+
+The cannon fires **one** bullet at a time. `hitcheck` walks the fleet each frame and, because
+aliens are two pixels wide, matches the bullet against `ax` *or* `ax+1`:
+
+```asm
+        jsr alienx          ; A = ax
+        sta ptmp
+        cmp bx
+        beq hc_xok
+        clc
+        adc #1              ; ax+1  (aliens are 2 px wide)
+        cmp bx
+        bne hc_next
+hc_xok: jsr alieny
+        cmp by
+        bne hc_next
+        ; hit! clear alive[i], stop the bullet, score++
+```
+
+### The state machine
+
+A single byte `state` (0 = playing, 1 = win, 2 = lose) drives everything. The loop checks two
+end conditions each frame:
+
+```asm
+        lda count           ; no aliens left -> win
+        bne notwin
+        jmp win
+notwin: lda fleety          ; fleet reached the cannon -> lose
+        clc
+        adc #6
+        cmp #38
+        bcc draw
+        jmp lose
+```
+
+`win` and `lose` paint a message into the HUD and wait for **R** (jump back to `restart`,
+which re-fills `alive` and resets the counters) or **Q**. `restart` is just the setup code with
+a label on it — reusing it for "new game" costs nothing.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut7_invaders.s>. Move with **A/D**, fire
+with **SPACE**, and clear the fleet before it lands. After a win or loss, press **R** to play
+again or **Q** to quit.
+
+Two headless checks pin down the core mechanics. First, the fresh-game state:
+
+```sh
+node verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "" \
+    0x0E=0x0F 0x0F=0x00 0x07=0x00 0x06=0x14
+```
+
+`count == 15`, `score == 0`, `state == 0`, cannon centered. Then an aligned shot — slide the
+cannon under the right column and fire:
+
+```sh
+node verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "AA ZZZZZZZZ" \
+    0x06=0x12 0x0E=0x0E 0x0F=0x01 0x0A=0x00
+```
+
+The bullet climbs, an alien dies (`count` 15 → 14), `score` ticks to 1, and the bullet is
+consumed (`bactive == 0`). The HUD even shows `SCORE: 01`.
+
+## 4. What just happened
+
+You shipped a game. More importantly, you used the pattern every game is built on: **state
+lives in a few bytes, the loop reads input → updates state → draws, and "objects" are just
+data your routines interpret.** A 15-alien fleet took two origin bytes and a 15-byte array.
+Scale that idea up — more arrays, more state — and you have any game you can imagine.
+
+## 5. Make it yours
+
+1. **Ramp the difficulty.** Lower `FLEETPD` as `count` drops so the fleet speeds up — the
+   trademark Space Invaders panic.
+2. **Aliens shoot back.** Give the fleet its own bullet: pick a random live column (Lesson 6's
+   RNG), drop a bullet from its bottom alien, and check it against the cannon.
+3. **Lives and levels.** Add a `lives` byte to the HUD; on a win, `jmp restart` but keep the
+   score to make a level 2.
+4. **Bunkers.** Draw a few grey blocks above the cannon and let both bullets chip them away
+   (clear a pixel on contact).
+
+## Next
+
+You've built a complete game in lo-res. In **[Lesson 8 — Hi-res and where to go
+next](08-hires.md)** we peek at the 3ric's high-resolution mode, then map the shipped games
+(`swarm`, `rocks`, `jungle`) so you can keep learning from real, finished code.

--- a/docs/tutorials/07-invaders.md
+++ b/docs/tutorials/07-invaders.md
@@ -78,8 +78,11 @@ die; try that in the exercises.
 
 ### Firing and collision
 
-The cannon fires **one** bullet at a time. `hitcheck` walks the fleet each frame and, because
-aliens are two pixels wide, matches the bullet against `ax` *or* `ax+1`:
+The cannon fires **one** bullet at a time. `hitcheck` walks the fleet each frame. Aliens are
+two pixels wide, so it matches the bullet against `ax` *or* `ax+1`. And because the bullet
+climbs **two rows per frame**, it can jump clean over a row — so we accept `by` *or* `by+1`
+too. Without that, an alien on an odd row (which is exactly what happens after the fleet
+drops) could never be hit: the bullet's row stays even and steps right past it.
 
 ```asm
         jsr alienx          ; A = ax
@@ -90,10 +93,14 @@ aliens are two pixels wide, matches the bullet against `ax` *or* `ax+1`:
         adc #1              ; ax+1  (aliens are 2 px wide)
         cmp bx
         bne hc_next
-hc_xok: jsr alieny
+hc_xok: jsr alieny          ; A = ay
+        cmp by              ; the bullet's row...
+        beq hc_hit
+        sec
+        sbc #1              ; ...or the row it skipped (ay-1 == by)
         cmp by
         bne hc_next
-        ; hit! clear alive[i], stop the bullet, score++
+hc_hit: ; hit! clear alive[i], stop the bullet, score++
 ```
 
 ### The state machine
@@ -126,7 +133,7 @@ again or **Q** to quit.
 Two headless checks pin down the core mechanics. First, the fresh-game state:
 
 ```sh
-node verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "" \
+node codegen/tools/verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "" \
     0x0E=0x0F 0x0F=0x00 0x07=0x00 0x06=0x14
 ```
 
@@ -134,7 +141,7 @@ node verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "" \
 cannon under the right column and fire:
 
 ```sh
-node verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "AA ZZZZZZZZ" \
+node codegen/tools/verify_keys.cjs codegen/programs/tut7_invaders.s 0x0800 "AA ZZZZZZZZ" \
     0x06=0x12 0x0E=0x0E 0x0F=0x01 0x0A=0x00
 ```
 

--- a/docs/tutorials/08-hires.md
+++ b/docs/tutorials/08-hires.md
@@ -1,0 +1,143 @@
+# Lesson 8 — Hi-res, and where to go next
+
+> **You'll build:** a 280×192 hi-res starfield with three rulers, then get a map of the
+> shipped games to study next.
+> **New ideas:** hi-res mode and its interleaved row memory; precomputing an address table;
+> reading real, finished 3ric games.
+> **Program:** [`codegen/programs/tut8_hires.s`](../../codegen/programs/tut8_hires.s) ·
+> **▶ Run it:** <https://ebadger.github.io/3ric/?src=programs/tut8_hires.s>
+
+---
+
+## 1. The idea
+
+Lo-res gave us 40×48 chunky color. **Hi-res** gives us **280×192** — six times the detail —
+and it's where the shipped 3ric games live. The trade-off is a stranger memory layout.
+
+Hi-res page 1 is `$2000–$3FFF`. Each byte holds **7 horizontal pixels** (bits 0–6, bit 0 =
+leftmost); bit 7 selects the color palette. So a full-width white line is `$7F` in every byte
+across a row.
+
+The catch is that **rows are interleaved** — row *y* is *not* simply `$2000 + y*40`. The
+address is the famous Apple-II formula:
+
+```
+addr(y) = $2000 + (y & 7)*$400 + ((y>>3) & 7)*$80 + (y>>6)*$28
+```
+
+Computing that per pixel would be slow and error-prone, so we do it **once** into a 192-entry
+lookup table and never think about it again.
+
+## 2. The code
+
+### Precomputing the row table
+
+`build_rows` (lifted straight from the shipped `swarm.s`) fills `ROWL[y]`/`ROWH[y]` with the
+low and high bytes of each row's address. We park those 192-byte tables in free RAM at
+`$6000`/`$6100`, well clear of both our program (`$0800`) and the screen (`$2000`):
+
+```asm
+SCREEN  = $2000
+ROWL    = $6000
+ROWH    = $6100
+```
+
+After `jsr build_rows`, drawing to row *y* is just: read `ROWL/ROWH[y]` into a pointer, then
+index by the byte column.
+
+### A white line
+
+```asm
+hline:  tay
+        lda ROWL,y          ; ptr = address of this pixel row
+        sta ptr
+        lda ROWH,y
+        sta ptr+1
+        ldy #39
+        lda #$7F            ; all 7 pixels on
+hl1:    sta (ptr),y
+        dey
+        bpl hl1
+        rts
+```
+
+We call it for rows 0, 96, and 191 — top, middle, bottom rulers.
+
+### A starfield without dividing by 7
+
+To place a single pixel you normally need `column = x / 7` and `bit = x mod 7` — a division.
+We sidestep it entirely: the starfield picks a **column (0–39)** and a **bit (0–6)** *directly*
+from the RNG, so there's nothing to divide:
+
+```asm
+        jsr rndbit          ; A = a one-bit mask from BITMASK
+        ldy col
+        ora (ptr),y         ; OR it in (don't clobber nearby stars)
+        sta (ptr),y
+```
+
+`BITMASK` is just `$01,$02,$04,$08,$10,$20,$40` — the seven pixel positions in a byte. Using
+`ora` means each star lights its own pixel without erasing its neighbours.
+
+> **Note the 65C02 touch:** the star loop uses `phx`/`plx` to save the counter across the
+> subroutine calls — instructions the original 6502 didn't have. The 3ric is a 65C02, so
+> they're fair game.
+
+## 3. Run it
+
+Open <https://ebadger.github.io/3ric/?src=programs/tut8_hires.s>: three crisp white lines and
+a sprinkling of stars, at a resolution lo-res can't touch. **Q** returns to text.
+
+Because the row table and pixel math are the whole point, we verify the rulers landed at the
+*exact* interleaved addresses the formula predicts:
+
+```sh
+node codegen/tools/run6502.mjs codegen/programs/tut8_hires.s \
+    --expect-mem 0x2000=0x7F --expect-mem 0x2228=0x7F \
+    --expect-mem 0x3FD0=0x7F --expect-halt idle
+```
+
+Row 0 → `$2000`, row 96 → `$2228`, row 191 → `$3FD0`. If `build_rows` were even one bit off,
+these would miss.
+
+## 4. Where to go next
+
+You now have the whole toolkit: text and lo-res and hi-res video, input, the game loop,
+motion, collision, randomness, score, and state machines. The best next step is to **read
+finished games** and modify them. They all live in `emulator/AICodeGen/` and run in the same
+browser emulator (open one from the editor's sample picker):
+
+| Game | File | What it teaches |
+| --- | --- | --- |
+| **Star Swarm** | `swarm/swarm.s` | The hi-res Space Invaders this series builds toward — sprite blitting, a HUD, bombs, a saucer. The "full version" of Lesson 7. |
+| **Rock Storm** | `rocks/rocks.s` | Asteroids-style vector drawing, rotation, thrust, and wrap-around motion. |
+| **Jungle Quest** | `jungle/jungle.s` | A hi-res platformer: gravity, jumping, scrolling, and tile collision. |
+| **Brick Buster** | `bricks/bricks.s` | Breakout in text mode — a compact take on ball/paddle/brick collision. |
+| **Paddles** | `paddles/paddles.s` | Two-player Pong; the simplest place to study game *rules* and scoring. |
+| **Minefield** | `mines/mines.s` | Minesweeper — grids, flood fill, and mouse-free cursor UI. |
+| **Life** | `life/life.s` | Conway's Game of Life: neighbour counting and double-buffering. |
+| **2048** | `2048/2048.s` | Sliding-tile logic and merging in a 4×4 grid. |
+
+And the two reference docs that describe the machine precisely:
+
+- [`codegen/platform/platform-ref.md`](../../codegen/platform/platform-ref.md) — the memory
+  map, soft switches, and ROM entry points.
+- [`codegen/platform/prompt-system.md`](../../codegen/platform/prompt-system.md) — the
+  assembler dialect and calling conventions.
+
+## 5. Make it yours
+
+1. **Twinkle.** In the `spin` loop, plot one fresh random star per frame with a small delay so
+   the field slowly fills.
+2. **A box, not lines.** Add left/right edges (bit `$01` in column 0, `$40` in column 39, down
+   every row) to frame the screen.
+3. **A moving dot.** Track a star's `col` and `bit`; each frame shift the bit left, and when it
+   passes bit 6 reset it to bit 0 and `inc col`. You've handled the /7 boundary by hand.
+4. **Port a lo-res lesson.** Re-draw Lesson 5's bouncing ball in hi-res using this `plot`
+   approach — the game logic doesn't change, only the drawing.
+
+## The end
+
+That's the series: from `HELLO` to Space Invaders to hi-res. You've written eight real
+programs and verified every one on the actual machine. Now open a shipped game, change a
+number, and see what happens — that's how everyone learned. Have fun.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,263 @@
+# 3ric Game Programming Tutorials
+
+> Learn to write games in **65C02 assembly** on the 3ric — with nothing to install.
+> Every lesson runs in the in-browser **Assemble & Run** editor at
+> <https://ebadger.github.io/3ric/>, so you can read, edit, re-assemble, and run each
+> program with one click.
+
+**Status: complete.** All eight lessons and their example programs are written and
+**verified on the emulator**. Start with the live index at
+<https://ebadger.github.io/3ric/tutorials.html> (or the **Tutorials** link in the site
+header), or jump straight to **[Lesson 1 — Hello, 3ric](01-hello.md)**. Each lesson links a
+one-click **▶ Run it** button that opens its program in the browser editor.
+
+---
+
+## Who this is for
+
+You've programmed a little in *some* language (variables, loops, `if`) but have never
+written assembly — or you've dabbled in 6502 and want to *make games* with it. You do
+**not** need to own any hardware, install a toolchain, or know Apple II lore. If you can
+open a web page, you can do every lesson.
+
+By the end you'll be able to read the 3ric's shipped games (`snake`, `bricks`, `rocks`,
+`swarm`, `jungle`, …) and write your own.
+
+## How the series works
+
+Each lesson is a short markdown page with four parts:
+
+1. **The idea** — one new concept (drawing, input, motion, collision, randomness…),
+   explained in plain language with a picture of the memory involved.
+2. **The code** — a small, fully-commented `.s` program that *builds on the previous
+   lesson's program*. We add one capability at a time; nothing is a black box.
+3. **Run it** — a one-click link that opens the program in the browser editor and runs
+   it: `https://ebadger.github.io/3ric/?src=programs/<name>.s`.
+4. **Make it yours** — 2–4 exercises that change or extend the program, from
+   one-liners to a small feature.
+
+Because the lessons build on each other, by Lesson 7 you've assembled a complete little
+game out of parts you wrote yourself.
+
+### How the examples stay honest
+
+Every example program lives in [`codegen/programs/`](../../codegen/programs) as a real
+`.s` file. That means:
+
+- It is **auto-staged to the live site** by `web/build.ps1`, so the "Run it" deep link
+  always works (`?src=programs/<name>.s`).
+- It is **verified headlessly** with the project harness before shipping — e.g.
+  `node codegen/tools/run6502.mjs codegen/programs/<name>.s --expect-serial "…"` — so the
+  code in the tutorial is guaranteed to assemble and run, never hand-waved. (This follows
+  the project rule: *prove 6502 behavior on the emulator, never fake it.*)
+
+If you've cloned the repo you can run any example locally exactly the way the site does;
+if you haven't, the browser is all you need.
+
+## What you'll need to know first (a 2-minute primer)
+
+The 65C02 is an 8-bit CPU. The whole mental model for these lessons:
+
+- **Three registers** you use constantly: **A** (accumulator — the "hands", where math
+  and comparisons happen), **X** and **Y** (index registers — counters and offsets).
+  Each holds one byte (0–255).
+- **Memory** is one flat list of byte-addressable cells from `$0000` to `$FFFF` (`$` =
+  hexadecimal). *Some* of those cells aren't RAM — they're the **screen**, the
+  **keyboard**, and **soft switches** that flip the machine's modes. Writing a game is
+  mostly "put the right byte in the right memory cell at the right time."
+- **Instructions** are tiny: load a byte into a register (`LDA`), store it back to memory
+  (`STA`), add/compare (`ADC`/`CMP`), jump/branch (`JMP`/`BNE`), call a subroutine
+  (`JSR`/`RTS`). We introduce each one the first time we need it — you don't have to learn
+  them up front.
+
+Everything else (addressing modes, the status flags, the stack) we teach *just in time*,
+in the lesson where it first earns its keep.
+
+## The 3ric, as a game machine
+
+The teaching subset of the hardware. Full detail is in the auto-generated
+[`platform reference`](../../codegen/platform/platform-ref.md).
+
+| Capability | What you get | Where it lives |
+| --- | --- | --- |
+| **Text** | 40 columns × 24 rows of characters | screen RAM at `$0400`–`$07FF` |
+| **Lo-res color** | 40 × 48 blocks (or 40 × 40 + a 4-row text HUD in *mixed* mode), 16 colors | same `$0400` page, two pixels per byte |
+| **Hi-res** | 280 × 192 dots | `$2000`–`$3FFF` (page 1) |
+| **Keyboard** | last key at `$C000` (bit 7 = "a key is ready"); touch `$C010` to clear it | soft-switch page |
+| **Mode switches** | text/graphics, lo/hi-res, full/mixed, page 1/2 | `$C050`–`$C057` |
+| **ROM helpers** | `COUT` ($FDED) prints a char; `HOME` ($FC58) clears the text screen; and ~1800 more | Monitor ROM |
+
+Two conventions used by every program in the series:
+
+- A program is loaded at, and starts running from, its **`.org` address** (we use
+  `$0800`, a chunk of free RAM). On real hardware that's `BRUN NAME.PRG 0800`.
+- A program **ends with `BRK`**, which drops back to the monitor. (In the browser you just
+  press Reset or run something else.)
+
+---
+
+## The lessons
+
+A 40-second summary of the whole arc, then the detail. Each lesson adds one capability
+and reuses the routines from the lessons before it.
+
+| # | Title | The big new idea | You build | Mode |
+| --- | --- | --- | --- | --- |
+| 1 | [Hello, 3ric](01-hello.md) | assemble/run; registers; a loop; printing | a message on screen | text |
+| 2 | [Drawing on the text screen](02-text-screen.md) | screen memory is just bytes | a titled, bordered scene + HUD | text |
+| 3 | [Input and the game loop](03-input.md) | read the keyboard; the read→update→draw loop | a hero you walk around | text |
+| 4 | [Color with lo-res graphics](04-lores.md) | mode switches; a `PLOT` routine | a movable color block | lo-res |
+| 5 | [Motion and collision](05-motion.md) | velocity; bouncing off walls | a bouncing ball | lo-res |
+| 6 | [Randomness and scoring](06-random.md) | an LFSR; spawning; keeping score | catch-the-food | lo-res |
+| 7 | [Space Invaders](07-invaders.md) | game states; formation AI; win/lose/restart | Space Invaders, start to finish | lo-res |
+| 8 | [Hi-res and beyond](08-hires.md) | hi-res dots; where to go next | a hi-res starfield | hi-res |
+
+### Lesson 1 — Hello, 3ric
+- **Goal:** get a program written, assembled, and running in the browser; understand the
+  loop that prints text.
+- **You'll learn:** the Assemble & Run editor; `.org` and the `.PRG`/`BRK` model;
+  `LDA`/`STA` and immediate vs. loaded values; a simple `LDX`/`INX`/`BNE` loop; the `COUT`
+  ROM routine; why screen/serial text uses **high-bit ASCII** (`'A'` → `$C1`) and `$8D`
+  for a carriage return.
+- **You'll build:** a program that prints a banner (e.g. `HELLO, 3RIC`) to the screen.
+- **Program:** `codegen/programs/tut1_hello.s` — a fully-commented cousin of the existing
+  [`hello.s`](../../codegen/programs/hello.s).
+- **Verified by:** `--expect-serial "HELLO, 3RIC"`.
+- **Make it yours:** change the message; print it twice; print your name on a second line.
+
+### Lesson 2 — Drawing on the text screen
+- **Goal:** stop using `COUT` and put bytes on the screen yourself — the foundation of all
+  drawing.
+- **You'll learn:** the text page at `$0400`; that rows are **not** stored back-to-back
+  (the interleaved layout) and how a small **row-address table** solves that; writing a
+  character by storing its (high-bit) code straight into screen RAM with indexed
+  addressing (`STA base,X`); `HOME` to clear; **inverse** video for a highlighted HUD.
+- **You'll build:** a static "game screen": a border box, a centered title, and a
+  `SCORE: 000` HUD line.
+- **Program:** `codegen/programs/tut2_screen.s`.
+- **Verified by:** decoding the 40×24 text screen and matching the drawn text.
+- **Make it yours:** move the box; change the border character; add a second HUD field.
+
+### Lesson 3 — Input and the game loop
+- **Goal:** make something *interactive* — the heart of every game.
+- **You'll learn:** reading the keyboard at `$C000` (bit 7 = ready) and clearing the
+  strobe at `$C010`; the universal **read → update → draw** loop; comparing the key with
+  `CMP` and branching (`BEQ`/`BNE`) to handle W/A/S/D and the arrow keys; storing the
+  player's X/Y in **zero-page** variables; erasing the old cell before drawing the new one;
+  keeping the player inside the border.
+- **You'll build:** a `@` hero you walk around inside the Lesson 2 box.
+- **Program:** `codegen/programs/tut3_move.s`.
+- **Verified by:** feeding scripted keypresses and asserting the hero's final position in
+  memory.
+- **Make it yours:** add diagonal keys; wrap around the edges instead of stopping; leave a
+  trail.
+
+### Lesson 4 — Color with lo-res graphics
+- **Goal:** turn on color graphics and draw blocks.
+- **You'll learn:** the mode **soft switches** (`$C050` graphics, `$C056` lo-res, `$C053`
+  mixed, `$C054` page 1) and that you *touch* them, not write values; the lo-res memory
+  model (each screen byte is **two stacked pixels** — low nibble on top, high nibble on
+  the bottom) and how a lo-res row maps to a text row; a reusable **`PLOT` subroutine**
+  (given X, Y, color) — the same nibble-packing idiom the shipped `snake.s` uses; the
+  16-color palette.
+- **You'll build:** a color swatch test, then a single block you move with the keyboard
+  (Lesson 3's input, now in color).
+- **Program:** `codegen/programs/tut4_lores.s`.
+- **Verified by:** asserting the plotted screen bytes for a few known cells.
+- **Make it yours:** cycle the block's color as it moves; draw a color gradient; plot your
+  initials.
+
+### Lesson 5 — Motion and collision
+- **Goal:** make things move on their own and react to walls.
+- **You'll learn:** representing **velocity** as a per-axis delta (`+1`/`−1`, stored as
+  `$01`/`$FF`); advancing position every frame; detecting a wall hit with `CMP` and
+  **reflecting** (flip the delta); pacing the loop so it's watchable; the erase-old /
+  draw-new pattern applied to a moving object.
+- **You'll build:** a ball that bounces around the lo-res field; a keypress nudges it.
+- **Program:** `codegen/programs/tut5_bounce.s`.
+- **Verified by:** running N frames headlessly and asserting the ball bounced (position /
+  direction changed as expected).
+- **Make it yours:** add gravity; speed the ball up on each bounce; add a second ball.
+
+### Lesson 6 — Randomness and scoring
+- **Goal:** add the two things that make a game a game — surprise and a score.
+- **You'll learn:** why you need pseudo-randomness and how a tiny **LFSR** produces it
+  (the `seedL`/`seedH` trick from `snake.s`); mapping a random byte into a field
+  coordinate; spawning food and re-spawning it when eaten; simple "am I standing on it?"
+  collision; incrementing a score and updating the HUD digits from Lesson 2.
+- **You'll build:** a player block that chases randomly-placed food; each pickup scores
+  and respawns the food.
+- **Program:** `codegen/programs/tut6_catch.s`.
+- **Verified by:** a fixed seed → deterministic food positions → scripted moves reach a
+  known score.
+- **Make it yours:** add a countdown timer; make some food worth more; add a "bad" cell to
+  avoid.
+
+### Lesson 7 — A complete game: Space Invaders
+- **Goal:** assemble everything so far into a finished, replayable arcade game.
+- **You'll learn:** a simple **game-state machine** (title → play → game-over → restart);
+  driving a **formation** of invaders that marches side to side, drops a row at the edges,
+  and speeds up as its ranks thin; a player cannon and a bullet that travels up the field
+  (Lesson 5's motion); bullet-vs-invader and invader-vs-cannon collision (Lesson 6's
+  collision); score and lives on the text HUD; a title screen and a restart key. It's built
+  in **lo-res**, so every technique carries straight over from Lessons 4–6.
+- **You'll build:** Space Invaders — slide a cannon along the bottom and clear a marching
+  block of invaders before they reach you.
+- **Program:** `codegen/programs/tut7_invaders.s`.
+- **Verified by:** scripted play — a fired shot removes an invader and bumps the score;
+  letting the formation reach the cannon triggers game-over.
+- **The full version:** afterward you'll be able to read the shipped, hi-res
+  [`swarm.s`](../../emulator/AICodeGen/swarm/swarm.s) (STAR SWARM) — the same game grown up
+  with destructible shields, a bonus saucer, and hi-res sprites.
+- **Make it yours:** add shields; a bonus saucer; let the invaders shoot back.
+
+### Lesson 8 — Hi-res and beyond
+- **Goal:** peek at the high-resolution screen and point the way to bigger projects.
+- **You'll learn:** switching to **hi-res** (`$C057`, page 1 at `$2000`); the
+  7-dots-per-byte layout and why hi-res math is trickier than lo-res; precomputing a
+  192-entry **row-address table** so the interleaved memory map is a non-issue; plotting
+  dots without ever dividing an X coordinate by 7.
+- **You'll build:** a hi-res starfield with three rulers (with a twinkle as an exercise).
+- **Program:** `codegen/programs/tut8_hires.s`.
+- **Verified by:** asserting lit pixels in the hi-res page.
+- **Where to go next:** a guided reading list of the shipped hi-res games — `swarm` (the
+  hi-res Space Invaders you just built a lo-res version of), `rocks` (vector shooter), and
+  `jungle` (platformer) — mapped to the concepts each one will teach you.
+
+---
+
+## Conventions used throughout
+
+- **Assembler dialect:** the project's own `asm6502.mjs` (see the
+  [code-generation guide](../../codegen/platform/prompt-system.md)). Labels `name:`,
+  equates `NAME = expr`, `.org`, `.byte`/`.word`, `$hex`/`%bin`/`'c'`, `<`/`>` for
+  low/high byte. Symbols are **case-insensitive** — the series keeps constant names
+  distinct from variable names (a real footgun documented in the guide).
+- **Program naming:** `tutN_shortname.s`, all in `codegen/programs/` so they auto-stage
+  and each gets a `?src=programs/tutN_shortname.s` deep link.
+- **Load address:** `$0800` unless a lesson says otherwise.
+- **Every program is verified** with `run6502.mjs` before it ships in a lesson.
+
+## Not covered (and why)
+
+- **Sound** — kept out of the core arc until the emulator's audio path is confirmed
+  end-to-end; a bonus lesson can be added if/when it's a first-class feature.
+- **Disk / SD file I/O** — orthogonal to game logic; the browser's Load/Share flow covers
+  distribution.
+- **Deep hi-res techniques** (shape tables, page-flipping, precise color) — Lesson 8 opens
+  the door and hands off to the shipped hi-res games as worked examples.
+
+## Decisions (from review)
+
+Locked in with ebadger:
+
+1. **Scope:** 8 lessons.
+2. **Capstone (Lesson 7):** **Space Invaders**, built in lo-res; the shipped hi-res
+   [`swarm.s`](../../emulator/AICodeGen/swarm/swarm.s) is the "full version" to read next.
+3. **Website surfacing:** add a **Tutorials** entry point on the live site
+   (<https://ebadger.github.io/3ric/>) and a **Tutorials** optgroup in the Assemble & Run
+   editor's sample picker, so each lesson's program is one click away. Each `tutN_*.s`
+   auto-stages via `web/build.ps1`; the picker and entry point are wired in
+   `web/index.html`.
+4. **Teaching depth:** keep the **just-in-time** approach — introduce each 6502 concept in
+   the lesson that first needs it; no separate up-front primer lesson.

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -56,6 +56,7 @@
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;Program&nbsp;Gallery</h1>
     <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <a class="nav" href="tutorials.html">&#9654;&nbsp;Tutorials</a>
     <span class="count" id="count">loading&hellip;</span>
   </header>
   <main>

--- a/web/index.html
+++ b/web/index.html
@@ -93,6 +93,7 @@
 <body>
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
+    <a class="nav" href="tutorials.html" title="Learn 65C02 game programming step by step">&#9654;&nbsp;Tutorials</a>
     <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
     <button id="reset">Reset</button>
     <button id="bootdisk">Boot Disk</button>
@@ -121,6 +122,16 @@
         <span class="title">ASSEMBLER</span>
         <span class="hint">sample</span>
         <select id="sample" title="load a sample program's source into the editor">
+          <optgroup label="Tutorials">
+            <option value="tut1_hello">Lesson 1 &middot; Hello</option>
+            <option value="tut2_screen">Lesson 2 &middot; Text screen</option>
+            <option value="tut3_move">Lesson 3 &middot; Keyboard</option>
+            <option value="tut4_lores">Lesson 4 &middot; Lo-res color</option>
+            <option value="tut5_bounce">Lesson 5 &middot; Motion</option>
+            <option value="tut6_catch">Lesson 6 &middot; Random &amp; score</option>
+            <option value="tut7_invaders">Lesson 7 &middot; Space Invaders</option>
+            <option value="tut8_hires">Lesson 8 &middot; Hi-res</option>
+          </optgroup>
           <optgroup label="Hi-res">
             <option value="swarm">STAR SWARM</option>
             <option value="rocks">ROCK STORM</option>

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -9,6 +9,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>https://ebadger.github.io/3ric/tutorials.html</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>https://ebadger.github.io/3ric/llms.txt</loc>
     <changefreq>monthly</changefreq>
   </url>

--- a/web/tutorials.html
+++ b/web/tutorials.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3ric — 65C02 Game Dev Tutorials</title>
+<meta name="description" content="Learn 65C02 assembly game programming on the 3ric, from Hello World to Space Invaders — eight browser-runnable lessons." />
+<style>
+  :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: "Cascadia Code", "Consolas", ui-monospace, monospace;
+    display: flex; flex-direction: column; min-height: 100vh;
+  }
+  header { padding: 10px 16px; border-bottom: 1px solid var(--dim); display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  header h1 { font-size: 14px; margin: 0; letter-spacing: 1px; }
+  header a.nav {
+    color: var(--fg); text-decoration: none; border: 1px solid var(--dim);
+    padding: 4px 10px; font-size: 12px; border-radius: 3px;
+  }
+  header a.nav:hover { background: var(--panel); }
+  main { flex: 1; width: 100%; max-width: 1120px; margin: 0 auto; padding: 16px; }
+  .intro { font-size: 13px; line-height: 1.55; margin: 2px 0 18px; }
+  .intro a { color: var(--fg); }
+  #grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 14px; }
+  .card {
+    border: 1px solid var(--dim); border-radius: 6px; background: var(--panel);
+    padding: 12px 13px; display: flex; flex-direction: column; gap: 9px;
+  }
+  .card .cardhead { display: flex; align-items: center; gap: 8px; }
+  .badge {
+    font-size: 10px; letter-spacing: .5px; text-transform: uppercase;
+    border: 1px solid var(--dim); border-radius: 10px; padding: 1px 7px;
+    color: var(--dim); white-space: nowrap;
+  }
+  .badge.cap { color: var(--fg); border-color: var(--fg); }
+  .card h2 { font-size: 14px; margin: 0; letter-spacing: .5px; }
+  .desc { font-size: 12px; line-height: 1.5; margin: 0; flex: 1; }
+  .learn { font-size: 11px; color: var(--dim); margin: 0; }
+  .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .run {
+    text-decoration: none; color: var(--fg);
+    border: 1px solid var(--fg); border-radius: 4px; padding: 5px 12px; font-size: 12px;
+  }
+  .run:hover { background: rgba(51, 255, 102, .08); }
+  .read {
+    text-decoration: none; color: var(--dim);
+    border: 1px solid var(--dim); border-radius: 4px; padding: 5px 12px; font-size: 12px;
+  }
+  .read:hover { background: var(--panel); color: var(--fg); }
+  footer { padding: 8px 16px; border-top: 1px solid var(--dim); font-size: 11px; color: var(--dim); }
+  footer a { color: var(--dim); }
+</style>
+</head>
+<body>
+  <header>
+    <h1>3ric&nbsp;&mdash;&nbsp;65C02&nbsp;Game&nbsp;Dev&nbsp;Tutorials</h1>
+    <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <a class="nav" href="gallery.html">&#9654;&nbsp;Gallery</a>
+  </header>
+  <main>
+    <p class="intro">
+      An eight-lesson course in <strong>65C02 assembly game programming</strong> on 3ric &mdash;
+      the from-scratch Apple-II-class machine that runs in your browser. Start at
+      <em>Hello, 3ric</em> and build up to a playable <strong>Space Invaders</strong>. Every
+      lesson comes with a small, fully-commented program you can <strong>run with one click</strong>,
+      edit in the <a href="index.html">in-browser editor</a>, and re-share. No install, no account.
+      Read the lessons in order &mdash; each one reuses the routines from the last.
+    </p>
+    <div id="grid" role="list">
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 1</span><h2>Hello, 3ric</h2></div>
+        <p class="desc">Your first program end-to-end: type it, assemble it, run it. Print
+          text with the ROM&rsquo;s character-out routine.</p>
+        <p class="learn">New: the assembler, <code>COUT</code>, the run loop.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut1_hello.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/01-hello.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 2</span><h2>The text screen</h2></div>
+        <p class="desc">Write straight to screen memory: draw a border, center a title, and
+          lay out a HUD on the 40&times;24 text grid.</p>
+        <p class="learn">New: screen memory, the interleaved row map, direct writes.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut2_screen.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/02-text-screen.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 3</span><h2>Reading the keyboard</h2></div>
+        <p class="desc">Steer a hero around the screen with W/A/S/D. Build the read-a-key,
+          erase, move, redraw loop every game uses.</p>
+        <p class="learn">New: the keyboard at <code>$C000</code>, bounds, the input loop.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut3_move.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/03-input.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 4</span><h2>Color with lo-res</h2></div>
+        <p class="desc">Flip into 40&times;48 lo-res color, write a reusable <code>plot</code>
+          routine, and steer a color-cycling block.</p>
+        <p class="learn">New: soft switches, the lo-res two-pixels-per-byte layout, 16 colors.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut4_lores.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/04-lores.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 5</span><h2>Motion &amp; collision</h2></div>
+        <p class="desc">A ball that moves on its own and bounces off all four walls &mdash;
+          your first real game loop with velocity.</p>
+        <p class="learn">New: the game loop, velocity, reflecting at boundaries, timing.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut5_bounce.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/05-motion.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 6</span><h2>Randomness &amp; scoring</h2></div>
+        <p class="desc">Catch-the-food: a random target, collision, and a live score in a
+          text HUD below the graphics.</p>
+        <p class="learn">New: an LFSR random generator, mixed mode, drawing a number.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut6_catch.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/06-random.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge cap">Capstone</span><h2>Space Invaders</h2></div>
+        <p class="desc">Put it all together: a marching alien fleet, a cannon, a bullet,
+          collision, score, and win/lose screens.</p>
+        <p class="learn">New: a game state machine, a fleet stored as data, edge-reverse motion.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut7_invaders.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/07-invaders.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+      <div class="card" role="listitem">
+        <div class="cardhead"><span class="badge">Lesson 8</span><h2>Hi-res &amp; next steps</h2></div>
+        <p class="desc">A peek at 280&times;192 high-resolution graphics, then a map of the
+          shipped games to read and remix from here.</p>
+        <p class="learn">New: hi-res mode, interleaved rows, precomputed address tables.</p>
+        <div class="actions">
+          <a class="run" href="index.html?src=programs/tut8_hires.s">&#9654; Run it</a>
+          <a class="read" href="https://github.com/ebadger/3ric/blob/main/docs/tutorials/08-hires.md" target="_blank" rel="noopener noreferrer">Read lesson</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+  <footer>
+    3ric Game Dev Tutorials &middot;
+    <a href="index.html">Emulator</a> &middot;
+    <a href="gallery.html">Gallery</a> &middot;
+    <a href="https://github.com/ebadger/3ric/tree/main/docs/tutorials">All lessons on GitHub</a> &middot;
+    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="llms.txt">For AI tools</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What this is

An outline-first, **browser-first** tutorial series that teaches 65C02 game programming on the 3ric. Each lesson pairs a markdown page with a small, **fully-commented** `.s` program that auto-stages to the live site (via `web/build.ps1`) and is one-click runnable at `?src=programs/<name>.s`. **All eight programs are verified headlessly on the cycle-honest emulator.**

## The lessons

| # | Lesson | Program | Mode |
| --- | --- | --- | --- |
| 1 | Hello, 3ric — assemble/run, registers, a loop, printing | `tut1_hello.s` | text |
| 2 | Drawing on the text screen — screen memory is just bytes | `tut2_screen.s` | text |
| 3 | Input and the game loop — read→update→draw | `tut3_move.s` | text |
| 4 | Color with lo-res — mode switches + a `PLOT` routine | `tut4_lores.s` | lo-res |
| 5 | Motion and collision — velocity, bouncing off walls | `tut5_bounce.s` | lo-res |
| 6 | Randomness and scoring — an LFSR, spawning, score HUD | `tut6_catch.s` | lo-res |
| 7 | **Capstone: Space Invaders** — game states, formation AI, win/lose/restart | `tut7_invaders.s` | lo-res |
| 8 | Hi-res and beyond — hi-res dots + a "where to go next" reading list | `tut8_hires.s` | hi-res |

Each lesson reuses routines from earlier ones and teaches just-in-time (no separate primer). Lesson 7's Space Invaders is a lo-res take on the shipped hi-res `swarm.s`; Lesson 8 points readers at the shipped games.

## Website integration

- **New `web/tutorials.html`** landing page — 8 gallery-styled lesson cards, each with a **▶ Run it** deep-link (opens the program in the browser editor) and a **Read lesson** GitHub link.
- **Tutorials** nav link added to `index.html` and `gallery.html` headers.
- **Tutorials** `<optgroup>` (8 options) added to the editor's `#sample` picker.
- `deploy-pages.yml` stages `web/tutorials.html`; `sitemap.xml` updated.

## Verification

- Every `tut*.s` verified on the emulator (`run6502.mjs` static checks, plus interactive key-injection and fixed-cycle checks for the autonomous/interactive demos).
- `web/build.ps1` build **succeeded**; all 8 programs staged to `web/programs/`.
- Assembler unit tests (`asm6502.test.mjs`) and web smoke tests (`test_boot`, `test_render`, `test_screen_text`, `test_keyboard`) **all pass**.
- Pre-push gate (assembler tests + boot smoke) passed on push.

> Note: `docs/` isn't deployed to Pages, so the landing page's "Read lesson" links resolve to `main` GitHub blob URLs after merge.

## Second-model review
- Reviewed diff: `ff6ef22...c0e6782` (fixes pushed as `90867a0`)
- GPT Reviewer (gpt-5.5): FIX-RECOMMENDED — 2 findings
- Gemini Reviewer (gemini-3.1-pro-preview): BLOCK — 2 findings
- Resolved: 3 fixed, 1 overridden
  - Overridden: Gemini #2 (WASD keys treated as uppercase-only) — the keyboard bridge uppercases every key at `web/web_bridge.cpp:273` (`WriteData(0xC000, 0x80 | toupper(...))`), so the uppercase-only compares are correct on both the browser and harness paths; the shipped in-browser `snake.s` uses the same uppercase-only pattern. Full per-finding tags + scorecards are in the review comment below.