### PR TITLE
Revalidate editor sample-source fetches so deploys aren't masked by browser cache

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -32,7 +32,11 @@ host it as static files.
   and the in-browser **Assembler** panel (imports `assemble()` from the staged
   `asm6502.mjs`). Honors optional `window.ASSET_BASE` / `?assets=` for CDN/R2 offload and
   `?src=` / `?prg=` / `?code=` deep links, plus a **Share** button that builds a one-click
-  link to the current editor program.
+  link to the current editor program. The sample-source loads (the **sample** dropdown and
+  `?src=programs/<name>.s`) fetch with `{ cache: "no-cache" }` so the browser **revalidates**
+  against Pages instead of serving a stale `max-age=600` copy — a freshly deployed program
+  shows up on the next selection without a hard refresh. (There is no service worker, and
+  GitHub Pages purges its CDN on every deploy, so the revalidation returns the new source.)
 - **Assembler downloads (`index.html` + staged `wozgen.mjs`):** the Assembler panel offers
   **Download .PRG** (the raw assembled bytes) and **Download .woz** — a bootable 5.25″ WOZ2
   disk image of the current program, generated fully client-side by `wozgen.mjs` (a
@@ -152,7 +156,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | WASM build of the VM core + WozLib + SD | Shipped | `web/build.ps1`, Emscripten 6.0.1. |
 | Canvas video + keyboard | Shipped | text/lo-res/hi-res, `$C000` input. |
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
-| In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. |
+| In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. Sample sources fetched with `cache:"no-cache"` (revalidate) so a new deploy isn't masked by the browser cache. |
 | Program downloads (.PRG / .woz) | Shipped | **Download .PRG** (raw bytes) + **Download .woz** (bootable WOZ2 via `wozgen.mjs`, a port of `dsk2woz2`, with a multi-track boot loader); verified by `web/test_woz_download.cjs`. |
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |

--- a/web/index.html
+++ b/web/index.html
@@ -423,7 +423,12 @@
     }
 
     async function loadSampleSrc(name) {
-      const resp = await fetch(`programs/${name}.s`);
+      // Revalidate rather than trust the browser's cached copy: sample sources
+      // are static files served with max-age=600, so a repeat visitor could
+      // otherwise keep loading a stale programs/<name>.s for up to 10 min after
+      // a deploy. "no-cache" forces a conditional GET; GitHub Pages purges its
+      // CDN on deploy, so this returns the freshly deployed source.
+      const resp = await fetch(`programs/${name}.s`, { cache: "no-cache" });
       if (!resp.ok) throw new Error(`fetch programs/${name}.s: ${resp.status}`);
       return resp.text();
     }
@@ -586,7 +591,9 @@
       const srcUrl = params0.get("src");
       if (srcUrl) {
         try {
-          const resp = await fetch(srcUrl);
+          // Revalidate (see loadSampleSrc) so a shared ?src=programs/<name>.s
+          // link reflects the latest deploy, not a stale cached copy.
+          const resp = await fetch(srcUrl, { cache: "no-cache" });
           if (!resp.ok) throw new Error(`${resp.status}`);
           srcEl.value = await resp.text();
           const m = /^programs\/([\w-]+)\.s$/.exec(srcUrl);


### PR DESCRIPTION
## What & why
The Assemble & Run editor loads sample program sources from static `programs/<name>.s` files served by GitHub Pages with `Cache-Control: max-age=600`. A repeat visitor whose browser cached a source before a deploy kept seeing the **stale** version in the sample dropdown (and via `?src=` share links) for up to ~10 minutes with no hard refresh — the staleness ebadger hit after merging #42.

## Fix
Fetch sample **sources** with `{ cache: "no-cache" }` so the browser issues a conditional request and picks up freshly deployed sources immediately:
- `loadSampleSrc()` — the `#sample` dropdown loader.
- the `?src=programs/<name>.s` deep-link / share loader.

There is no service worker, and GitHub Pages purges its Fastly CDN on every deploy, so the revalidation returns the newly deployed source. Binary `.prg` / wasm / data loaders (`fetchBytes` / `fetchBytesUrl`) are intentionally left cacheable.

## Verification
- Inline `index.html` module script syntax-checked (`node --check`).
- Pre-push gate green: 65C02 assembler encoding tests + emulator boot smoke test.
- Confirmed the live `programs/blocks.s` on Pages already serves fresh content; this removes the remaining client-cache masking.

## Spec
Updated `specs/WEB-CLIENT.md` (UI bullet + Implementation Status) — specs-first.

## Second-model review
- Reviewed diff: `afdf7ef...8b6ea14`
- GPT Reviewer (gpt-5.6-sol): LGTM — 0 findings
- Gemini Reviewer (gemini-3.1-pro-preview): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden (no findings raised)