### PR TITLE
Add "Hello, KansasFest 2026" browser demo + gallery entry

### DIFF
--- a/codegen/programs/kfest.s
+++ b/codegen/programs/kfest.s
@@ -1,0 +1,75 @@
+; ============================================================================
+; kfest.s — 3ric says hello to KansasFest 2026.
+;
+; A zero-install greeting for the Apple II crowd. It selects full-screen text,
+; clears the 40x24 screen, and prints a framed welcome through the ROM monitor's
+; COUT ($FDED) — which also echoes to the serial port, so the headless harness
+; can verify every line. It then rests in a tight loop so the message stays put
+; on screen in the browser (a clean "idle" halt).
+;
+;   Try it in the browser (nothing to install):
+;     https://ebadger.github.io/3ric/?src=programs/kfest.s
+;   ...or scan the KansasFest QR code.
+;
+;   Verify locally with the headless emulator:
+;     node codegen/tools/run6502.mjs codegen/programs/kfest.s \
+;         --expect-serial "HELLO, KANSASFEST 2026" --expect-halt idle
+;
+;   On real hardware:  BRUN KFEST.PRG 0800
+; ============================================================================
+
+        .org $0800
+
+; ---- ROM routines & soft switches (from the platform reference) -------------
+COUT    = $FDED             ; print A (ASCII, high bit set) to screen + serial
+HOME    = $FC58             ; clear the text screen, cursor home
+SW_TEXT = $C051             ; select text mode
+SW_FULL = $C052             ; full screen (clear mixed graphics/text)
+SW_PG1  = $C054             ; display page 1
+
+; ---- zero-page string pointer used by PUTS ----------------------------------
+STRLO   = $06
+STRHI   = $07
+
+; ---- program ----------------------------------------------------------------
+        bit SW_TEXT         ; make sure we are in full-screen text, page 1
+        bit SW_FULL
+        bit SW_PG1
+        jsr HOME            ; clean screen, cursor to the top-left
+
+        lda #<msg           ; point PUTS at the greeting
+        sta STRLO
+        lda #>msg
+        sta STRHI
+        jsr puts
+
+rest:   bra rest            ; keep the greeting on screen (clean idle halt)
+
+; ---- PUTS: print the NUL-terminated string at STRLO/STRHI via COUT ----------
+; The text below is stored as plain ASCII; COUT wants the high bit set, so we
+; OR in $80 on the way out. That also turns a stored $0D into $8D (COUT's CR).
+puts:   ldy #0
+putslp: lda (STRLO),y
+        beq putsend         ; $00 terminates the string
+        ora #$80
+        jsr COUT
+        iny
+        bne putslp
+        inc STRHI           ; carry into the high byte for strings > 255 bytes
+        bra putslp
+putsend:rts
+
+; ---- the message (plain ASCII; $0D = new line, $00 = end) -------------------
+msg:    .byte $0D
+        .byte "  *** HELLO, KANSASFEST 2026! ***", $0D
+        .byte $0D
+        .byte "  THIS IS 3RIC -- A FROM-SCRATCH", $0D
+        .byte "  APPLE-II-CLASS 65C02 COMPUTER.", $0D
+        .byte $0D
+        .byte "  BUILT FROM CHIPS, DOCUMENTED ON", $0D
+        .byte "  YOUTUBE -- AND RUNNING RIGHT NOW", $0D
+        .byte "  IN YOUR BROWSER. NO INSTALL.", $0D
+        .byte $0D
+        .byte "  TYPE YOUR OWN 6502 BELOW, THEN", $0D
+        .byte "  HIT *SHARE* TO PASS IT ON.", $0D
+        .byte $00

--- a/web/gallery.json
+++ b/web/gallery.json
@@ -3,6 +3,15 @@
   "_readme": "Community Gallery manifest for the 3ric web client. Each entry becomes a card on gallery.html with a one-click 'Run & Remix' link into the in-browser editor. To feature your own program: add its .s source under codegen/programs/ (build.ps1 stages every codegen/programs/*.s into web/programs/) and append an entry below, then open a pull request. Fields: title (required), author, authorUrl, mode (Hi-res|Lo-res|Text|Serial), description, tags[]; and a run target of either src ('programs/<name>.s') or an inline code (URL-safe base64 for ?code=), plus an optional org (hex load address, only when the source has no .org directive).",
   "entries": [
     {
+      "title": "Hello, KansasFest 2026",
+      "author": "3ric",
+      "authorUrl": "https://github.com/ebadger/3ric",
+      "mode": "Text",
+      "src": "programs/kfest.s",
+      "description": "3ric's zero-install greeting to the Apple II crowd for KansasFest 2026 — a framed text welcome you can run, remix, and re-share right in the browser. No install, no account.",
+      "tags": ["demo", "text", "kansasfest", "greeting"]
+    },
+    {
       "title": "Swarm",
       "author": "3ric",
       "authorUrl": "https://github.com/ebadger/3ric",


### PR DESCRIPTION
## What

A zero-install greeting for the Apple II crowd at **KansasFest 2026**:

- **`codegen/programs/kfest.s`** — a 65C02 text-mode program that selects full-screen text, clears the 40×24 screen, and prints a framed welcome via the ROM monitor's `COUT` ($FDED), then rests in a clean idle loop so the message stays on screen in the browser.
- **`web/gallery.json`** — features it as the first Community Gallery card, which also makes it deep-linkable at `?src=programs/kfest.s`.

## Why

I'm not attending KFest 2026 in person, so the launch plan leans on a single portable asset: a **QR code that boots the machine on someone's phone in seconds**. That needs a short, clean deep link — which only exists once this sample is deployed to Pages. Merging this makes the primary link live:

**https://ebadger.github.io/3ric/?src=programs/kfest.s**

(A self-contained `?code=` link works today without deploy, but inlining the source makes a dense, hard-to-scan QR — hence the short `?src=` path.)

## Verification

```
node codegen/tools/run6502.mjs codegen/programs/kfest.s \
    --expect-serial "HELLO, KANSASFEST 2026" --expect-halt idle
→ VERDICT: PASS   (decoded 40×24 screen shows the full greeting; clean idle halt)
```

Pre-push gate green: assembler encoding tests PASS, boot smoke test PASS.

## Deploy path

`deploy-pages.yml` triggers on `codegen/programs/**` and `web/**`, and `build.ps1` stages `codegen/programs/*.s` into `web/programs/`, so `?src=programs/kfest.s` resolves after merge + redeploy.

## Notes

- No spec change needed — this follows the documented gallery-contribution flow (`.s` source + `gallery.json` entry). ROM-SOFTWARE.md already tracks `codegen/programs/` as an ongoing library, generically.
- Not committed: `kfest.prg` (gitignored build artifact) and `web/programs/` (regenerated by the build).

## Second-model review
- Reviewed diff: `7f6a207...b45d807`
- GPT Reviewer (gpt-5.5): LGTM — 0 findings
- Gemini Reviewer (gemini-3.1-pro-preview): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden (no findings raised)
- Verbatim reviewer output + per-model scorecards posted as a PR comment.

🤖 Companion launch assets (post copy, lightning-talk script, QR PNGs) were generated alongside this but live outside the repo.