### PR TITLE
Update GPT Reviewer agent model to gpt-5.6-sol

### DIFF
--- a/.github/agents/gpt-reviewer.md
+++ b/.github/agents/gpt-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: GPT Reviewer
-description: "Independent code-review specialist powered by a strong non-Claude model (e.g. GPT-5.5). One of two model-diverse reviewers (with Gemini Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
-model: gpt-5.5
+description: "Independent code-review specialist powered by a strong non-Claude model (e.g. GPT-5.6 Sol). One of two model-diverse reviewers (with Gemini Reviewer) consulted BY RULE before any code/spec/schema PR is published — see docs/CODE-REVIEW-PANEL.md. Reviews a diff for bugs, security holes, data-integrity and critical-path risks, cross-layer breakage, and missing tests, then returns ranked findings with concrete fixes and a verdict. Read-only: never edits code. Do NOT use for feature design, implementation, deployment, or product decisions."
+model: gpt-5.6-sol
 tools: ["read", "search"]
 disable-model-invocation: true
 ---


### PR DESCRIPTION
## What

Bump the **GPT Reviewer** code-review agent (`.github/agents/gpt-reviewer.md`) from `gpt-5.5` to `gpt-5.6-sol` (GPT-5.6 Sol).

## Changes
- `model:` frontmatter field → `gpt-5.6-sol`
- Description example updated from "e.g. GPT-5.5" → "e.g. GPT-5.6 Sol" to stay consistent

No behavioral/spec changes — this only swaps the model backing the independent GPT reviewer. `gpt-reviewer.md` was the only file referencing the version (both reviewers confirmed no stale `gpt-5.5` references elsewhere). Cross-vendor diversity preserved: GPT reviewer stays non-Claude/non-Gemini vs the Gemini reviewer's `gemini-3.1-pro-preview`.

## Second-model review
- Reviewed diff: `796c1522...12ff4d23`
- GPT Reviewer (gpt-5.6-sol): LGTM — 0 findings
- Gemini Reviewer (gemini-3.1-pro-preview): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>