### PR TITLE
Add a 3ric "Story" landing page linked into the web client

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/gallery.html web/tutorials.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/gallery.html web/tutorials.html web/story.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs web/wozgen.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -48,11 +48,13 @@ host it as static files.
   files are committed (not generated), so the deploy workflow stages them into `_site/`.
 - **Story / landing page (`story.html`):** a committed, WASM-free narrative page that tells
   the story of 3ric and the wider hardware-hacking journey (the Atari-1200XL / learning-journey
-  origin, the Lode-Runner goal that drove the migration to Apple II hardware, the
-  hardware-generated VGA graphics with NTSC-artifact color reproduced in logic — the part the
-  author is proudest of — the shared-RAM CPU/video timing, breadboard → PCB, the Ultima IV
-  payoff, and the related builds — the Badger6502 **Pico** kit/emulator, ESP32/Atari-2600
-  experiments, and the cross-platform Lode Runner saga). It links each chapter to its YouTube
+  origin, the Lode-Runner goal that drove the push toward Apple II *compatibility* — 3ric is an
+  original design, not a clone, with its own ROM and modern I/O (PS/2 keyboard/mouse, SNES pads,
+  SD card), so some Apple II software and Applesoft do not run — the hardware-generated VGA
+  graphics with NTSC-artifact color reproduced in logic (the part the author is proudest of), the
+  shared-RAM CPU/video timing, breadboard → PCB, the Ultima IV payoff, the in-browser build →
+  **Download .woz** Apple II dev-kit angle, and the related builds — the Badger6502 **Pico**
+  kit/emulator, ESP32/Atari-2600 experiments, and the cross-platform Lode Runner saga). It links each chapter to its YouTube
   episode via a **lite-embed facade** (a static `img.youtube.com` thumbnail that, on click,
   swaps in a privacy-friendly `youtube-nocookie.com` iframe — so no third-party player loads
   until the visitor asks for it) and funnels visitors into the live emulator/editor, the

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -46,6 +46,19 @@ host it as static files.
   auto-runs it. Manifest entries carry `title`, `author`/`authorUrl`, `mode`, `description`,
   `tags`, and a run target (a `src` program path or inline `code`, plus optional `org`). Both
   files are committed (not generated), so the deploy workflow stages them into `_site/`.
+- **Story / landing page (`story.html`):** a committed, WASM-free narrative page that tells
+  the story of 3ric and the wider hardware-hacking journey (the Ben-Eater-kit origin, the
+  Ultima IV quest, the VGA-artifact-color / PLL / Apple II language-card work, breadboard →
+  PCB, and the related builds — the Badger6502 **Pico** kit/emulator, ESP32/Atari-2600
+  experiments, and the cross-platform Lode Runner saga). It links each chapter to its YouTube
+  episode via a **lite-embed facade** (a static `img.youtube.com` thumbnail that, on click,
+  swaps in a privacy-friendly `youtube-nocookie.com` iframe — so no third-party player loads
+  until the visitor asks for it) and funnels visitors into the live emulator/editor, the
+  Gallery, and the Tutorials. A **Community & discussion** section links the `r/beneater`
+  subreddit and the 6502.org project thread; curated post highlights are added by editing the
+  page. Pure static markup (one small inline script for the facade); no WASM, no bundle
+  dependency. Linked from the `index.html` / `gallery.html` / `tutorials.html` headers so it is
+  reachable from anywhere in the web client.
 - **`llms.txt`:** a committed, machine-readable entry point (published at the site root) that
   gives AI coding tools a 65C02 codegen quickstart plus links to the platform reference
   (`codegen/platform/*`), a worked example, the live editor, and the gallery submission flow
@@ -120,7 +133,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
   generator, a JS port of `emulator/dsk2woz2`). The `.woz` boot loader depends on the `$C600`
   P5 boot PROM contract (`ROM-SOFTWARE.md`) and the Disk II phase-stepping model (`EMULATOR.md`).
 - **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`) — its **Stage
-  site** step stages `gallery.html` + `gallery.json` + `llms.txt` + `robots.txt` +
+  site** step stages `gallery.html` + `gallery.json` + `story.html` + `llms.txt` + `robots.txt` +
   `sitemap.xml` (alongside `index.html` and `programs/`) into `_site/`; the public users of
   the demo, and AI coding tools that fetch `llms.txt`.
 
@@ -135,6 +148,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | Program downloads (.PRG / .woz) | Shipped | **Download .PRG** (raw bytes) + **Download .woz** (bootable WOZ2 via `wozgen.mjs`, a port of `dsk2woz2`, with a multi-track boot loader); verified by `web/test_woz_download.cjs`. |
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |
+| Story / landing page | Shipped | `story.html` — narrative of 3ric + the wider hardware-hacking journey; lite-embed YouTube chapters (facade → `youtube-nocookie` iframe on click); links to emulator/gallery/tutorials + `r/beneater` / 6502.org. Reddit post highlights stubbed for a later curation pass. Linked from the `index.html`/`gallery.html`/`tutorials.html` headers; staged by the deploy workflow. |
 | AI-contributor entry point (`llms.txt`) | Shipped | machine-readable 65C02 codegen quickstart + links; published at the site root, staged by the deploy workflow. |
 | `llms.txt` discoverability | Shipped | `<link rel="alternate">` + footer links in `index.html`/`gallery.html`; `robots.txt` + `sitemap.xml` staged (advisory on the project-page root; authoritative under a custom domain). |
 | Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -47,9 +47,11 @@ host it as static files.
   `tags`, and a run target (a `src` program path or inline `code`, plus optional `org`). Both
   files are committed (not generated), so the deploy workflow stages them into `_site/`.
 - **Story / landing page (`story.html`):** a committed, WASM-free narrative page that tells
-  the story of 3ric and the wider hardware-hacking journey (the Ben-Eater-kit origin, the
-  Ultima IV quest, the VGA-artifact-color / PLL / Apple II language-card work, breadboard →
-  PCB, and the related builds — the Badger6502 **Pico** kit/emulator, ESP32/Atari-2600
+  the story of 3ric and the wider hardware-hacking journey (the Atari-1200XL / learning-journey
+  origin, the Lode-Runner goal that drove the migration to Apple II hardware, the
+  hardware-generated VGA graphics with NTSC-artifact color reproduced in logic — the part the
+  author is proudest of — the shared-RAM CPU/video timing, breadboard → PCB, the Ultima IV
+  payoff, and the related builds — the Badger6502 **Pico** kit/emulator, ESP32/Atari-2600
   experiments, and the cross-platform Lode Runner saga). It links each chapter to its YouTube
   episode via a **lite-embed facade** (a static `img.youtube.com` thumbnail that, on click,
   swaps in a privacy-friendly `youtube-nocookie.com` iframe — so no third-party player loads

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -73,7 +73,7 @@
     3ric Program Gallery &middot;
     <a href="index.html">Emulator</a> &middot;
     <a href="story.html">Story</a> &middot;
-    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="https://github.com/ebadger/3ric" target="_blank" rel="noopener noreferrer">Source</a> &middot;
     <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a> &middot;
     <a href="llms.txt">For AI tools</a> &middot;
     <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support</a>

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -56,6 +56,7 @@
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;Program&nbsp;Gallery</h1>
     <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <a class="nav" href="story.html">&#9654;&nbsp;Story</a>
     <a class="nav" href="tutorials.html">&#9654;&nbsp;Tutorials</a>
     <span class="count" id="count">loading&hellip;</span>
   </header>
@@ -71,6 +72,7 @@
   <footer>
     3ric Program Gallery &middot;
     <a href="index.html">Emulator</a> &middot;
+    <a href="story.html">Story</a> &middot;
     <a href="https://github.com/ebadger/3ric">Source</a> &middot;
     <a href="https://github.com/ebadger/3ric/edit/main/web/gallery.json" target="_blank" rel="noopener noreferrer">Add your program</a> &middot;
     <a href="llms.txt">For AI tools</a> &middot;

--- a/web/index.html
+++ b/web/index.html
@@ -93,6 +93,7 @@
 <body>
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
+    <a class="nav" href="story.html" title="The story of 3ric + the build series">&#9654;&nbsp;Story</a>
     <a class="nav" href="tutorials.html" title="Learn 65C02 game programming step by step">&#9654;&nbsp;Tutorials</a>
     <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
     <button id="reset">Reset</button>
@@ -185,6 +186,8 @@
     <br />Building with an AI tool? Point it at <a href="llms.txt"><code>llms.txt</code></a>
     &mdash; a machine-readable 65C02 codegen guide &mdash; or see
     <a href="https://github.com/ebadger/3ric/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING</a>.
+    <br />New here? <a href="story.html">Read the story of how 3ric was built</a>
+    &mdash; the breadboard-to-PCB journey, with the YouTube build series.
     <br />Enjoying 3ric? <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support the project</a>
     &mdash; sponsorship funds parts, boards, and more build videos.
   </footer>

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -5,6 +5,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>https://ebadger.github.io/3ric/story.html</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>https://ebadger.github.io/3ric/gallery.html</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/web/story.html
+++ b/web/story.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>3ric — The Story: I built a 6502 computer, and it became an Apple II</title>
-<meta name="description" content="The story of 3ric — I set out to learn how 8-bit computers really work, so I built one from a pile of chips. To run the games I loved it grew into an Apple II: hardware-generated VGA, Apple II artifact color reproduced in logic I designed, Lode Runner, and finally Ultima IV. Watch the build series and run the machine in your browser." />
+<title>3ric — The Story: I built a 6502 computer that speaks Apple II</title>
+<meta name="description" content="The story of 3ric — I set out to learn how 8-bit computers really work, so I built one from a pile of chips. It's an original design, not an Apple II clone, but it speaks enough Apple II to run Lode Runner and finish Ultima IV — hardware-generated VGA with artifact color reproduced in logic I designed. Run it in your browser, and export bootable .woz disks that boot on a real Apple II." />
 <meta property="og:type" content="website" />
-<meta property="og:title" content="3ric — I built a homebrew Apple II to run the games I loved" />
-<meta property="og:description" content="It started with an Atari 1200XL and one question: how do these 8-bit machines really work? So I built one — and to run Lode Runner and Ultima IV it became an Apple II, artifact-color graphics and all. Watch the build series and run it in your browser." />
+<meta property="og:title" content="3ric — an original 6502 computer that speaks Apple II" />
+<meta property="og:description" content="It started with an Atari 1200XL and one question: how do these 8-bit machines really work? So I built one — an original design that runs Lode Runner and Ultima IV, artifact-color graphics and all. Run it in your browser, and export .woz disks that boot on a real Apple II." />
 <meta property="og:url" content="https://ebadger.github.io/3ric/story.html" />
 <meta property="og:image" content="https://i.ytimg.com/vi/e65qVK7zNGM/hqdefault.jpg" />
 <style>
@@ -121,18 +121,19 @@
   <main>
     <section class="hero">
       <p class="kicker">A homebrew computing story</p>
-      <h2>I wanted to learn how 8-bit computers <em>really</em> work. So I built one &mdash; and it became an <span class="amber">Apple&nbsp;II</span>.</h2>
+      <h2>I wanted to learn how 8-bit computers <em>really</em> work. So I built one &mdash; an original machine that learned to speak <span class="amber">Apple&nbsp;II</span>.</h2>
       <p>
         It started with an Atari&nbsp;1200XL I grew up with and a question I could never shake: how do
         these machines <em>actually</em> work? The only honest way to find out was to build one, so I
         wired up a 6502 from a pile of chips. Then a goal took hold &mdash; get the games I loved
         running on hardware I designed, starting with <strong>Lode&nbsp;Runner</strong> &mdash; and
-        that one goal quietly rebuilt the whole machine into an <strong>Apple&nbsp;II</strong>, because
-        the Apple&nbsp;II had the simplest graphics of its generation you can still build from
-        off-the-shelf parts today. I had no idea if I could pull it off. I did it anyway: ran
-        Lode&nbsp;Runner, then <strong>finished Ultima&nbsp;IV</strong> on it, then a whole lot more.
-        And the best part &mdash; you can <strong>run the finished machine right now, in your
-        browser</strong>.
+        that one goal pushed the whole design toward <strong>Apple&nbsp;II compatibility</strong>,
+        because the Apple&nbsp;II had the simplest graphics of its generation you can still build from
+        off-the-shelf parts today. 3RIC isn&rsquo;t an Apple&nbsp;II clone &mdash; it&rsquo;s an
+        original design with its own ROM and modern I/O &mdash; but it speaks enough Apple&nbsp;II to
+        run Lode&nbsp;Runner, finish <strong>Ultima&nbsp;IV</strong>, and a whole lot more. I had no
+        idea if I could pull it off. I did it anyway. And the best part: you can <strong>run it right
+        now in your browser</strong> &mdash; and even build Apple&nbsp;II software with it.
       </p>
       <div class="cta">
         <a class="btn" href="index.html">&#9654;&nbsp;Run 3ric in your browser</a>
@@ -203,13 +204,16 @@
 
     <section class="chapter">
       <p class="chapnum">Chapter 3 &middot; The twist</p>
-      <h3>To run Lode&nbsp;Runner, I had to build an Apple&nbsp;II</h3>
+      <h3>To run Lode&nbsp;Runner, I had to speak Apple&nbsp;II</h3>
       <p>
-        Here&rsquo;s the plot twist: to run the games I was after, my machine had to <em>become</em>
-        an Apple&nbsp;II &mdash; and that was a deliberate choice. Of that whole generation, the
+        Here&rsquo;s the plot twist: to run the games I was after, my machine had to <em>behave</em>
+        like an Apple&nbsp;II &mdash; and that was a deliberate choice. Of that whole generation, the
         <strong>Apple&nbsp;II had the simplest graphics hardware you can still build from
-        off-the-shelf parts today</strong>, so chasing Lode&nbsp;Runner quietly steered almost every
-        design decision toward Apple&nbsp;II compatibility.
+        off-the-shelf parts today</strong>, so chasing Lode&nbsp;Runner steered almost every design
+        decision toward Apple&nbsp;II compatibility. But 3RIC is <strong>no clone</strong> &mdash; the
+        schematic is an <strong>original design</strong> that doesn&rsquo;t look like an Apple&nbsp;II
+        at all. It just gets <em>close enough in behavior</em> to run a surprising amount of
+        Apple&nbsp;II software.
       </p>
       <p>
         The graphics system is the part I&rsquo;m <span class="hl">proudest of</span>. On 3RIC the
@@ -220,8 +224,16 @@
         designed myself</strong>. And because the CPU and the video hardware <strong>share the same
         RAM</strong>, the whole thing only works with <strong>exact timing</strong>: the two have to
         take turns on the bus so they never collide. Getting that dance right is the engineering
-        I&rsquo;m most proud of &mdash; and a machine that has to think it&rsquo;s an Apple&nbsp;II
-        deserves its own name, so the ebadger6502 became <strong>3RIC</strong>.
+        I&rsquo;m most proud of.
+      </p>
+      <p>
+        And make no mistake &mdash; 3RIC is its own machine. It takes a <strong>PS/2 keyboard and
+        mouse</strong>, <strong>SNES controllers</strong>, and an <strong>SD card</strong> &mdash;
+        none of which the Apple&nbsp;II had &mdash; so its <strong>ROM is significantly different</strong>,
+        and there&rsquo;s no Applesoft BASIC. That originality is half the fun, and it&rsquo;s also why
+        <em>not</em> everything runs: some titles lean on Apple&nbsp;II internals that 3RIC simply does
+        its own way. A machine this original deserves its own name &mdash; so the ebadger6502 became
+        <strong>3RIC</strong>.
       </p>
       <blockquote>
         &ldquo;A new computer deserves a new name &mdash; from now on ebadger6502 is the 3RIC 6502.&rdquo;
@@ -450,6 +462,13 @@
         core that models the chips boots the real 512&nbsp;KB ROM in any browser &mdash; no install, no
         account. Click the screen and type at the monitor prompt, boot a disk, or open the built-in
         <strong>65C02 assembler</strong> and write a program that runs on the machine instantly.
+      </p>
+      <p>
+        And here&rsquo;s my favorite part for tinkerers: it doubles as an <strong>Apple&nbsp;II dev
+        kit</strong>. Write and assemble a program in the browser, get it running, then hit
+        <strong>Download&nbsp;.woz</strong> &mdash; you get a bootable 5.25&Prime; disk image,
+        generated entirely client-side, that boots not just on 3RIC but on a <strong>real
+        Apple&nbsp;II</strong>. Build a game here; run it on real hardware.
       </p>
       <div class="cta">
         <a class="btn" href="index.html">&#9654;&nbsp;Launch the emulator</a>

--- a/web/story.html
+++ b/web/story.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>3ric — The Story: I built a 6502 computer to beat Ultima IV</title>
-<meta name="description" content="The story of 3ric — a from-scratch, Apple-II-class 65C02 computer built on breadboards to run Ultima IV — plus the wider hardware-hacking journey: a Raspberry Pi Pico 6502 kit, VGA artifact color, Lode Runner, and more. Watch the build series and run the machine in your browser." />
+<title>3ric — The Story: I built a 6502 computer, and it became an Apple II</title>
+<meta name="description" content="The story of 3ric — I set out to learn how 8-bit computers really work, so I built one from a pile of chips. To run the games I loved it grew into an Apple II: hardware-generated VGA, Apple II artifact color reproduced in logic I designed, Lode Runner, and finally Ultima IV. Watch the build series and run the machine in your browser." />
 <meta property="og:type" content="website" />
-<meta property="og:title" content="3ric — The Story of a homebrew 65C02 computer" />
-<meta property="og:description" content="From a Ben-Eater breadboard to a PCB that beats Ultima IV. Watch the build series and run the machine in your browser — no install." />
+<meta property="og:title" content="3ric — I built a homebrew Apple II to run the games I loved" />
+<meta property="og:description" content="It started with an Atari 1200XL and one question: how do these 8-bit machines really work? So I built one — and to run Lode Runner and Ultima IV it became an Apple II, artifact-color graphics and all. Watch the build series and run it in your browser." />
 <meta property="og:url" content="https://ebadger.github.io/3ric/story.html" />
 <meta property="og:image" content="https://i.ytimg.com/vi/e65qVK7zNGM/hqdefault.jpg" />
 <style>
@@ -121,15 +121,18 @@
   <main>
     <section class="hero">
       <p class="kicker">A homebrew computing story</p>
-      <h2>I set out to beat <span class="amber">Ultima&nbsp;IV</span> on a computer I built from a pile of chips.</h2>
+      <h2>I wanted to learn how 8-bit computers <em>really</em> work. So I built one &mdash; and it became an <span class="amber">Apple&nbsp;II</span>.</h2>
       <p>
-        3ric started as a Ben-Eater-style 6502 on a breadboard and a stubborn idea: don&rsquo;t
-        just <em>emulate</em> an Apple&nbsp;II &mdash; <strong>build one</strong>, wire by wire, until
-        it could run a real Apple&nbsp;II RPG with the right graphics and sound &mdash; and then
-        actually finish the game on it. Somewhere along the way the machine earned a name, grew a
-        micro-SD &ldquo;DOS,&rdquo; sprouted a VGA video path, jumped from breadboards to a custom
-        PCB, and spun off a whole family of side-quests. This is that story &mdash; and the best part
-        is you can <strong>run the finished machine right now, in your browser</strong>.
+        It started with an Atari&nbsp;1200XL I grew up with and a question I could never shake: how do
+        these machines <em>actually</em> work? The only honest way to find out was to build one, so I
+        wired up a 6502 from a pile of chips. Then a goal took hold &mdash; get the games I loved
+        running on hardware I designed, starting with <strong>Lode&nbsp;Runner</strong> &mdash; and
+        that one goal quietly rebuilt the whole machine into an <strong>Apple&nbsp;II</strong>, because
+        the Apple&nbsp;II had the simplest graphics of its generation you can still build from
+        off-the-shelf parts today. I had no idea if I could pull it off. I did it anyway: ran
+        Lode&nbsp;Runner, then <strong>finished Ultima&nbsp;IV</strong> on it, then a whole lot more.
+        And the best part &mdash; you can <strong>run the finished machine right now, in your
+        browser</strong>.
       </p>
       <div class="cta">
         <a class="btn" href="index.html">&#9654;&nbsp;Run 3ric in your browser</a>
@@ -139,13 +142,14 @@
 
     <section class="chapter">
       <p class="chapnum">Chapter 1 &middot; Where it started</p>
-      <h3>A 6502 childhood dream</h3>
+      <h3>It started with an Atari&nbsp;1200XL</h3>
       <p>
-        Like a lot of people who fall down this rabbit hole, I started with the 6502 &mdash; the
-        same 8-bit CPU behind the Apple&nbsp;II, the Commodore&nbsp;64, and the NES &mdash; and a
-        Ben-Eater-shaped urge to understand a computer by building one from nothing. Add a VGA
-        signal, a Raspberry&nbsp;Pi&nbsp;Pico, and a copy of <strong>Lode&nbsp;Runner</strong>, and a
-        childhood dream quietly came true on my workbench.
+        I grew up with an <strong>Atari&nbsp;1200XL</strong> and a fascination with computers in
+        general &mdash; how does a box of silicon turn switches into games? Years later I wanted a
+        real answer instead of a hand-wavy one, so I went back to the 8-bit era and started with the
+        <strong>6502</strong> &mdash; the same CPU behind the Apple&nbsp;II, the Commodore&nbsp;64, and
+        the NES. No blueprint, no fixed destination &mdash; just a Ben-Eater-shaped urge to understand
+        a computer by building one from nothing. First and foremost, this was a learning journey.
       </p>
       <figure class="vid feature">
         <div class="media">
@@ -158,14 +162,16 @@
     </section>
 
     <section class="chapter">
-      <p class="chapnum">Chapter 2 &middot; The quest</p>
-      <h3>&ldquo;Can this thing run Ultima&nbsp;IV?&rdquo;</h3>
+      <p class="chapnum">Chapter 2 &middot; A goal takes shape</p>
+      <h3>A first machine &mdash; and a target: Lode&nbsp;Runner</h3>
       <p>
-        The first version was the <strong>EB6502</strong>. I bolted on a bit-banged micro-SD card and
-        wrote a tiny DOS for it, then started porting games &mdash; Chess, Breakout, Gomoku &mdash;
-        just to prove the machine could <em>play</em>. That was the moment the real challenge showed
-        up: could I get <span class="hl">Ultima&nbsp;IV</span>, a proper Apple&nbsp;II RPG, running end
-        to end on hardware I designed myself?
+        The first working machine was the <strong>EB6502</strong>. I bolted on a bit-banged micro-SD
+        card, wrote a tiny DOS for it, and started porting games &mdash; Chess, Breakout, Gomoku
+        &mdash; just to prove the thing could <em>play</em>. That&rsquo;s when the learning project
+        grew a mission: get the games I actually loved running on hardware I built myself, starting
+        with <strong>Lode&nbsp;Runner</strong>. Chasing that one game would end up dictating almost
+        every design decision that followed &mdash; and put an even bigger challenge,
+        <span class="hl">Ultima&nbsp;IV</span>, on the horizon.
       </p>
       <div class="video-row">
         <figure class="vid">
@@ -197,13 +203,25 @@
 
     <section class="chapter">
       <p class="chapnum">Chapter 3 &middot; The twist</p>
-      <h3>Wait&hellip; am I building an Apple&nbsp;II?</h3>
+      <h3>To run Lode&nbsp;Runner, I had to build an Apple&nbsp;II</h3>
       <p>
-        To run Apple&nbsp;II software faithfully, I kept having to <em>become</em> the Apple&nbsp;II:
-        emulate its <strong>artifact color</strong> out of a modern VGA signal using logic, tame the
-        timing with a <strong>PLL</strong>, and add a <strong>language card</strong> with the bank
-        switching Ultima&nbsp;IV expects. A machine that has to act like an Apple&nbsp;II deserves its
-        own identity &mdash; so the ebadger6502 became <strong>3RIC</strong>.
+        Here&rsquo;s the plot twist: to run the games I was after, my machine had to <em>become</em>
+        an Apple&nbsp;II &mdash; and that was a deliberate choice. Of that whole generation, the
+        <strong>Apple&nbsp;II had the simplest graphics hardware you can still build from
+        off-the-shelf parts today</strong>, so chasing Lode&nbsp;Runner quietly steered almost every
+        design decision toward Apple&nbsp;II compatibility.
+      </p>
+      <p>
+        The graphics system is the part I&rsquo;m <span class="hl">proudest of</span>. On 3RIC the
+        video is generated entirely in <strong>hardware</strong>, out to a clean modern
+        <strong>VGA</strong> signal. The Apple&nbsp;II&rsquo;s famous hi-res color was a gorgeous hack
+        &mdash; it fell out of <strong>color-burst artifacts on the NTSC signal</strong> &mdash; so to
+        get that same color on VGA I reproduced the artifact behavior in <strong>logic circuits I
+        designed myself</strong>. And because the CPU and the video hardware <strong>share the same
+        RAM</strong>, the whole thing only works with <strong>exact timing</strong>: the two have to
+        take turns on the bus so they never collide. Getting that dance right is the engineering
+        I&rsquo;m most proud of &mdash; and a machine that has to think it&rsquo;s an Apple&nbsp;II
+        deserves its own name, so the ebadger6502 became <strong>3RIC</strong>.
       </p>
       <blockquote>
         &ldquo;A new computer deserves a new name &mdash; from now on ebadger6502 is the 3RIC 6502.&rdquo;
@@ -322,13 +340,28 @@
 
     <section class="chapter">
       <p class="chapnum">Chapter 6 &middot; The payoff</p>
-      <h3>Ultima&nbsp;IV, completed.</h3>
+      <h3>Lode&nbsp;Runner ran. Then I set my sights on Ultima&nbsp;IV.</h3>
       <p>
-        Years of Saturdays later, the machine I built from chips booted the disk, ran the game, and I
-        <strong>finished Ultima&nbsp;IV on it</strong> &mdash; the exact thing I set out to do. Then I
-        sat down for a proper wrap-up on what the whole adventure taught me.
+        And then it happened: <strong>Lode&nbsp;Runner ran on the machine I built</strong> &mdash; the
+        exact goal that had started the whole redesign. So I aimed higher and went after
+        <strong>Ultima&nbsp;IV</strong>, a full Apple&nbsp;II RPG, end to end &mdash; and
+        <strong>finished it on 3RIC</strong>. With the hard problems solved, a whole lot of other
+        games fell into place too. I&rsquo;d blown right past the plan I started with.
       </p>
+      <blockquote>
+        Honestly, the whole project was a lesson in faith. When I set out to run Lode&nbsp;Runner I had
+        no idea how I&rsquo;d get there &mdash; it felt outside what I was capable of. I did it anyway,
+        and far exceeded my own expectations.
+      </blockquote>
       <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="XI2BuQyncEE" style="background-image:url(https://i.ytimg.com/vi/XI2BuQyncEE/hqdefault.jpg)" aria-label="Play video: Homebrew Lode Runner on 3RIC">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/XI2BuQyncEE" target="_blank" rel="noopener noreferrer">Homebrew Lode&nbsp;Runner on 3RIC</a><span class="dur">0:09</span></figcaption>
+        </figure>
         <figure class="vid">
           <div class="media">
             <button class="lite-yt" data-id="kvI9nI8rl0o" style="background-image:url(https://i.ytimg.com/vi/kvI9nI8rl0o/hqdefault.jpg)" aria-label="Play video: 3RIC 6502 homebrew computer — Ultima IV completed">
@@ -400,14 +433,6 @@
           </div>
           <figcaption><a href="https://youtu.be/8Bl3qC75VYw" target="_blank" rel="noopener noreferrer">ESP32, Atari&nbsp;2600 &amp; the XAC</a><span class="dur">2:55</span></figcaption>
         </figure>
-        <figure class="vid">
-          <div class="media">
-            <button class="lite-yt" data-id="XI2BuQyncEE" style="background-image:url(https://i.ytimg.com/vi/XI2BuQyncEE/hqdefault.jpg)" aria-label="Play video: Homebrew Lode Runner on 3RIC">
-              <span class="play" aria-hidden="true">&#9654;</span>
-            </button>
-          </div>
-          <figcaption><a href="https://youtu.be/XI2BuQyncEE" target="_blank" rel="noopener noreferrer">Homebrew Lode&nbsp;Runner on 3RIC</a><span class="dur">0:09</span></figcaption>
-        </figure>
       </div>
       <p class="playlist-note">
         That&rsquo;s the highlight reel &mdash; the full run of build logs, shorts, and deep dives lives on the
@@ -477,7 +502,7 @@
     <a href="tutorials.html">Tutorials</a> &middot;
     <a href="gallery.html">Gallery</a> &middot;
     <a href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer">Build series</a> &middot;
-    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="https://github.com/ebadger/3ric" target="_blank" rel="noopener noreferrer">Source</a> &middot;
     <a href="llms.txt">For AI tools</a> &middot;
     <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support</a>
   </footer>

--- a/web/story.html
+++ b/web/story.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3ric — The Story: I built a 6502 computer to beat Ultima IV</title>
+<meta name="description" content="The story of 3ric — a from-scratch, Apple-II-class 65C02 computer built on breadboards to run Ultima IV — plus the wider hardware-hacking journey: a Raspberry Pi Pico 6502 kit, VGA artifact color, Lode Runner, and more. Watch the build series and run the machine in your browser." />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="3ric — The Story of a homebrew 65C02 computer" />
+<meta property="og:description" content="From a Ben-Eater breadboard to a PCB that beats Ultima IV. Watch the build series and run the machine in your browser — no install." />
+<meta property="og:url" content="https://ebadger.github.io/3ric/story.html" />
+<meta property="og:image" content="https://i.ytimg.com/vi/e65qVK7zNGM/hqdefault.jpg" />
+<style>
+  :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; --amber:#ffcc66; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: "Cascadia Code", "Consolas", ui-monospace, monospace;
+    display: flex; flex-direction: column; min-height: 100vh;
+  }
+  a { color: var(--fg); }
+  header { padding: 10px 16px; border-bottom: 1px solid var(--dim); display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  header h1 { font-size: 14px; margin: 0; letter-spacing: 1px; }
+  header a.nav {
+    color: var(--fg); text-decoration: none; border: 1px solid var(--dim);
+    padding: 4px 10px; font-size: 12px; border-radius: 3px;
+  }
+  header a.nav:hover { background: var(--panel); }
+  header .spacer { margin-left: auto; }
+  main { flex: 1; width: 100%; max-width: 1120px; margin: 0 auto; padding: 8px 16px 24px; }
+
+  /* Hero */
+  .hero { padding: 30px 4px 18px; border-bottom: 1px dashed var(--dim); margin-bottom: 8px; }
+  .hero .kicker { color: var(--dim); font-size: 12px; letter-spacing: 2px; text-transform: uppercase; margin: 0 0 10px; }
+  .hero h2 { font-size: clamp(22px, 4.4vw, 40px); line-height: 1.15; margin: 0 0 14px; letter-spacing: .5px; }
+  .hero h2 .amber { color: var(--amber); }
+  .hero p { font-size: 14px; line-height: 1.6; max-width: 74ch; margin: 0 0 18px; }
+  .cta { display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn {
+    text-decoration: none; color: var(--bg); background: var(--fg); font-weight: 600;
+    border: 1px solid var(--fg); border-radius: 5px; padding: 9px 16px; font-size: 13px;
+  }
+  .btn:hover { background: #5cff88; }
+  .btn.ghost { color: var(--fg); background: transparent; }
+  .btn.ghost:hover { background: rgba(51,255,102,.10); }
+
+  /* Chapters */
+  .chapter { padding: 26px 4px; border-bottom: 1px solid rgba(29,107,51,.5); }
+  .chapter:last-of-type { border-bottom: none; }
+  .chapnum { color: var(--dim); font-size: 12px; letter-spacing: 2px; text-transform: uppercase; margin: 0 0 6px; }
+  .chapter h3 { font-size: clamp(18px, 3vw, 24px); margin: 0 0 12px; letter-spacing: .5px; }
+  .chapter p { font-size: 13.5px; line-height: 1.62; max-width: 76ch; margin: 0 0 14px; }
+  .chapter p .hl { color: var(--amber); }
+  blockquote {
+    margin: 14px 0; padding: 8px 14px; border-left: 3px solid var(--dim);
+    color: #7de79a; font-style: italic; max-width: 74ch;
+  }
+  blockquote cite { display:block; margin-top:6px; font-style: normal; color: var(--dim); font-size: 12px; }
+
+  /* Video cards */
+  .vid { margin: 16px 0; }
+  .media {
+    position: relative; aspect-ratio: 16 / 9; width: 100%;
+    border: 1px solid var(--dim); border-radius: 8px; overflow: hidden; background: #000;
+  }
+  .media > .lite-yt, .media > iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+  .lite-yt {
+    display: grid; place-items: center; cursor: pointer; padding: 0; margin: 0;
+    background-color: #000; background-size: cover; background-position: center;
+  }
+  .lite-yt::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,0) 55%, rgba(0,0,0,.55)); }
+  .lite-yt .play {
+    position: relative; z-index: 1; font-size: 26px; line-height: 1; color: var(--bg);
+    background: var(--fg); border: 0; border-radius: 999px; width: 64px; height: 64px;
+    display: grid; place-items: center; padding-left: 5px; box-shadow: 0 4px 16px rgba(0,0,0,.5);
+    transition: transform .1s ease, background .1s ease;
+  }
+  .lite-yt:hover .play, .lite-yt:focus-visible .play { transform: scale(1.08); background: #5cff88; }
+  .lite-yt:focus-visible { outline: 2px solid var(--amber); outline-offset: 2px; }
+  figure.vid { margin: 16px 0 0; }
+  figcaption { font-size: 12px; color: var(--fg); margin-top: 8px; line-height: 1.5; }
+  figcaption a { text-decoration: none; border-bottom: 1px dotted var(--dim); }
+  figcaption a:hover { border-bottom-color: var(--fg); }
+  figcaption .dur { color: var(--dim); margin-left: 6px; }
+  .feature .media { border-color: var(--fg); }
+
+  .video-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 16px; margin-top: 12px; }
+  .video-row figure.vid { margin: 0; }
+
+  .playlist-note { font-size: 12px; color: var(--dim); margin-top: 14px; }
+  .playlist-note a { color: var(--fg); }
+
+  /* Community / discussion */
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 14px; margin-top: 14px; }
+  .linkcard {
+    border: 1px solid var(--dim); border-radius: 6px; background: var(--panel);
+    padding: 13px 14px; display: flex; flex-direction: column; gap: 7px;
+  }
+  .linkcard h4 { margin: 0; font-size: 13px; letter-spacing: .5px; }
+  .linkcard p { margin: 0; font-size: 12px; line-height: 1.5; color: #8fe6a8; }
+  .linkcard a.go { align-self: flex-start; margin-top: 2px; text-decoration: none; color: var(--fg); border: 1px solid var(--fg); border-radius: 4px; padding: 4px 11px; font-size: 12px; }
+  .linkcard a.go:hover { background: rgba(51,255,102,.08); }
+  .stub { border-style: dashed; }
+  .stub p { color: var(--dim); }
+
+  footer { padding: 10px 16px; border-top: 1px solid var(--dim); font-size: 11px; color: var(--dim); }
+  footer a { color: var(--dim); }
+  footer a:hover { color: var(--fg); }
+</style>
+<link rel="alternate" type="text/markdown" title="llms.txt — 65C02 codegen guide for AI tools" href="llms.txt" />
+</head>
+<body>
+  <header>
+    <h1>3ric&nbsp;&mdash;&nbsp;The&nbsp;Story</h1>
+    <a class="nav" href="index.html" title="Run the machine in your browser">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <a class="nav" href="tutorials.html" title="Learn 65C02 game programming">&#9654;&nbsp;Tutorials</a>
+    <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
+    <a class="nav spacer" href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer" title="The full build series on YouTube">&#9654;&nbsp;Build series</a>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="kicker">A homebrew computing story</p>
+      <h2>I set out to beat <span class="amber">Ultima&nbsp;IV</span> on a computer I built from a pile of chips.</h2>
+      <p>
+        3ric started as a Ben-Eater-style 6502 on a breadboard and a stubborn idea: don&rsquo;t
+        just <em>emulate</em> an Apple&nbsp;II &mdash; <strong>build one</strong>, wire by wire, until
+        it could run a real Apple&nbsp;II RPG with the right graphics and sound &mdash; and then
+        actually finish the game on it. Somewhere along the way the machine earned a name, grew a
+        micro-SD &ldquo;DOS,&rdquo; sprouted a VGA video path, jumped from breadboards to a custom
+        PCB, and spun off a whole family of side-quests. This is that story &mdash; and the best part
+        is you can <strong>run the finished machine right now, in your browser</strong>.
+      </p>
+      <div class="cta">
+        <a class="btn" href="index.html">&#9654;&nbsp;Run 3ric in your browser</a>
+        <a class="btn ghost" href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer">Watch the build series</a>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 1 &middot; Where it started</p>
+      <h3>A 6502 childhood dream</h3>
+      <p>
+        Like a lot of people who fall down this rabbit hole, I started with the 6502 &mdash; the
+        same 8-bit CPU behind the Apple&nbsp;II, the Commodore&nbsp;64, and the NES &mdash; and a
+        Ben-Eater-shaped urge to understand a computer by building one from nothing. Add a VGA
+        signal, a Raspberry&nbsp;Pi&nbsp;Pico, and a copy of <strong>Lode&nbsp;Runner</strong>, and a
+        childhood dream quietly came true on my workbench.
+      </p>
+      <figure class="vid feature">
+        <div class="media">
+          <button class="lite-yt" data-id="e65qVK7zNGM" style="background-image:url(https://i.ytimg.com/vi/e65qVK7zNGM/hqdefault.jpg)" aria-label="Play video: 6502 childhood dream come true (+VGA, Pi Pico, and Lode Runner too)">
+            <span class="play" aria-hidden="true">&#9654;</span>
+          </button>
+        </div>
+        <figcaption><a href="https://youtu.be/e65qVK7zNGM" target="_blank" rel="noopener noreferrer">6502 childhood dream come true (+VGA, Pi Pico, and Lode Runner too)</a><span class="dur">9:31</span></figcaption>
+      </figure>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 2 &middot; The quest</p>
+      <h3>&ldquo;Can this thing run Ultima&nbsp;IV?&rdquo;</h3>
+      <p>
+        The first version was the <strong>EB6502</strong>. I bolted on a bit-banged micro-SD card and
+        wrote a tiny DOS for it, then started porting games &mdash; Chess, Breakout, Gomoku &mdash;
+        just to prove the machine could <em>play</em>. That was the moment the real challenge showed
+        up: could I get <span class="hl">Ultima&nbsp;IV</span>, a proper Apple&nbsp;II RPG, running end
+        to end on hardware I designed myself?
+      </p>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="kXQsNKizgxw" style="background-image:url(https://i.ytimg.com/vi/kXQsNKizgxw/hqdefault.jpg)" aria-label="Play video: MicroSD DOS for the EB6502 — porting Chess, Breakout and Gomoku">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/kXQsNKizgxw" target="_blank" rel="noopener noreferrer">MicroSD DOS for the EB6502 &mdash; Chess, Breakout &amp; Gomoku</a><span class="dur">4:21</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="JQuxmTqFi28" style="background-image:url(https://i.ytimg.com/vi/JQuxmTqFi28/hqdefault.jpg)" aria-label="Play video: EB6502 walkthrough — Ultima IV on the EB6502? A retro computing challenge">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/JQuxmTqFi28" target="_blank" rel="noopener noreferrer">EB6502 walkthrough &mdash; a retro computing challenge</a><span class="dur">19:00</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="Pr4oF3ofoNE" style="background-image:url(https://i.ytimg.com/vi/Pr4oF3ofoNE/hqdefault.jpg)" aria-label="Play video: Ultima IV on a 6502 — bringing a classic RPG to life">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/Pr4oF3ofoNE" target="_blank" rel="noopener noreferrer">Ultima&nbsp;IV on a 6502 &mdash; bringing a classic RPG to life</a><span class="dur">4:58</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 3 &middot; The twist</p>
+      <h3>Wait&hellip; am I building an Apple&nbsp;II?</h3>
+      <p>
+        To run Apple&nbsp;II software faithfully, I kept having to <em>become</em> the Apple&nbsp;II:
+        emulate its <strong>artifact color</strong> out of a modern VGA signal using logic, tame the
+        timing with a <strong>PLL</strong>, and add a <strong>language card</strong> with the bank
+        switching Ultima&nbsp;IV expects. A machine that has to act like an Apple&nbsp;II deserves its
+        own identity &mdash; so the ebadger6502 became <strong>3RIC</strong>.
+      </p>
+      <blockquote>
+        &ldquo;A new computer deserves a new name &mdash; from now on ebadger6502 is the 3RIC 6502.&rdquo;
+        <cite>&mdash; my 6502.org project thread</cite>
+      </blockquote>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="LZXh7j7UPaY" style="background-image:url(https://i.ytimg.com/vi/LZXh7j7UPaY/hqdefault.jpg)" aria-label="Play video: 3RIC 6502 — am I building an Apple II?">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/LZXh7j7UPaY" target="_blank" rel="noopener noreferrer">3RIC 6502 &mdash; am I building an Apple&nbsp;II?</a><span class="dur">7:49</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="UuSKEHjjHn0" style="background-image:url(https://i.ytimg.com/vi/UuSKEHjjHn0/hqdefault.jpg)" aria-label="Play video: Porting Ultima IV — the Apple II language card and banking challenge">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/UuSKEHjjHn0" target="_blank" rel="noopener noreferrer">The Apple&nbsp;II language card &amp; banking challenge</a><span class="dur">7:03</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="kC3BS5_F_xo" style="background-image:url(https://i.ytimg.com/vi/kC3BS5_F_xo/hqdefault.jpg)" aria-label="Play video: Is the 3R1C a Commander X16 killer? Ultima IV update">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/kC3BS5_F_xo" target="_blank" rel="noopener noreferrer">A Commander&nbsp;X16 killer? &mdash; Ultima&nbsp;IV update</a><span class="dur">8:03</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 4 &middot; Making it a real computer</p>
+      <h3>Disks, joysticks, demos &amp; music</h3>
+      <p>
+        A computer isn&rsquo;t fun until it&rsquo;s <em>playable</em>. 3RIC got Apple&nbsp;II
+        <strong>disk emulation</strong>, <strong>joysticks</strong> hacked out of a SNES gamepad, a
+        run of deater&rsquo;s jaw-dropping <strong>Mode&nbsp;7</strong> demo, and even a
+        Petscii&nbsp;Robots intro screen with <strong>Mockingboard</strong> music. Bit by bit it
+        stopped being a project and started being a machine.
+      </p>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="rA7bQ838gZ0" style="background-image:url(https://i.ytimg.com/vi/rA7bQ838gZ0/hqdefault.jpg)" aria-label="Play video: 3RIC — playtime with Apple II disk emulation">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/rA7bQ838gZ0" target="_blank" rel="noopener noreferrer">Playtime with Apple&nbsp;II disk emulation</a><span class="dur">39:00</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="HeC8wlNiH0c" style="background-image:url(https://i.ytimg.com/vi/HeC8wlNiH0c/hqdefault.jpg)" aria-label="Play video: 3RIC gets joysticks — hacking a SNES gamepad">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/HeC8wlNiH0c" target="_blank" rel="noopener noreferrer">3RIC gets joysticks &mdash; hacking a SNES gamepad</a><span class="dur">7:01</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="a_jcKuw44c8" style="background-image:url(https://i.ytimg.com/vi/a_jcKuw44c8/hqdefault.jpg)" aria-label="Play video: Breadboard 6502 running deater's Mode 7 Apple II demo">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/a_jcKuw44c8" target="_blank" rel="noopener noreferrer">deater&rsquo;s Mode&nbsp;7 Apple&nbsp;II demo</a><span class="dur">1:54</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="quxPbxa5BJE" style="background-image:url(https://i.ytimg.com/vi/quxPbxa5BJE/hqdefault.jpg)" aria-label="Play video: Petscii Robots intro with Mockingboard music on 3RIC">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/quxPbxa5BJE" target="_blank" rel="noopener noreferrer">Petscii&nbsp;Robots + Mockingboard music</a><span class="dur">0:32</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 5 &middot; From wires to a board</p>
+      <h3>Breadboards &rarr; PCB</h3>
+      <p>
+        A wall of jumper wires can only take you so far. The scariest, most satisfying step was
+        turning the rat&rsquo;s nest into a real <strong>printed circuit board</strong> &mdash;
+        committing the design to copper, ordering it, and hoping it powers on. (Spoiler: it took a
+        couple of tries. It always does.)
+      </p>
+      <figure class="vid feature">
+        <div class="media">
+          <button class="lite-yt" data-id="w9Gtfwvl4cY" style="background-image:url(https://i.ytimg.com/vi/w9Gtfwvl4cY/hqdefault.jpg)" aria-label="Play video: 3RIC 6502 from breadboards to PCB">
+            <span class="play" aria-hidden="true">&#9654;</span>
+          </button>
+        </div>
+        <figcaption><a href="https://youtu.be/w9Gtfwvl4cY" target="_blank" rel="noopener noreferrer">3RIC 6502 &mdash; from breadboards to PCB</a><span class="dur">9:15</span></figcaption>
+      </figure>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="WHrFdTmDhjY" style="background-image:url(https://i.ytimg.com/vi/WHrFdTmDhjY/hqdefault.jpg)" aria-label="Play video: 3R1C homebrew computer — tear it down?">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/WHrFdTmDhjY" target="_blank" rel="noopener noreferrer">Tear it down?</a><span class="dur">2:40</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="WXjMHbjiHTY" style="background-image:url(https://i.ytimg.com/vi/WXjMHbjiHTY/hqdefault.jpg)" aria-label="Play video: Oops, I did it again — the PCB build">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/WXjMHbjiHTY" target="_blank" rel="noopener noreferrer">Oops, I did it again (PCB build)</a><span class="dur">0:25</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 6 &middot; The payoff</p>
+      <h3>Ultima&nbsp;IV, completed.</h3>
+      <p>
+        Years of Saturdays later, the machine I built from chips booted the disk, ran the game, and I
+        <strong>finished Ultima&nbsp;IV on it</strong> &mdash; the exact thing I set out to do. Then I
+        sat down for a proper wrap-up on what the whole adventure taught me.
+      </p>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="kvI9nI8rl0o" style="background-image:url(https://i.ytimg.com/vi/kvI9nI8rl0o/hqdefault.jpg)" aria-label="Play video: 3RIC 6502 homebrew computer — Ultima IV completed">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/kvI9nI8rl0o" target="_blank" rel="noopener noreferrer">Ultima&nbsp;IV completed</a><span class="dur">0:37</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="0BFpo2a4FHQ" style="background-image:url(https://i.ytimg.com/vi/0BFpo2a4FHQ/hqdefault.jpg)" aria-label="Play video: 3RIC homebrew 6502 — the conclusion">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/0BFpo2a4FHQ" target="_blank" rel="noopener noreferrer">3RIC homebrew 6502 &mdash; the conclusion</a><span class="dur">9:01</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 7 &middot; Not just one machine</p>
+      <h3>The wider hardware-hacking universe</h3>
+      <p>
+        3RIC is the headline, but it lives in a bigger tinkering habit. There&rsquo;s the
+        <strong>Badger6502&nbsp;Pico</strong> &mdash; a DIY kit and a Raspberry&nbsp;Pi&nbsp;Pico
+        running a 6502 emulator, complete with a 3D-printed case &mdash; the endless
+        <strong>Lode&nbsp;Runner</strong> saga that hops between an Apple&nbsp;II, the Pico, and
+        3RIC, and detours into <strong>ESP32</strong>, the <strong>Atari&nbsp;2600</strong>, and the
+        XAC controller adapter. Same curiosity, different silicon.
+      </p>
+      <div class="video-row">
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="A-ka1GT2asc" style="background-image:url(https://i.ytimg.com/vi/A-ka1GT2asc/hqdefault.jpg)" aria-label="Play video: DIY Badger6502Pico Kit — case assembly demonstration">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/A-ka1GT2asc" target="_blank" rel="noopener noreferrer">DIY Badger6502&nbsp;Pico Kit &mdash; case assembly</a><span class="dur">1:41</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="umDmZJTn25A" style="background-image:url(https://i.ytimg.com/vi/umDmZJTn25A/hqdefault.jpg)" aria-label="Play video: Pi Pico firsts — the Badger6502 Pico, Lode Runner evolved">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/umDmZJTn25A" target="_blank" rel="noopener noreferrer">Pi&nbsp;Pico firsts &mdash; Lode&nbsp;Runner evolved</a><span class="dur">10:54</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="T5tWXcCaBWw" style="background-image:url(https://i.ytimg.com/vi/T5tWXcCaBWw/hqdefault.jpg)" aria-label="Play video: Lode Runner on my Pi Pico 6502 emulator and an Apple II side by side">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/T5tWXcCaBWw" target="_blank" rel="noopener noreferrer">Pico vs. Apple&nbsp;II, side by side</a><span class="dur">1:28</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="UJyYEBcQ2sE" style="background-image:url(https://i.ytimg.com/vi/UJyYEBcQ2sE/hqdefault.jpg)" aria-label="Play video: The homebrew ebadger 6502 Lode Runner epic tale continues">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/UJyYEBcQ2sE" target="_blank" rel="noopener noreferrer">The Lode&nbsp;Runner epic tale continues</a><span class="dur">4:13</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="8Bl3qC75VYw" style="background-image:url(https://i.ytimg.com/vi/8Bl3qC75VYw/hqdefault.jpg)" aria-label="Play video: My adventures with ESP32, Atari 2600 and the XAC">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/8Bl3qC75VYw" target="_blank" rel="noopener noreferrer">ESP32, Atari&nbsp;2600 &amp; the XAC</a><span class="dur">2:55</span></figcaption>
+        </figure>
+        <figure class="vid">
+          <div class="media">
+            <button class="lite-yt" data-id="XI2BuQyncEE" style="background-image:url(https://i.ytimg.com/vi/XI2BuQyncEE/hqdefault.jpg)" aria-label="Play video: Homebrew Lode Runner on 3RIC">
+              <span class="play" aria-hidden="true">&#9654;</span>
+            </button>
+          </div>
+          <figcaption><a href="https://youtu.be/XI2BuQyncEE" target="_blank" rel="noopener noreferrer">Homebrew Lode&nbsp;Runner on 3RIC</a><span class="dur">0:09</span></figcaption>
+        </figure>
+      </div>
+      <p class="playlist-note">
+        That&rsquo;s the highlight reel &mdash; the full run of build logs, shorts, and deep dives lives on the
+        <a href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer">3RIC build series</a>
+        and my <a href="https://www.youtube.com/@thecodesorcerer" target="_blank" rel="noopener noreferrer">YouTube channel</a>.
+      </p>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Chapter 8 &middot; Your turn</p>
+      <h3>Now the whole machine runs in your browser</h3>
+      <p>
+        Here&rsquo;s the twist ending: alongside the real hardware I built a <strong>cycle-honest C++
+        emulator</strong> of 3RIC and compiled it to <strong>WebAssembly</strong>, so the exact same
+        core that models the chips boots the real 512&nbsp;KB ROM in any browser &mdash; no install, no
+        account. Click the screen and type at the monitor prompt, boot a disk, or open the built-in
+        <strong>65C02 assembler</strong> and write a program that runs on the machine instantly.
+      </p>
+      <div class="cta">
+        <a class="btn" href="index.html">&#9654;&nbsp;Launch the emulator</a>
+        <a class="btn ghost" href="tutorials.html">Learn to program it</a>
+        <a class="btn ghost" href="gallery.html">Browse the gallery</a>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <p class="chapnum">Community &middot; Follow along</p>
+      <h3>Join the build</h3>
+      <div class="cards">
+        <div class="linkcard">
+          <h4>&#9654; YouTube build series</h4>
+          <p>Every episode, short, and deep dive from the workbench.</p>
+          <a class="go" href="https://www.youtube.com/@thecodesorcerer" target="_blank" rel="noopener noreferrer">Watch &amp; subscribe</a>
+        </div>
+        <div class="linkcard">
+          <h4>r/beneater</h4>
+          <p>The homebrew-6502 community where a lot of this journey was shared and debated.</p>
+          <a class="go" href="https://www.reddit.com/r/beneater/" target="_blank" rel="noopener noreferrer">Open the subreddit</a>
+        </div>
+        <div class="linkcard">
+          <h4>6502.org &mdash; project thread</h4>
+          <p>My long-running &ldquo;3RIC&rdquo; build log among fellow 6502 hardware nerds.</p>
+          <a class="go" href="https://6502.org/forum/viewtopic.php?t=7749" target="_blank" rel="noopener noreferrer">Read the thread</a>
+        </div>
+        <div class="linkcard">
+          <h4>Source on GitHub</h4>
+          <p>Emulator, ROM, schematics, and the in-browser assembler &mdash; all open.</p>
+          <a class="go" href="https://github.com/ebadger/3ric" target="_blank" rel="noopener noreferrer">github.com/ebadger/3ric</a>
+        </div>
+        <div class="linkcard stub">
+          <h4>Reddit post highlights</h4>
+          <p>Curated r/beneater posts and milestones will land here soon.</p>
+          <a class="go" href="https://www.reddit.com/r/beneater/" target="_blank" rel="noopener noreferrer">r/beneater &rarr;</a>
+        </div>
+        <div class="linkcard">
+          <h4>&#9749; Support the project</h4>
+          <p>Sponsorship funds parts, boards, and more build videos &mdash; every backer is credited.</p>
+          <a class="go" href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">Become a sponsor</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    3ric &mdash; The Story &middot;
+    <a href="index.html">Emulator</a> &middot;
+    <a href="tutorials.html">Tutorials</a> &middot;
+    <a href="gallery.html">Gallery</a> &middot;
+    <a href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer">Build series</a> &middot;
+    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="llms.txt">For AI tools</a> &middot;
+    <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support</a>
+  </footer>
+
+  <script>
+    // Lite-embed facade: each .lite-yt shows a static YouTube thumbnail; clicking (or
+    // Enter/Space, since it's a <button>) swaps in a privacy-friendly youtube-nocookie
+    // player. Nothing loads from YouTube's player domain until the visitor opts in.
+    (function () {
+      "use strict";
+      var buttons = document.querySelectorAll(".lite-yt");
+      Array.prototype.forEach.call(buttons, function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-id");
+          if (!/^[A-Za-z0-9_-]{11}$/.test(id || "")) return; // static IDs only
+          var iframe = document.createElement("iframe");
+          iframe.src = "https://www.youtube-nocookie.com/embed/" + id + "?autoplay=1&rel=0";
+          iframe.title = btn.getAttribute("aria-label") || "YouTube video player";
+          iframe.setAttribute("allow", "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share");
+          iframe.setAttribute("allowfullscreen", "");
+          iframe.setAttribute("loading", "eager");
+          btn.replaceWith(iframe);
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/tutorials.html
+++ b/web/tutorials.html
@@ -166,8 +166,8 @@
     <a href="index.html">Emulator</a> &middot;
     <a href="story.html">Story</a> &middot;
     <a href="gallery.html">Gallery</a> &middot;
-    <a href="https://github.com/ebadger/3ric/tree/main/docs/tutorials">All lessons on GitHub</a> &middot;
-    <a href="https://github.com/ebadger/3ric">Source</a> &middot;
+    <a href="https://github.com/ebadger/3ric/tree/main/docs/tutorials" target="_blank" rel="noopener noreferrer">All lessons on GitHub</a> &middot;
+    <a href="https://github.com/ebadger/3ric" target="_blank" rel="noopener noreferrer">Source</a> &middot;
     <a href="llms.txt">For AI tools</a>
   </footer>
 </body>

--- a/web/tutorials.html
+++ b/web/tutorials.html
@@ -57,6 +57,7 @@
   <header>
     <h1>3ric&nbsp;&mdash;&nbsp;65C02&nbsp;Game&nbsp;Dev&nbsp;Tutorials</h1>
     <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
+    <a class="nav" href="story.html">&#9654;&nbsp;Story</a>
     <a class="nav" href="gallery.html">&#9654;&nbsp;Gallery</a>
   </header>
   <main>
@@ -163,6 +164,7 @@
   <footer>
     3ric Game Dev Tutorials &middot;
     <a href="index.html">Emulator</a> &middot;
+    <a href="story.html">Story</a> &middot;
     <a href="gallery.html">Gallery</a> &middot;
     <a href="https://github.com/ebadger/3ric/tree/main/docs/tutorials">All lessons on GitHub</a> &middot;
     <a href="https://github.com/ebadger/3ric">Source</a> &middot;


### PR DESCRIPTION
## What & why

Adds an engaging **`web/story.html`** landing page that tells the story of 3ric — and, per request, the **wider hardware‑hacking journey**, not just 3ric — and wires it into the web client. It funnels visitors from the narrative into the live browser emulator.

The narrative is written in the author's own voice, drawn from the YouTube build series (all 16 playlist episodes + the broader `@thecodesorcerer` channel — 29 uploads total), the [6502.org project thread](https://6502.org/forum/viewtopic.php?t=7749), and Eric's first‑person account of the project.

- **Chapter arc:** an **Atari 1200XL** childhood + *"how do these machines really work?"* learning journey → a **first machine (EB6502)** and the goal that changed everything: **get Lode Runner running** → the twist: *to run Lode Runner, I had to make my machine speak Apple II* — an **original design** (its schematic looks nothing like an Apple II) that gets close enough in behavior to run a lot of Apple II software, though not all of it (the Apple II had the simplest graphics you can still build from off‑the‑shelf parts today) → the **graphics system the author is proudest of** — hardware‑generated **VGA**, Apple II **NTSC color‑burst artifact color reproduced in designed logic**, and a **shared‑RAM CPU/video bus** that only works with exact timing → its own machine: **modern I/O** (PS/2 keyboard + mouse, SNES pads, SD card) and a **significantly different ROM** (generic MS‑BASIC, no Applesoft) → named **3RIC** → disks/joysticks/Mockingboard/Mode‑7 → **breadboard → PCB** → the payoff: **Lode Runner runs → Ultima IV finished → many more games**, with a first‑person *"lesson in faith"* reflection → the wider universe (**Badger6502 Pico** kit + Pi Pico 6502 emulator, ESP32/Atari‑2600/XAC, the cross‑platform Lode Runner saga) → **run it in your browser** — and, because the in‑browser build exports a bootable **.woz**, the site doubles as an **Apple II dev kit** (build here, boot on real hardware).
- Each chapter links its episode via a **lite‑embed facade**: a static `i.ytimg.com` thumbnail that swaps in a privacy‑friendly `youtube-nocookie.com` iframe only **after the visitor clicks** — so nothing loads from YouTube's player domain on page load. Keyboard‑accessible (real `<button>`s), and video IDs are validated static‑only (`/^[A-Za-z0-9_-]{11}$/`) in the swap handler.

## Changes
- **`web/story.html`** — new page, terminal‑green theme identical to `gallery.html`/`tutorials.html`; 22 curated videos; Community section; OG tags.
- **Nav wiring** — a **Story** link added to the headers *and* footers of `index.html`, `gallery.html`, `tutorials.html`.
- **`.github/workflows/deploy-pages.yml`** — stage `web/story.html` into `_site/`.
- **`web/sitemap.xml`** — add the story page.
- **`specs/WEB-CLIENT.md`** — document the page (contracts, deploy staging, Implementation Status) — *specs updated in the same commits.*

## Verification
- All **22** video cards validated: `data-id` ↔ thumbnail ↔ `youtu.be` link all align (22 unique, no dupes/orphans); tag structure balances; all thumbnails return HTTP 200.
- Assembler pre‑push gate: **ALL PASS**.
- `index/gallery/tutorials/story.html` all serve **200** locally; rendered in a browser preview.

## Second-model review
Per `docs/CODE-REVIEW-PANEL.md`, two independent read‑only reviewers on different vendors reviewed this change across three rounds as the narrative evolved. Final diff reviewed: `7f6a207..b24cf00`.

| Reviewer (model) | Round 1 (`e6ba632`) | Round 2 (`dc8c7b8`) | Round 3 (`b24cf00`, final) |
| --- | --- | --- | --- |
| **GPT (`gpt-5.5`)** | 1 finding (MEDIUM) — footer `Source` link missing `target=_blank rel=noopener noreferrer` | **LGTM** — 0 findings | **LGTM** — 0 findings |
| **Gemini (`gemini-3.1-pro-preview`)** | **LGTM** — 0 findings | **LGTM** — 0 findings | **LGTM** — 0 findings |

- **Round 2** reviewed the narrative reframe to the author's real story (Atari 1200XL → Lode Runner goal → graphics system → Ultima IV → "lesson in faith").
- **Round 3** reviewed the accuracy correction (3RIC framed as an *original, Apple‑II‑compatible* design rather than a clone; modern I/O; significantly different ROM; no Applesoft; not all Apple II software runs) plus the new **Apple II dev‑kit / Download .woz** paragraph.
- **Resolved:** GPT's Round‑1 finding — added `target="_blank" rel="noopener noreferrer"` to the GitHub `Source` / `All lessons` footer links in `story.html`, `gallery.html`, and `tutorials.html` (also harmonized the pre‑existing site‑wide inconsistency).
- **Overridden:** none.
- Both reviewers independently cleared, on the final diff: iframe‑build injection safety (11‑char allow‑list regex), external‑link `rel`, relative paths for the `/3ric/` project page, 22/22 video‑ID integrity, HTML validity, factual consistency of the `.woz`/no‑Applesoft claims against the code + specs, and deploy/sitemap/spec consistency.

Verbatim reviewer outputs + per‑model scorecards are posted as PR comments.

## Follow‑up (needs your input)
The **r/beneater** post summaries aren't included yet — Reddit hard‑blocks automated access (403 on every route) and your posts aren't search‑indexed. There's a clearly‑marked **"Reddit post highlights"** stub in the Community section ready to fill. Paste the post links/text and I'll fold curated highlights into that section.

Also easy to adjust: which/how many videos appear per chapter, the copy's voice (currently first‑person), and whether you'd prefer plain thumbnail‑links over the click‑to‑play facade.

🔗 Preview after merge: <https://ebadger.github.io/3ric/story.html>