### PR TITLE
Add browser gamepad support through VIA

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -70,13 +70,14 @@ jobs:
           node web/test_audio_worklet.cjs
           node web/test_audio_pacing.cjs
           node web/test_mockingboard.cjs
+          node web/test_gamepad.cjs
           node web/test_boot.cjs
 
       # Stage only what the page needs (not the C++/test sources) as the site root.
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/emulation-clock.js web/audio-worklet.js web/gallery.html web/tutorials.html web/story.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/emulation-clock.js web/audio-worklet.js web/gamepad.js web/gallery.html web/tutorials.html web/story.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs web/wozgen.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/emulator/AICodeGen/blocks/blocks.s
+++ b/emulator/AICodeGen/blocks/blocks.s
@@ -4,11 +4,11 @@
 ;   * Generic falling-block stacker in a 10 x 20 well.
 ;   * Controls: Left/Right arrows or A/D move, Up/W rotates, Down/S drops,
 ;     Q quits.  SPACE restarts after game over.
-;   * SNES gamepad (real hardware): D-pad Left/Right move, Down soft-drops,
-;     Up / A / B rotate, SELECT quits, START restarts after game over.  The pad
-;     is read from the ROM's GAMEPAD1 ($CEE0) table, refreshed by touching PTRIG
-;     ($C070) which raises the VIA CB2 edge -> NMI pad-scan.  The emulator has no
-;     gamepad hardware, so the pad is a no-op there; verify on real hardware.
+;   * SNES gamepad: D-pad Left/Right move, Down soft-drops, Up / A / B rotate,
+;     SELECT quits, START restarts after game over.  The pad is read from the
+;     ROM's GAMEPAD1 ($CEE0) table, refreshed by touching PTRIG ($C070) which
+;     raises the VIA CB2 edge -> NMI pad-scan.  Browser USB/Bluetooth pads use
+;     this same VIA serial path.
 ;   * The well contents live in RAM; the text screen is rendered from that model.
 ;   * Gravity is paced by a 16-bit counter (GRAV) tuned for the native ~1.57 MHz
 ;     clock (~0.8 s/cell) so the drop is a comfortable classic pace, not too fast.
@@ -263,11 +263,9 @@ rk_rot:
 ; Down soft-drops fast while held; rotate is edge-detected via gpRot so one
 ; press = one turn; SELECT quits.
 ;
-; A real D-pad can never report LEFT+RIGHT or UP+DOWN simultaneously, so those
-; impossible combinations are rejected.  That also makes the pad a no-op under
-; emulation: the emulator models no pad hardware, so the ROM's bit-bang reads
-; every button as pressed -- the guard catches that and leaves the game on the
-; keyboard.  A disconnected pad reads all-zero (also safe).
+; A D-pad should not report LEFT+RIGHT or UP+DOWN simultaneously, so those
+; impossible combinations are rejected defensively.  A disconnected pad reads
+; all-zero.
 ; ---------------------------------------------------------------------------
 read_pad:
         lda PTRIG               ; strobe -> CB2 -> NMI -> ROM fills GAMEPAD1
@@ -582,7 +580,7 @@ go_wait:
         lda PTRIG               ; refresh the pad (-> CB2 -> NMI -> ROM scan)
         lda GAMEPAD1 + PAD_LEFT
         and GAMEPAD1 + PAD_RIGHT
-        bne go_wait             ; invalid combo (also the emulator) -> ignore pad
+        bne go_wait             ; invalid opposing directions -> ignore pad
         lda GAMEPAD1 + PAD_UP
         and GAMEPAD1 + PAD_DOWN
         bne go_wait
@@ -945,4 +943,3 @@ sh_j3: .byte 0,0, 0,1, 1,1, 2,1
 msg_status: .byte "BLOCK DROP  SCORE:000 A/D W/S ROT Q +PAD", 0
 msg_over:   .byte "**** GAME OVER ****", 0
 msg_again:  .byte "SPACE = PLAY AGAIN     Q = QUIT", 0
-

--- a/emulator/AICodeGen/blocks/prompt.md
+++ b/emulator/AICodeGen/blocks/prompt.md
@@ -40,7 +40,9 @@ node codegen/tools/blocks.test.mjs
 ## Run it
 
 - **Hardware / disk:** `BRUN BLOCKS.PRG 0800` — **A/D** move, **W** rotate,
-  **S** soft-drop, **Q** quits.
+  **S** soft-drop, **Q** quits; SNES D-pad moves/drops, A/B rotates, Select
+  quits, and Start restarts.
 - **Hosted emulator:** the **Games** dropdown, deep link
   `?prg=programs/blocks.prg&org=0800`, or **Load .PRG…** at address `0800`.
-  The gravity is tuned for the native **1×** (≈1.57 MHz) Speed setting.
+  Standard USB/Bluetooth controllers use the same SNES controls. The gravity is
+  tuned for the native **1×** (≈1.57 MHz) Speed setting.

--- a/emulator/AICodeGen/swarm/prompt.md
+++ b/emulator/AICodeGen/swarm/prompt.md
@@ -75,10 +75,10 @@ node codegen/tools/swarm.test.mjs
 - **D / right** — move the cannon right
 - **SPACE** — fire; also starts the game from the title screen and restarts on
   the game-over screen
-- **SNES D-pad left / right** — move the cannon on real hardware
+- **SNES D-pad left / right** — move the cannon
 - **SNES A / B** — fire
 - **SNES START** — start or restart; **SELECT** — quit to the monitor
 
 The ROM refreshes its `GAMEPAD1` table when the game touches `PTRIG`; impossible
-D-pad states are ignored so the unmodelled controller stays inert in the
-emulator. Verify pad input on real hardware.
+D-pad states are ignored defensively. The shared emulator models the same VIA/SNES
+serial path, with browser USB/Bluetooth controllers supplying the button state.

--- a/emulator/AICodeGen/swarm/swarm.s
+++ b/emulator/AICodeGen/swarm/swarm.s
@@ -7,10 +7,9 @@
 ; marches side to side, drops a row and speeds up as its ranks thin, rains bombs,
 ; and hides behind crumbling bunkers while a mystery saucer streaks overhead.
 ; Keyboard: A/D or Left/Right move, SPACE fires and starts/restarts the game.
-; SNES pad (real hardware): D-pad Left/Right move, A/B fire, START starts or
-; restarts, and SELECT quits.  Touching PTRIG refreshes the ROM's GAMEPAD1 table;
-; impossible D-pad states are rejected so the pad stays inert in the emulator,
-; which does not model controller hardware.
+; SNES pad: D-pad Left/Right move, A/B fire, START starts or restarts, and SELECT
+; quits.  Touching PTRIG refreshes the ROM's GAMEPAD1 table on hardware and in the
+; emulator; browser USB/Bluetooth pads follow this same VIA serial path.
 ; All sprite art, code and the name are original; only the un-copyrightable
 ; genre mechanics are shared with the classic.
 ;
@@ -434,9 +433,8 @@ api_select:
 api_ret:
         rts
 
-; pad_valid : carry set when the table contains a physically possible D-pad
-;   state.  The emulator's unmodelled pad reads every button as pressed, so this
-;   guard also prevents phantom movement, firing, starts, and quits there.
+; pad_valid : carry set when the table contains a physically possible D-pad state.
+;   Reject opposing directions defensively for hardware and host controllers.
 pad_valid:
         lda GAMEPAD1 + PAD_LEFT
         and GAMEPAD1 + PAD_RIGHT

--- a/emulator/Badger6502VMLib/Badger6502VMLib.vcxproj
+++ b/emulator/Badger6502VMLib/Badger6502VMLib.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="ay38910.cpp" />
     <ClCompile Include="mockingboard.cpp" />
     <ClCompile Include="PS2Keyboard.cpp" />
+    <ClCompile Include="snesgamepads.cpp" />
     <ClCompile Include="symbols.cpp" />
     <ClCompile Include="via.cpp" />
     <ClCompile Include="vm.cpp" />
@@ -47,6 +48,7 @@
     <ClInclude Include="opcodes.h" />
     <ClInclude Include="mockingboard.h" />
     <ClInclude Include="ps2keyboard.h" />
+    <ClInclude Include="snesgamepads.h" />
     <ClInclude Include="symbols.h" />
     <ClInclude Include="via.h" />
     <ClInclude Include="vm.h" />

--- a/emulator/Badger6502VMLib/snesgamepads.cpp
+++ b/emulator/Badger6502VMLib/snesgamepads.cpp
@@ -1,0 +1,76 @@
+#include "snesgamepads.h"
+
+#include "via.h"
+
+namespace
+{
+	constexpr uint8_t LATCH = 0x40;
+	constexpr uint8_t CLOCK = 0x80;
+	constexpr uint8_t DATA_1 = 0x20;
+	constexpr uint8_t DATA_2 = 0x10;
+	constexpr uint8_t DATA_MASK = DATA_1 | DATA_2;
+}
+
+SNESGamepads::SNESGamepads(VIA& via)
+	: _via(via)
+{
+	Reset();
+}
+
+void SNESGamepads::Reset()
+{
+	_latchedButtons.fill(0);
+	_bit = 16;
+	const uint8_t portB = _via.GetPortBOutput();
+	_latch = (portB & LATCH) != 0;
+	_clock = (portB & CLOCK) != 0;
+	RefreshDataLines();
+}
+
+bool SNESGamepads::SetState(size_t controller, uint16_t pressedButtons)
+{
+	if (controller >= CONTROLLER_COUNT)
+	{
+		return false;
+	}
+
+	_liveButtons[controller] = pressedButtons & BUTTON_MASK;
+	return true;
+}
+
+void SNESGamepads::UpdatePortB(uint8_t portB)
+{
+	const bool latch = (portB & LATCH) != 0;
+	const bool clock = (portB & CLOCK) != 0;
+
+	if (latch && !_latch)
+	{
+		_latchedButtons = _liveButtons;
+		_bit = 0;
+	}
+	else if (!latch && clock && !_clock && _bit < 16)
+	{
+		++_bit;
+	}
+
+	_latch = latch;
+	_clock = clock;
+	RefreshDataLines();
+}
+
+void SNESGamepads::RefreshDataLines()
+{
+	uint8_t data = DATA_MASK;
+	if (_bit < 16)
+	{
+		if (_latchedButtons[0] & (uint16_t)(1u << _bit))
+		{
+			data &= (uint8_t)~DATA_1;
+		}
+		if (_latchedButtons[1] & (uint16_t)(1u << _bit))
+		{
+			data &= (uint8_t)~DATA_2;
+		}
+	}
+	_via.SetPortBInputBits(DATA_MASK, data);
+}

--- a/emulator/Badger6502VMLib/snesgamepads.h
+++ b/emulator/Badger6502VMLib/snesgamepads.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+class VIA;
+
+class SNESGamepads
+{
+public:
+	static constexpr size_t CONTROLLER_COUNT = 2;
+	static constexpr uint16_t BUTTON_MASK = 0x0FFF;
+
+	explicit SNESGamepads(VIA& via);
+
+	void Reset();
+	bool SetState(size_t controller, uint16_t pressedButtons);
+	void UpdatePortB(uint8_t portB);
+
+private:
+	void RefreshDataLines();
+
+	VIA& _via;
+	std::array<uint16_t, CONTROLLER_COUNT> _liveButtons = {};
+	std::array<uint16_t, CONTROLLER_COUNT> _latchedButtons = {};
+	uint8_t _bit = 16;
+	bool _latch = false;
+	bool _clock = false;
+};

--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -33,6 +33,7 @@ VM::~VM()
 {
 	delete _cpu;
 	delete _acia;
+	delete _gamepads;
 	delete _via1;
 	delete _mockingboard;
 	delete _pPS2;
@@ -44,6 +45,7 @@ void VM::Init()
 	_cpu = new CPU(this);
 	_acia = new ACIA(this);
 	_via1 = new VIA(this);
+	_gamepads = new SNESGamepads(*_via1);
 	_mockingboard = new Mockingboard();
 	_pPS2 = new PS2Keyboard(this);
 	srand(*(unsigned int*)(void*)this);
@@ -77,6 +79,7 @@ void VM::Reset()
 	_acia->Reset();
 	_pPS2->Reset();
 	_via1->Reset();
+	_gamepads->Reset();
 	_mockingboard->Reset();
 }
 
@@ -110,11 +113,17 @@ void VM::SignalVIA1Pin(VIA::Pins pin)
 	UpdateVIA1NMI();
 }
 
+bool VM::SetGamepadState(uint8_t controller, uint16_t pressedButtons)
+{
+	return _gamepads->SetState(controller, pressedButtons);
+}
+
 void VM::TickDevices(uint32_t cycles)
 {
 	for (uint32_t i = 0; i < cycles; ++i)
 	{
 		_via1->Tick();
+		_gamepads->UpdatePortB(_via1->GetPortBOutput());
 		UpdateVIA1NMI();
 		_mockingboard->Tick();
 	}
@@ -592,6 +601,7 @@ void VM::WriteData(uint16_t address, uint8_t byte)
 	{
 		// VIA1
 		_via1->WriteRegister(address & 0xF, byte);
+		_gamepads->UpdatePortB(_via1->GetPortBOutput());
 		UpdateVIA1NMI();
 	}
 	else if (address >= MM_MOCKINGBOARD_VIA1_START

--- a/emulator/Badger6502VMLib/vm.h
+++ b/emulator/Badger6502VMLib/vm.h
@@ -5,6 +5,7 @@
 #include "acia.h"
 #include "via.h"
 #include "mockingboard.h"
+#include "snesgamepads.h"
 #include "ps2keyboard.h"
 #include <functional>
 #include <unordered_map>
@@ -148,6 +149,7 @@ public:
 	void TickDevices(uint32_t cycles);
 	bool IRQAsserted() const;
 	void SignalVIA1Pin(VIA::Pins pin);
+	bool SetGamepadState(uint8_t controller, uint16_t pressedButtons);
 	CPU* GetCPU();
 	VIA* GetVIA1();
 	Mockingboard* GetMockingboard();
@@ -202,6 +204,7 @@ private:
 	CPU	*			_cpu;
 	ACIA *			_acia;
 	VIA *			_via1;
+	SNESGamepads *	_gamepads;
 	Mockingboard *	_mockingboard;
 	PS2Keyboard *	_pPS2;
 	

--- a/emulator/Badger6502VMTest/Badger6502VMTest.vcxproj
+++ b/emulator/Badger6502VMTest/Badger6502VMTest.vcxproj
@@ -237,6 +237,7 @@
     <ClCompile Include="Compare.cpp" />
     <ClCompile Include="EOR.cpp" />
     <ClCompile Include="Flags.cpp" />
+    <ClCompile Include="GamepadTests.cpp" />
     <ClCompile Include="IncDec_Mem.cpp" />
     <ClCompile Include="JMP.cpp" />
     <ClCompile Include="JSR_RTS.cpp" />

--- a/emulator/Badger6502VMTest/Badger6502VMTest.vcxproj.filters
+++ b/emulator/Badger6502VMTest/Badger6502VMTest.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="MockingboardTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GamepadTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/emulator/Badger6502VMTest/GamepadTests.cpp
+++ b/emulator/Badger6502VMTest/GamepadTests.cpp
@@ -1,0 +1,97 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+#include "vm.h"
+
+#include <array>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace
+{
+	std::array<uint16_t, 2> ScanGamepads(VM& vm)
+	{
+		std::array<uint16_t, 2> result = {};
+
+		vm.WriteData(MM_VIA1_START + VIA::DDRB, 0xC0);
+		vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x00);
+		vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x40);
+
+		for (uint8_t bit = 0; bit < 16; ++bit)
+		{
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x00);
+			const uint8_t portB = vm.ReadData(MM_VIA1_START + VIA::ORB_IRB);
+			if ((portB & 0x20) == 0)
+			{
+				result[0] |= (uint16_t)(1u << bit);
+			}
+			if ((portB & 0x10) == 0)
+			{
+				result[1] |= (uint16_t)(1u << bit);
+			}
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x80);
+		}
+
+		return result;
+	}
+}
+
+namespace Badger6502VMTest
+{
+	TEST_CLASS(GamepadTests)
+	{
+	public:
+		TEST_METHOD(SerializesBothControllersInROMOrder)
+		{
+			VM vm(true);
+			Assert::IsTrue(vm.SetGamepadState(0, 0x0A55));
+			Assert::IsTrue(vm.SetGamepadState(1, 0x05AA));
+
+			const std::array<uint16_t, 2> scanned = ScanGamepads(vm);
+
+			Assert::AreEqual((uint16_t)0x0A55, scanned[0]);
+			Assert::AreEqual((uint16_t)0x05AA, scanned[1]);
+		}
+
+		TEST_METHOD(HoldsLatchedStateUntilTheNextScan)
+		{
+			VM vm(true);
+			Assert::IsTrue(vm.SetGamepadState(0, 0x0001));
+
+			vm.WriteData(MM_VIA1_START + VIA::DDRB, 0xC0);
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x00);
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x40);
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x00);
+			Assert::IsTrue(vm.SetGamepadState(0, 0x0002));
+
+			Assert::AreEqual(
+				(uint8_t)0,
+				(uint8_t)(vm.ReadData(MM_VIA1_START + VIA::ORB_IRB) & 0x20));
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x80);
+			vm.WriteData(MM_VIA1_START + VIA::ORB_IRB, 0x00);
+			Assert::AreEqual(
+				(uint8_t)0x20,
+				(uint8_t)(vm.ReadData(MM_VIA1_START + VIA::ORB_IRB) & 0x20));
+
+			Assert::AreEqual((uint16_t)0x0002, ScanGamepads(vm)[0]);
+		}
+
+		TEST_METHOD(ResetPreservesTheConnectedControllerState)
+		{
+			VM vm(true);
+			Assert::IsTrue(vm.SetGamepadState(0, 0x0FFF));
+
+			vm.Reset();
+
+			Assert::AreEqual((uint16_t)0x0FFF, ScanGamepads(vm)[0]);
+		}
+
+		TEST_METHOD(RejectsInvalidControllersAndUnusedButtons)
+		{
+			VM vm(true);
+
+			Assert::IsFalse(vm.SetGamepadState(2, 0x0001));
+			Assert::IsTrue(vm.SetGamepadState(0, 0xFFFF));
+			Assert::AreEqual((uint16_t)0x0FFF, ScanGamepads(vm)[0]);
+		}
+	};
+}

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -11,9 +11,9 @@
 
 Faithfully emulate the 3ric machine: a WDC 65C02 CPU, 36 KB RAM, Microsoft BASIC + a 512 KB
 ROM (monitor/DOS), Apple-II-style text/lo-res/hi-res video, keyboard, a 6551 ACIA serial
-port, a 6522 VIA (I/O + bit-banged SPI micro-SD), a slot-4 dual-AY Mockingboard, and a Disk
-II 5.25″ floppy. It is the **reference implementation of the target hardware** — the
-emulator is correct when it behaves like the real machine will.
+port, a 6522 VIA (I/O + bit-banged SPI micro-SD + two serial SNES gamepads), a slot-4
+dual-AY Mockingboard, and a Disk II 5.25″ floppy. It is the **reference implementation of
+the target hardware** — the emulator is correct when it behaves like the real machine will.
 
 ## Contracts / Interfaces
 
@@ -21,10 +21,10 @@ emulator is correct when it behaves like the real machine will.
 
 | Project | Role |
 |---------|------|
-| `Badger6502VMLib` | The VM core: `vm`, `cpu`, `Instructions`, `acia`, `via`, `mockingboard`, `ay38910`, `PS2Keyboard`, `badgervmpal` (video). Windows-only: `symbols`, `Disassemble`. |
+| `Badger6502VMLib` | The VM core: `vm`, `cpu`, `Instructions`, `acia`, `via`, `snesgamepads`, `mockingboard`, `ay38910`, `PS2Keyboard`, `badgervmpal` (video). Windows-only: `symbols`, `Disassemble`. |
 | `WozLib` | Disk II emulation: `DriveEmulator`, `WozDisk`, `WozFile` (`.woz` images). |
 | `MockMicroSD` | Bit-banged SPI SD card (`SDCard`) over a memory-mapped image (`MappedFile`). |
-| `Badger6502VMTest` | MSTest (native C++) CPU unit tests — one file per instruction family. |
+| `Badger6502VMTest` | MSTest (native C++) CPU and peripheral tests, including VIA, SNES gamepads, and Mockingboard. |
 | `Console`, `Badger6502Emulator`(+Package) | Win32 console and WinUI hosts. |
 | `WozFileTestApp`, `dsk2woz2`, `picodisk` | WOZ tooling / disk conversion / Pico target. |
 
@@ -48,6 +48,20 @@ $D000–$FFFF  ROM (monitor / OS / DOS shell); reset vector at $FFFC/$FFFD
 Soft switches are dispatched by `VM::DoSoftSwitches(address, write)`; memory-access
 callbacks (`CallbackWriteMemory`, `CallbackSetSoftSwitches`) let hosts hook I/O (the web
 bridge uses this to clock the SD card and advance the drive).
+
+**SNES gamepad contract (onboard VIA1 at `$C200`):**
+
+- VIA1 PB6 drives the shared controller latch and PB7 drives the shared clock. Controller 1
+  returns active-low serial data on PB5 and controller 2 on PB4.
+- `VM::SetGamepadState(index, pressedMask)` accepts controller indexes 0 and 1. Bits 0–11
+  are pressed-state bits in the ROM's wire order: `B`, `Y`, `SELECT`, `START`, `UP`, `DOWN`,
+  `LEFT`, `RIGHT`, `A`, `X`, `L`, `R`; bits 12–15 are unused and ignored.
+- A PB6 rising edge snapshots both live masks. Bit 0 is then visible on PB5/PB4; each PB7
+  rising edge advances to the next bit. Host changes during a scan take effect only at the
+  next latch, just like physical SNES shift registers. After bit 15 the data lines idle high.
+- A machine reset clears only the in-flight serial transaction; it does not disconnect or
+  release host-reported controllers. The peripheral is attached only to the onboard VIA1,
+  not either slot-4 Mockingboard VIA.
 
 ## Behaviour / Rules
 
@@ -90,11 +104,15 @@ bridge uses this to clock the SD card and advance the drive).
 - The onboard `$C200` VIA's enabled interrupt output retains its ROM contract as queued NMI
   edges, including control-pin and timer sources. This is separate from the two Mockingboard
   VIA IRQ outputs.
+- SNES controller data is applied through VIA1's external PB5/PB4 input pins and obeys DDRB;
+  software still performs the real `$C070` → CB2/NMI → ROM bit-bang scan.
 - AY 1 and AY 2 are separate left/right outputs. The shared core produces interleaved stereo
   PCM; host muting disables sample collection without stopping VIA or AY state progression.
 
 ## Data flow
 
+`host controller state → VM::SetGamepadState() → SNES latch/clock on VIA1 PB6/PB7 →
+active-low PB5/PB4 → ROM NMI scan → GAMEPAD1/GAMEPAD2`; otherwise
 `6502 ROM/program → VM::Step() → memory/soft-switch access → device
 (video/ACIA/VIA/Mockingboard/SD/Disk II) → framebuffer + serial + stereo PCM + register
 state → host (native window or web bridge → canvas/audio)`.
@@ -114,5 +132,6 @@ state → host (native window or web bridge → canvas/audio)`.
 | Text / lo-res / hi-res video | Shipped | `badgervmpal`; color/fringe logic shared with hosts. |
 | Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |
 | VIA1 + bit-banged SPI micro-SD | Shipped | `via` + `MockMicroSD`. |
+| Two serial SNES gamepads on VIA1 | Shipped | Shared native/WASM peripheral; latch/clock, active-low data, reset, and two-pad scans covered by MSTest. |
 | Slot-4 dual-AY Mockingboard | Shipped | Exact 3RIC `$C400/$C480`, 1.5734375 MHz, VIA IRQ, and hard-panned stereo; covered by native and WASM tests. |
 | Disk II 5.25″ floppy (WozLib) | Shipped | `$C600` boot PROM + `$C0E0–$C0EF`. |

--- a/specs/HARDWARE.md
+++ b/specs/HARDWARE.md
@@ -47,6 +47,17 @@ device/soft-switch page (keyboard, ACIA `$C1xx`, VIA1 `$C2xx`, ROM disk `$C3xx`,
 device responds; video circuit + A2COLOR GAL → composite/color output`. The emulator models
 this same routing in `VM::DoSoftSwitches` and the device handlers.
 
+### SNES gamepads
+
+`kicad/3ric/Communication_sch.kicad_sch` contains two SNES controller sockets:
+
+- VIA1 PB6 drives their shared `GC_LATCH` net and PB7 drives shared `GC_CLOCK`.
+- Controller 1's active-low serial data returns on PB5; controller 2 returns on PB4.
+- A latch pulse snapshots all buttons, then each clock pulse shifts the next bit in SNES
+  order: B, Y, Select, Start, Up, Down, Left, Right, A, X, L, R, then four unused bits.
+- The emulator mirrors these existing connections through VIA1 external input pins; browser
+  controllers change only the host-side button state and do not alter this hardware contract.
+
 ### Slot-4 Mockingboard
 
 `kicad/3ric/Mockingboard.kicad_sch` defines two 65C22-to-AY-3-8910 channels:
@@ -75,5 +86,6 @@ this same routing in `VM::DoSoftSwitches` and the device handlers.
 | 22V10 address-decode GAL | In progress | `3ricDecoder.PLD` / `EB6502 DECODER.PLD`; mirrors `MM_*`. |
 | Apple-II color GAL | In progress | `A2COLOR.PLD` + `logisim/apple2color.circ`. |
 | Address-map validation | Present | `test/memory_map_test`. |
+| Dual SNES controller interface | Shipped (schematic + emulator) | Shared PB6/PB7 latch/clock and active-low PB5/PB4 data; browser controllers exercise the same serial contract. |
 | Slot-4 dual-AY Mockingboard | Shipped | `$C400/$C480`, direct PHI2 clock, dual IRQ, hard stereo; shared emulator and browser implementation matches the schematic. |
 | PCB fabrication / bring-up | Tracked in build series | Emulator is the reference until hardware is verified. |

--- a/specs/ROM-SOFTWARE.md
+++ b/specs/ROM-SOFTWARE.md
@@ -29,10 +29,11 @@ from a micro-SD card, a Disk II floppy, or the in-browser assembler.
   under `sei`), then reads **`GAMEPAD1 $CEE0`** / `GAMEPAD2 $CEF0` — 16-byte tables, one byte
   per button (`1` = pressed): `B`=0, `Y`=1, `SELECT`=2, `START`=3, `UP`=4, `DOWN`=5,
   `LEFT`=6, `RIGHT`=7, `A`=8, `X`=9, `L`=$A, `R`=$B. `JOYSTICK_MODE $CE15` must be `0`
-  (pads — the power-on default). The emulator models no pad hardware (its VIA port reads
-  back the last written value, so a scan reports every button pressed); programs must reject
-  impossible states (e.g. `LEFT`+`RIGHT`) and verify pad input on real hardware. Addresses
-  are exported in `codegen/platform/platform-ref.*`.
+  (pads — the power-on default). The emulator models the same two active-low SNES shift
+  registers on VIA1, so host-supplied controller masks flow through the unmodified ROM scan;
+  a disconnected controller reports no buttons. Programs may still reject impossible states
+  such as `LEFT`+`RIGHT` defensively. Addresses are exported in
+  `codegen/platform/platform-ref.*`.
 - **`.PRG` programs:** assembled by the codegen toolchain (`CODEGEN.md`). Sources: tracked
   `.s` files (`codegen/programs/hello.s`, `emulator/AICodeGen/<name>/<name>.s`); assembled
   `.prg` images are git-ignored (regenerated). Run on hardware/SD via `BRUN NAME.PRG <org>`,
@@ -46,8 +47,8 @@ from a micro-SD card, a Disk II floppy, or the in-browser assembler.
     pendulum arc and Jump releases it without immediately re-catching; it also releases
     safely over the far bank.
   - **Hardware controls:** SNES D-pad moves/ducks and A/B jumps via the ROM's
-    `PTRIG`/`GAMEPAD1` contract. Impossible opposing directions reject the emulator's
-    all-buttons-pressed placeholder state, so keyboard behavior remains unchanged in WASM.
+    `PTRIG`/`GAMEPAD1` contract. The browser maps standard USB/Bluetooth controllers through
+    the emulator's SNES/VIA peripheral; impossible opposing directions remain rejected.
     End screens ignore repeated gameplay keys: Return restarts from the keyboard, while
     Start/A/B must be released before a fresh pad restart press.
   - **World:** screen descriptors define up to two ground gaps, two raised platforms, one
@@ -112,5 +113,5 @@ reloads the same descriptor at its checkpoint.
 | Disk II boot PROM | Shipped | `$C600`; boots self-booting WOZ images. |
 | 6502 program library | Ongoing | `codegen/programs/`, `emulator/AICodeGen/` (games/demos). |
 | ROCK STORM vector game | Shipped / cycle-guarded | Opening-wave live frame is 133,262 cycles against a 175,000-cycle limit; both distributed `.prg` copies are generated from `rocks.s`. |
-| SNES gamepad input | Shipped (hardware) | ROM fills `GAMEPAD1/2` on a `$C070` touch; `blocks` (BLOCK DROP) reads it — D-pad move/soft-drop, `A`/`B`/Up rotate, `SELECT` quit, `START` restart. Inert in the emulator (no pad hardware). |
+| SNES gamepad input | Shipped | ROM fills `GAMEPAD1/2` on a `$C070` touch; the shared emulator peripheral follows the same VIA serial protocol, and the browser maps two standard USB/Bluetooth controllers into it. |
 | Jungle Quest — The Sunstone Run | Shipped | Six-screen `$0800` mixed-hi-res platformer; focused suite includes a complete successful expedition. |

--- a/specs/SYSTEM.md
+++ b/specs/SYSTEM.md
@@ -12,9 +12,9 @@
 schematics, a custom PCB, and 22V10 GAL address-decode logic) plus a cycle-honest **C++
 emulator** of the same machine. The emulator also compiles to **WebAssembly**, so the exact
 same VM core boots the real 512 KB ROM in any browser — text/lo-res/hi-res video on a
-canvas, keyboard input, a Disk II 5.25″ floppy, and a bit-banged micro-SD card. A small
-Node **codegen** toolchain assembles 65C02 programs and validates them headlessly on the
-same WASM core. The "why" lives in `docs/MISSION.md`.
+canvas, keyboard and USB/Bluetooth gamepad input, a Disk II 5.25″ floppy, and a bit-banged
+micro-SD card. A small Node **codegen** toolchain assembles 65C02 programs and validates
+them headlessly on the same WASM core. The "why" lives in `docs/MISSION.md`.
 
 ## Architecture at a glance
 
@@ -25,7 +25,7 @@ same WASM core. The "why" lives in `docs/MISSION.md`.
    Emulator core — 65C02 VM in C++  (emulator/Badger6502VMLib)
      ├─ WozLib       — Disk II 5.25" floppy (.woz)        ┐ shared sources,
      ├─ MockMicroSD  — bit-banged SPI FAT32 card          ├ guarded for both
-     └─ video / keyboard / ACIA (serial) / VIA (I/O)      ┘ native + WASM
+     └─ video / keyboard / SNES pads / ACIA / VIA         ┘ native + WASM
                  │                              │
    native hosts (Windows/WinUI,        Emscripten bridge (web/web_bridge.cpp)
    Console) via Badger6502VM.sln                │
@@ -48,8 +48,8 @@ same WASM core. The "why" lives in `docs/MISSION.md`.
 
 | Layer | Spec | Covers |
 |-------|------|--------|
-| Emulator core (C++ VM) | [`EMULATOR.md`](./EMULATOR.md) | 65C02 CPU, memory map, soft switches, VIA/ACIA/keyboard/video, WozLib, MockMicroSD |
-| Web / WASM client | [`WEB-CLIENT.md`](./WEB-CLIENT.md) | Emscripten build, embind bridge API, canvas UI, in-browser assembler, Pages deploy |
+| Emulator core (C++ VM) | [`EMULATOR.md`](./EMULATOR.md) | 65C02 CPU, memory map, soft switches, VIA/ACIA/keyboard/gamepads/video, WozLib, MockMicroSD |
+| Web / WASM client | [`WEB-CLIENT.md`](./WEB-CLIENT.md) | Emscripten build, embind bridge API, canvas/gamepad UI, in-browser assembler, Pages deploy |
 | Codegen tooling | [`CODEGEN.md`](./CODEGEN.md) | `asm6502` assembler, `run6502`/`harness`, platform-ref generation, validation channels |
 | ROM & software | [`ROM-SOFTWARE.md`](./ROM-SOFTWARE.md) | 512 KB ROM (monitor/DOS/BASIC), fonts, 6502 programs, `.PRG` format |
 | Hardware | [`HARDWARE.md`](./HARDWARE.md) | KiCad schematics/PCB, 22V10 GAL address decode, logisim/diylayout models |
@@ -77,6 +77,7 @@ same WASM core. The "why" lives in `docs/MISSION.md`.
 | 65C02 CPU + memory map + soft switches | Shipped |
 | Text / lo-res / hi-res video rendering | Shipped |
 | Keyboard (`$C000`/`$C010`) + ACIA serial | Shipped |
+| Two SNES pads via VIA1 + browser Gamepad API | Shipped |
 | Disk II 5.25″ WOZ boot (self-booting machine-code disks) | Shipped |
 | Micro-SD FAT32 + ROM DOS shell | Shipped |
 | Slot-4 dual-AY Mockingboard | Shipped |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -10,14 +10,14 @@
 ## Purpose
 
 Boot the real 512 KB ROM in any browser: render Apple-II text/lo-res/hi-res video to a
-`<canvas>`, feed keystrokes through the memory-mapped keyboard, run Disk II and micro-SD
-images, and assemble/run 65C02 source client-side — all 100% client-side so GitHub Pages can
-host it as static files.
+`<canvas>`, feed keyboard and standard Gamepad API input through the machine's real input
+paths, run Disk II and micro-SD images, and assemble/run 65C02 source client-side — all 100%
+client-side so GitHub Pages can host it as static files.
 
 ## Contracts / Interfaces
 
 - **Build:** `web/build.ps1` compiles `Badger6502VMLib` (vm, cpu, Instructions, acia, via,
-  mockingboard, ay38910, PS2Keyboard, badgervmpal) + `WozLib` (DriveEmulator, WozDisk,
+  snesgamepads, mockingboard, ay38910, PS2Keyboard, badgervmpal) + `WozLib` (DriveEmulator, WozDisk,
   WozFile) + `MockMicroSD` (SDCard, MappedFile) + `web/web_bridge.cpp` with
   `-DPLATFORM_WEB`. Excludes `symbols.cpp` and `Disassemble.cpp`. Key flags:
   `-std=c++17 -O2 -lembind -sMODULARIZE=1
@@ -26,11 +26,12 @@ host it as static files.
 - **Bridge API (embind, `web_bridge.cpp`):** `loadData(addr, bytes)`, `seedBasicRom()`,
   `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
   `runCycles(cycleBudget)`, `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial),
+  `setGamepadState(index, pressedMask)`,
   `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM),
   `renderFrame()` (RGBA framebuffer), `pc/sp/regA/regX/regY/status`, `sdReadCount()`.
 - **Compat shims (`web_compat.h`):** map MSVC-isms (`OutputDebugString`, `sprintf_s`,
   `fopen_s`, `_ASSERT`, …) onto Emscripten so `WozLib`/`MockMicroSD` compile unchanged.
-- **UI (`index.html`):** `requestAnimationFrame` driver, keyboard, disk/SD/clock/sound
+- **UI (`index.html`):** `requestAnimationFrame` driver, keyboard/gamepad, disk/SD/clock/sound
   controls, and the in-browser **Assembler** panel (imports `assemble()` from the staged
   `asm6502.mjs`). Honors optional `window.ASSET_BASE` / `?assets=` for CDN/R2 offload and
   `?src=` / `?prg=` / `?code=` deep links, plus a **Share** button that builds a one-click
@@ -39,6 +40,14 @@ host it as static files.
   against Pages instead of serving a stale `max-age=600` copy — a freshly deployed program
   shows up on the next selection without a hard refresh. (There is no service worker, and
   GitHub Pages purges its CDN on every deploy, so the revalidation returns the new source.)
+- **Browser gamepads (`gamepad.js` + `index.html`):** the frame driver polls the standard
+  Gamepad API before running the CPU, keeps the first two connected devices in stable player
+  slots, maps each to the 12-button SNES mask, and calls `setGamepadState()` for both slots.
+  Standard-layout face buttons 0/1/2/3 map to SNES B/A/Y/X; 8/9 to Select/Start; 4 or 6 to
+  L; 5 or 7 to R; D-pad buttons 12–15 and left-stick axes 0/1 (0.5 deadzone) map directions.
+  USB and Bluetooth pairing is handled by the operating system — the page does not use Web
+  Bluetooth. Browsers may hide a connected pad until the user presses one of its buttons;
+  the header reports API availability and the currently assigned players.
 - **Assembler downloads (`index.html` + staged `wozgen.mjs`):** the Assembler panel offers
   **Download .PRG** (the raw assembled bytes) and **Download .woz** — a bootable 5.25″ WOZ2
   disk image of the current program, generated fully client-side by `wozgen.mjs` (a
@@ -105,6 +114,10 @@ host it as static files.
   playback, renders without per-sample allocation, and discards only the oldest queued frames
   if a stalled producer exceeds the latency bound. Sound is generated only at 1x speed;
   changing speed mutes and flushes PCM while the emulated VIA/AY state continues to advance.
+- Gamepad state is sampled once per rendered frame, independently of CPU speed. Disconnecting
+  a pad releases every button immediately; reconnecting fills the first free player slot.
+  The shared VM, not JavaScript, performs the SNES latch/clock protocol and active-low VIA
+  input behavior.
 - **Parity is the rule:** the WASM build must behave like the native build. Do not add
   behavior in the bridge that isn't in the shared core unless it's a genuinely
   presentation-only concern (canvas, clock pacing) — and never behind an unguarded fork.
@@ -143,7 +156,8 @@ host it as static files.
 ## Data flow
 
 `build.ps1 → badger6502.js/.wasm + data/ → index.html loads WASM → boot recipe (loadData /
-seedBasicRom / loadFont / reset) → elapsed-time budget→runCycles() per frame →
+seedBasicRom / loadFont / reset) → Gamepad API→gamepad.js mapping→setGamepadState()→shared
+SNES/VIA peripheral; elapsed-time budget→runCycles() per frame →
 renderFrame()→canvas, drainOutput()→log, drainAudio()→AudioWorklet→speakers; keyDown()→$C000;
 Boot Disk/Mount SD →
 insertDisk()/loadSD() → C600G / EC5CG`.
@@ -159,9 +173,9 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
   generator, a JS port of `emulator/dsk2woz2`). The `.woz` boot loader depends on the `$C600`
   P5 boot PROM contract (`ROM-SOFTWARE.md`) and the Disk II phase-stepping model (`EMULATOR.md`).
 - **Downstream:** GitHub Pages deploy (`.github/workflows/deploy-pages.yml`) — its **Stage
-  site** step stages `gallery.html` + `gallery.json` + `story.html` + `llms.txt` + `robots.txt` +
-  `sitemap.xml` (alongside `index.html` and `programs/`) into `_site/`; the public users of
-  the demo, and AI coding tools that fetch `llms.txt`.
+  site** step stages `gamepad.js` + `gallery.html` + `gallery.json` + `story.html` + `llms.txt`
+  + `robots.txt` + `sitemap.xml` (alongside `index.html` and `programs/`) into `_site/`; the
+  public users of the demo, and AI coding tools that fetch `llms.txt`.
 
 ## Implementation Status
 
@@ -169,6 +183,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 |------|--------|-------|
 | WASM build of the VM core + WozLib + SD | Shipped | `web/build.ps1`, Emscripten 6.0.1. |
 | Canvas video + keyboard | Shipped | text/lo-res/hi-res, `$C000` input. |
+| USB/Bluetooth gamepads | Shipped | Two stable player slots through the standard Gamepad API and shared SNES/VIA peripheral; covered by browser-mapping, serial-protocol, and ROM-table tests. |
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
 | In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. Sample sources fetched with `cache:"no-cache"` (revalidate) so a new deploy isn't masked by the browser cache. |
 | Program downloads (.PRG / .woz) | Shipped | **Download .PRG** (raw bytes) + **Download .woz** (bootable WOZ2 via `wozgen.mjs`, a port of `dsk2woz2`, with a multi-track boot loader); verified by `web/test_woz_download.cjs`. |
@@ -180,5 +195,5 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |
 | Adjustable CPU clock | Shipped | frontend-only pacing; native **1× ≈ 1.57 MHz** (25.175 MHz VGA dot clock ÷ 16) default. |
 | Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the shared dual-AY stereo PCM; sound enabled only at 1x. |
-| Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/keyboard/screen/sd/disk). |
+| Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/input/audio/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -5,7 +5,7 @@
 > no status. Move historical detail to `status/CHANGELOG.md` and deep runbooks to
 > `docs/runbooks/`.
 
-_Last updated: 2026-07-13 — ebadger (via Copilot)_
+_Last updated: 2026-07-14 — ebadger (via Copilot)_
 
 ---
 
@@ -46,6 +46,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web/test_audio_pacing.cjs        # real WASM PCM rate at 60/144 Hz displays
 & $node web/test_audio_worklet.cjs       # prebuffer + bounded PCM queue
 & $node web/test_mockingboard.cjs        # slot-4 mirrors, stereo PCM, 3RIC clock, VIA IRQ
+& $node web/test_gamepad.cjs             # browser mapping, VIA serial pads, ROM tables
 & $node web/test_sd.cjs                  # mount SD + DIR lists the FAT32 root
 & $node web/test_disk.cjs                # boot a WOZ floppy via C600G into a hi-res title
 & $node web/test_woz_download.cjs        # "Download .woz" builds a bootable disk that boots via C600G
@@ -76,8 +77,9 @@ secrets. Nothing to configure and nothing to commit. (The only "secret" is the s
 ## Current state / known gaps
 
 - **Emulator:** boots the unmodified 512 KB ROM to the monitor; text/lo-res/hi-res color
-  video; keyboard; ACIA serial; Disk II WOZ boot; micro-SD FAT32 DOS shell; slot-4
-  dual-AY Mockingboard at the hardware's 1.5734375 MHz clock; adjustable CPU clock.
+  video; keyboard; two serial SNES pads; ACIA serial; Disk II WOZ boot; micro-SD FAT32 DOS
+  shell; slot-4 dual-AY Mockingboard at the hardware's 1.5734375 MHz clock; adjustable CPU
+  clock. The browser maps standard USB/Bluetooth controllers through the SNES/VIA path.
   Shared VM core runs identically on Windows and in the browser.
 - **In-browser assembler:** assembles 65C02 source client-side with the project's own
   `asm6502.mjs` and runs it like `BRUN`; ships ~11 sample programs; deep-linkable via `?src=`.

--- a/web/README.md
+++ b/web/README.md
@@ -4,12 +4,11 @@ This folder is a self-contained Emscripten/WebAssembly port of the `3ric` 65C02
 Apple-II-clone emulator. It compiles the existing C++ VM core
 (`emulator/Badger6502VMLib`) and disk library (`emulator/WozLib`) to WebAssembly,
 boots the real 512KB ROM, renders Apple-II text/hi-res/lo-res video to an HTML
-`<canvas>`, feeds keystrokes through the memory-mapped keyboard at `$C000`, and
-plays the slot-4 dual-AY Mockingboard through Web Audio.
+`<canvas>`, feeds keyboard and gamepad input through the machine's hardware paths,
+and plays the slot-4 dual-AY Mockingboard through Web Audio.
 
-Everything here is additive. The shared VM/WozLib sources gained only
-`__EMSCRIPTEN__` / `PLATFORM_WEB`-guarded branches, so the Windows (WinUI) and
-Pico builds compile and behave exactly as before.
+The VM peripherals remain in the shared C++ core so native and WASM builds behave
+identically. Browser-only presentation code stays in the bridge and JavaScript.
 
 ## What works
 
@@ -18,6 +17,9 @@ Pico builds compile and behave exactly as before.
   the WinUI host renderer (`MainWindow.xaml.cpp`) into the bridge so the color /
   fringe logic is identical.
 - Keyboard input via the Apple-II `$C000` / `$C010` strobe mechanism.
+- **Two gamepads** through the standard browser Gamepad API. USB and Bluetooth
+  devices use the same path after OS pairing; the shared VM serializes them as real
+  SNES pads through VIA1 and the unmodified ROM fills `GAMEPAD1/2`.
 - **Micro-SD card** (bit-banged SPI through VIA1) backing a FAT32 disk image. A
   **Mount SD** button drops into the ROM's DOS shell (`>` prompt) and lists the
   card; from there `DIR`, `CAT`, `CD <dir>`, `BLOAD`/`BRUN <file>` all work.
@@ -43,7 +45,8 @@ Pico builds compile and behave exactly as before.
 
 | File | Purpose |
 | --- | --- |
-| `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/registers/audio, drives the SD card, and produces the RGBA framebuffer. |
+| `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/gamepad/registers/audio, drives the SD card, and produces the RGBA framebuffer. |
+| `gamepad.js` | Dependency-free standard-layout browser controller mapping and stable two-player assignment. |
 | `emulation-clock.js` | Elapsed-time cycle pacer that keeps finite CPU speeds independent of display refresh rate and carries instruction overshoot between frames. |
 | `audio-worklet.js` | Stereo PCM queue on the browser audio-rendering thread; no `SharedArrayBuffer` or cross-origin isolation required. |
 | `web_compat.h` | Tiny shims so `WozLib` + `MockMicroSD`'s MSVC-isms (`OutputDebugString`, `sprintf_s`, `swprintf_s`, `fopen_s`, `_ASSERT`, …) compile under Emscripten. |
@@ -53,7 +56,7 @@ Pico builds compile and behave exactly as before.
 | `asm6502.mjs` | The 65C02 assembler, staged from `codegen/tools/asm6502.mjs` (git-ignored). Dual-use: the same file is a Node CLI and a browser ES module — `index.html` imports its `assemble()` for **Assemble & Run**. |
 | `serve.ps1` | Starts `python -m http.server` (defaults to port 8011) for local dev. |
 | `Caddyfile` | Production static server config (compression + cache headers) for hosting behind a Cloudflare Tunnel. |
-| `test_*.cjs` | Headless Node validations (boot, render, keyboard, screen decode, SD, disk). |
+| `test_*.cjs` | Headless Node validations (boot, render, input, audio, screen decode, SD, disk). |
 
 Build outputs (`badger6502.js`, `badger6502.wasm`), the staged `data/` copies,
 and the editor's staged `asm6502.mjs` + `programs/*.s` sample sources are
@@ -79,7 +82,7 @@ cd web
 This compiles these sources with `-DPLATFORM_WEB`:
 
 ```
-Badger6502VMLib: vm cpu Instructions acia via ay38910 mockingboard PS2Keyboard badgervmpal
+Badger6502VMLib: vm cpu Instructions acia via snesgamepads ay38910 mockingboard PS2Keyboard badgervmpal
 WozLib:          DriveEmulator WozDisk WozFile
 MockMicroSD:     SDCard MappedFile
 bridge:          web_bridge.cpp
@@ -111,6 +114,18 @@ Press **Enable Sound** to start stereo Mockingboard playback. Browser autoplay
 rules require this click; sound is intentionally generated only at native 1×.
 
 > Port 8011 is used because 8000 is taken on this machine.
+
+## Browser gamepads
+
+Pair a Bluetooth controller in the operating system, or connect one over USB, then
+press a controller button after opening the page. The browser may not expose a pad
+until that first input. The header assigns the first two connected devices to stable
+**P1** and **P2** slots and releases every button immediately on disconnect.
+
+Standard-layout face buttons map to SNES B/A/Y/X, Select/Start map to the center
+buttons, either bumper or trigger maps to L/R, and the D-pad or left stick controls
+directions (0.5 deadzone). Games read the normal ROM `PTRIG` and `GAMEPAD1/2`
+interface; JavaScript does not bypass the VIA or ROM scan.
 
 ## In-browser assembler (Assemble & Run)
 
@@ -195,6 +210,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web\test_audio_pacing.cjs # real WASM PCM rate at 60/144 Hz displays
 & $node web\test_audio_worklet.cjs # prebuffer + bounded PCM queue
 & $node web\test_mockingboard.cjs # mirrors, stereo PCM, 3RIC clock, timer IRQ
+& $node web\test_gamepad.cjs    # mapping, VIA serialization, ROM GAMEPAD1/2 scan
 & $node web\test_sd.cjs          # mount the SD card + DIR lists the FAT32 root
 & $node web\test_disk.cjs        # boot a WOZ floppy via C600G into a hi-res title
 ```

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -42,6 +42,7 @@ $sources = @(
     (Join-Path $lib "via.cpp"),
     (Join-Path $lib "ay38910.cpp"),
     (Join-Path $lib "mockingboard.cpp"),
+    (Join-Path $lib "snesgamepads.cpp"),
     (Join-Path $lib "PS2Keyboard.cpp"),
     (Join-Path $lib "badgervmpal.cpp"),
     # WozLib (DriveEmulator is embedded in VM; WozDisk/WozFile are needed to link).

--- a/web/gamepad.js
+++ b/web/gamepad.js
@@ -1,0 +1,91 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else root.BadgerGamepads = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  const AXIS_DEADZONE = 0.5;
+  const SNES = Object.freeze({
+    B: 1 << 0,
+    Y: 1 << 1,
+    SELECT: 1 << 2,
+    START: 1 << 3,
+    UP: 1 << 4,
+    DOWN: 1 << 5,
+    LEFT: 1 << 6,
+    RIGHT: 1 << 7,
+    A: 1 << 8,
+    X: 1 << 9,
+    L: 1 << 10,
+    R: 1 << 11,
+  });
+
+  function buttonPressed(gamepad, index) {
+    const button = gamepad.buttons && gamepad.buttons[index];
+    return !!button && (button.pressed || button.value >= 0.5);
+  }
+
+  function axisValue(gamepad, index) {
+    if (!gamepad.axes || index >= gamepad.axes.length) return 0;
+    const value = Number(gamepad.axes[index]);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function mapGamepad(gamepad) {
+    if (!gamepad || gamepad.connected === false) return 0;
+
+    let state = 0;
+    if (buttonPressed(gamepad, 0)) state |= SNES.B;
+    if (buttonPressed(gamepad, 1)) state |= SNES.A;
+    if (buttonPressed(gamepad, 2)) state |= SNES.Y;
+    if (buttonPressed(gamepad, 3)) state |= SNES.X;
+    if (buttonPressed(gamepad, 8)) state |= SNES.SELECT;
+    if (buttonPressed(gamepad, 9)) state |= SNES.START;
+    if (buttonPressed(gamepad, 4) || buttonPressed(gamepad, 6)) state |= SNES.L;
+    if (buttonPressed(gamepad, 5) || buttonPressed(gamepad, 7)) state |= SNES.R;
+
+    const horizontal = axisValue(gamepad, 0);
+    const vertical = axisValue(gamepad, 1);
+    if (buttonPressed(gamepad, 12) || vertical <= -AXIS_DEADZONE) state |= SNES.UP;
+    if (buttonPressed(gamepad, 13) || vertical >= AXIS_DEADZONE) state |= SNES.DOWN;
+    if (buttonPressed(gamepad, 14) || horizontal <= -AXIS_DEADZONE) state |= SNES.LEFT;
+    if (buttonPressed(gamepad, 15) || horizontal >= AXIS_DEADZONE) state |= SNES.RIGHT;
+
+    return state;
+  }
+
+  class GamepadManager {
+    constructor() {
+      this._slots = [null, null];
+    }
+
+    poll(gamepads) {
+      const connected = new Map();
+      for (let i = 0; gamepads && i < gamepads.length; i++) {
+        const gamepad = gamepads[i];
+        if (gamepad && gamepad.connected !== false) connected.set(gamepad.index, gamepad);
+      }
+
+      for (let slot = 0; slot < this._slots.length; slot++) {
+        if (!connected.has(this._slots[slot])) this._slots[slot] = null;
+      }
+
+      for (const gamepad of connected.values()) {
+        if (this._slots.includes(gamepad.index)) continue;
+        const free = this._slots.indexOf(null);
+        if (free < 0) break;
+        this._slots[free] = gamepad.index;
+      }
+
+      return this._slots.map((index) => {
+        const gamepad = connected.get(index);
+        return gamepad
+          ? { index, id: gamepad.id || `Gamepad ${index}`, mask: mapGamepad(gamepad) }
+          : null;
+      });
+    }
+  }
+
+  return { AXIS_DEADZONE, SNES, GamepadManager, mapGamepad };
+});

--- a/web/index.html
+++ b/web/index.html
@@ -116,6 +116,7 @@
       title="Enable the slot-4 dual-AY Mockingboard at native 1x speed">Enable Sound</button>
     <span class="regs" id="regs">PC:---- A:-- X:-- Y:-- SP:-- P:--</span>
     <span class="regs" id="mode">mode:---</span>
+    <span class="hint" id="gamepads">gamepads: detecting&hellip;</span>
     <span class="hint" id="status">loading wasm&hellip;</span>
   </header>
   <main>
@@ -171,8 +172,9 @@
   <footer>
     65C02 emulator core (C++) + WozLib compiled to WebAssembly via Emscripten. Boots the real 512KB ROM,
     renders Apple-II text/hi-res to the canvas, feeds keystrokes through the memory-mapped keyboard ($C000),
-    and emulates the 3RIC slot-4 dual-AY Mockingboard in stereo.
-    Click the screen and type. &ldquo;Boot Disk&rdquo; boots the bundled 5.25&Prime; floppy (or pick a .woz with
+    maps up to two USB/Bluetooth gamepads through the real SNES/VIA interface, and emulates the 3RIC
+    slot-4 dual-AY Mockingboard in stereo.
+    Click the screen and type, or pair a controller and press a button. &ldquo;Boot Disk&rdquo; boots the bundled 5.25&Prime; floppy (or pick a .woz with
     &ldquo;Insert&rdquo;) through the Disk&nbsp;II ROM at $C600. &ldquo;Mount SD&rdquo; enters the DOS shell
     (prompt &ldquo;&gt;&rdquo;) and lists the micro-SD card &mdash; load games and programs from there.
     &ldquo;Load .PRG&rdquo; loads a raw program image at the given hex address and runs it, exactly like
@@ -198,6 +200,7 @@
   </footer>
 
   <script src="emulation-clock.js"></script>
+  <script src="gamepad.js"></script>
   <script src="badger6502.js"></script>
   <script>
     // The 3ric clocks its 65C02 from the 25.175 MHz VGA dot clock divided by 16,
@@ -216,7 +219,10 @@
     const regsEl  = document.getElementById("regs");
     const modeEl  = document.getElementById("mode");
     const statusEl = document.getElementById("status");
+    const gamepadsEl = document.getElementById("gamepads");
     const soundButton = document.getElementById("sound");
+    const gamepadManager = new BadgerGamepads.GamepadManager();
+    let gamepadAccessBlocked = false;
 
     let vm = null;
     let imageData = null;
@@ -319,6 +325,49 @@
         `mode:${m} pg${vm.gfxPage()+1}${vm.mixed() ? " MIX" : ""} font:${vm.font()}`;
     }
 
+    function pollGamepads() {
+      if (typeof navigator.getGamepads !== "function" || gamepadAccessBlocked) {
+        gamepadsEl.textContent = "gamepads: unavailable";
+        gamepadsEl.title = gamepadAccessBlocked
+          ? "Gamepad access is blocked by this page's browser permissions"
+          : "This browser does not expose the standard Gamepad API";
+        vm.setGamepadState(0, 0);
+        vm.setGamepadState(1, 0);
+        return;
+      }
+
+      let browserGamepads;
+      try {
+        browserGamepads = navigator.getGamepads();
+      } catch (error) {
+        if (!error || error.name !== "SecurityError") throw error;
+        gamepadAccessBlocked = true;
+        gamepadsEl.textContent = "gamepads: unavailable";
+        gamepadsEl.title = "Gamepad access is blocked by this page's browser permissions";
+        vm.setGamepadState(0, 0);
+        vm.setGamepadState(1, 0);
+        return;
+      }
+
+      const slots = gamepadManager.poll(browserGamepads);
+      for (let player = 0; player < slots.length; player++) {
+        vm.setGamepadState(player, slots[player] ? slots[player].mask : 0);
+      }
+
+      const assigned = [];
+      for (let player = 0; player < slots.length; player++) {
+        if (slots[player]) assigned.push(`P${player + 1}`);
+      }
+      gamepadsEl.textContent = assigned.length
+        ? `gamepads: ${assigned.join(" ")}`
+        : "gamepads: press a controller button";
+      gamepadsEl.title = slots
+        .map((slot, player) => slot ? `P${player + 1}: ${slot.id}` : null)
+        .filter(Boolean)
+        .join("\n") ||
+        "Pair a USB/Bluetooth controller with this device, then press one of its buttons";
+    }
+
     function clearAudioQueue() {
       if (audioNode) audioNode.port.postMessage({ type: "clear" });
     }
@@ -412,6 +461,8 @@
     }
 
     function frame(timestamp) {
+      pollGamepads();
+
       // Feed one queued key when the keyboard strobe is clear (bit 7 of $C000).
       if (inputQueue.length && (vm.peek(0xC000) & 0x80) === 0) {
         vm.keyDown(inputQueue.shift());

--- a/web/test_gamepad.cjs
+++ b/web/test_gamepad.cjs
@@ -1,0 +1,115 @@
+// Browser mapping + shared VIA/SNES protocol + ROM gamepad-table integration.
+//
+// Run with:
+//   C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe web\test_gamepad.cjs
+
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+const { GamepadManager, SNES, mapGamepad } = require("./gamepad.js");
+
+const DATA = path.join(__dirname, "data");
+const rom = fs.readFileSync(path.join(DATA, "badger6502.bin"));
+
+function makeGamepad(index, pressed = [], axes = [0, 0], id = `Pad ${index}`) {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0 }));
+  for (const button of pressed) buttons[button] = { pressed: true, value: 1 };
+  return { axes, buttons, connected: true, id, index, mapping: "standard" };
+}
+
+function scanVIA(vm) {
+  const result = [0, 0];
+  vm.writeBus(0xc202, 0xc0); // PB6/PB7 are latch/clock outputs
+  vm.writeBus(0xc200, 0x00);
+  vm.writeBus(0xc200, 0x40); // latch both controllers
+
+  for (let bit = 0; bit < 16; bit++) {
+    vm.writeBus(0xc200, 0x00);
+    const port = vm.readBus(0xc200);
+    if ((port & 0x20) === 0) result[0] |= 1 << bit;
+    if ((port & 0x10) === 0) result[1] |= 1 << bit;
+    vm.writeBus(0xc200, 0x80);
+  }
+  return result;
+}
+
+function tableMatches(vm, base, mask) {
+  for (let bit = 0; bit < 16; bit++) {
+    const expected = (mask & (1 << bit)) !== 0 ? 1 : 0;
+    if (vm.peek(base + bit) !== expected) return false;
+  }
+  return true;
+}
+
+async function main() {
+  const allButtons = mapGamepad(
+    makeGamepad(0, [0, 1, 2, 3, 4, 5, 8, 9, 12, 13, 14, 15]));
+  const standardMapping = allButtons === 0x0fff;
+  const analogMapping =
+    mapGamepad(makeGamepad(0, [6, 7], [-0.75, 0.75])) ===
+    (SNES.L | SNES.R | SNES.LEFT | SNES.DOWN);
+  const deadzone =
+    mapGamepad(makeGamepad(0, [], [0.49, -0.49])) === 0;
+
+  const manager = new GamepadManager();
+  const first = manager.poll([makeGamepad(3), makeGamepad(7)]);
+  const disconnected = manager.poll([makeGamepad(7)]);
+  const reconnected = manager.poll([makeGamepad(9), makeGamepad(7)]);
+  const stableSlots =
+    first[0].index === 3 && first[1].index === 7 &&
+    disconnected[0] === null && disconnected[1].index === 7 &&
+    reconnected[0].index === 9 && reconnected[1].index === 7;
+
+  const Module = await createBadgerVM();
+  const vm = new Module.WebVM();
+  const pad1 = SNES.B | SNES.LEFT | SNES.A | SNES.L;
+  const pad2 = SNES.Y | SNES.START | SNES.RIGHT | SNES.R;
+
+  const acceptsControllers =
+    vm.setGamepadState(0, pad1) &&
+    vm.setGamepadState(1, pad2) &&
+    !vm.setGamepadState(2, 1);
+  const serial = scanVIA(vm);
+  const viaProtocol = serial[0] === pad1 && serial[1] === pad2;
+
+  vm.loadData(0, new Uint8Array(rom.subarray(0, 0x10000)));
+  vm.seedBasicRom();
+  vm.reset();
+  for (let i = 0; i < 20; i++) vm.run(50000);
+
+  vm.setGamepadState(0, pad1);
+  vm.setGamepadState(1, pad2);
+  vm.poke(0xce15, 0); // JOYSTICK_MODE = SNES pads
+  for (let i = 0; i < 16; i++) {
+    vm.poke(0xcee0 + i, 0xff);
+    vm.poke(0xcef0 + i, 0xff);
+  }
+  vm.readBus(0xc070); // PTRIG -> VIA1 CB2 -> NMI -> ROM scan
+  vm.run(5000);
+  const romScan =
+    tableMatches(vm, 0xcee0, pad1) &&
+    tableMatches(vm, 0xcef0, pad2);
+
+  console.log("--- browser gamepad test ---");
+  console.log("standard button mapping :", standardMapping);
+  console.log("analog/trigger mapping  :", analogMapping);
+  console.log("analog deadzone         :", deadzone);
+  console.log("stable player slots     :", stableSlots);
+  console.log("bridge validation       :", acceptsControllers);
+  console.log("VIA serial protocol     :", viaProtocol);
+  console.log("ROM GAMEPAD1/2 scan     :", romScan);
+
+  vm.delete();
+
+  if (!standardMapping || !analogMapping || !deadzone || !stableSlots ||
+      !acceptsControllers || !viaProtocol || !romScan) {
+    console.error("\nFAIL");
+    process.exit(1);
+  }
+  console.log("\nPASS");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -298,6 +298,19 @@ public:
         _vm->WriteData(0xC000, (uint8_t)(0x80 | toupper(ascii & 0x7F)));
     }
 
+    // --- SNES gamepads ------------------------------------------------------
+
+    bool setGamepadState(int controller, int pressedButtons)
+    {
+        if (controller < 0 || controller >= (int)SNESGamepads::CONTROLLER_COUNT
+            || pressedButtons < 0 || pressedButtons > 0xFFFF)
+        {
+            return false;
+        }
+        return _vm->SetGamepadState(
+            (uint8_t)controller, (uint16_t)pressedButtons);
+    }
+
     // --- direct memory access ---------------------------------------------
 
     void poke(int addr, int value) { _vm->GetData()[addr & 0xFFFF] = (uint8_t)(value & 0xFF); }
@@ -571,6 +584,7 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("disableAudio", &WebVM::disableAudio)
         .function("drainAudio",   &WebVM::drainAudio)
         .function("keyDown",      &WebVM::keyDown)
+        .function("setGamepadState", &WebVM::setGamepadState)
         .function("poke",         &WebVM::poke)
         .function("peek",         &WebVM::peek)
         .function("readBus",      &WebVM::readBus)


### PR DESCRIPTION
## Summary
- model two SNES controllers in the shared C++ VM through onboard VIA1 latch, clock, and active-low data pins
- map two standard USB/Bluetooth browser controllers into stable player slots without bypassing the ROM scan path
- add native protocol tests, browser/WASM/ROM integration coverage, Pages deployment wiring, and cross-layer documentation

## Validation
- 197 native MSTests
- WASM build plus all green `web/test_*.cjs` tests, including mapping, VIA serialization, ROM `GAMEPAD1/2`, Mockingboard, SD, Disk II, audio, and boot coverage
- assembler encoding, BLOCK DROP, and STAR SWARM suites

`web/test_woz_download.cjs` case 3 remains red identically on `origin/main`; this pre-existing sample-attract assertion is unrelated to the gamepad change.