### PR TITLE
Add $C030 system speaker audio

### DIFF
--- a/codegen/SPEC.md
+++ b/codegen/SPEC.md
@@ -53,12 +53,13 @@ $2000-$5FFF  hi-res video (page 1 $2000, page 2 $4000)
 $9000-$BFFF  BASIC ROM (generic Microsoft BASIC, not Applesoft)
 $C000        keyboard data (bit7 = strobe)
 $C010        keyboard strobe clear
+$C030        system speaker toggle (any read or write access)
 $C050-$C057  display soft switches (gfx/text, page, mixed, lo/hi-res)
 $C0E0-$C0EF  Disk II
 $C100-$C10F  ACIA (6551) serial  <-- writing the data reg emits a byte to drainOutput()
 $C200-$C20F  VIA1 (bit-banged SPI micro-SD lives here)
 $C300-$C30F  ROM disk / char-gen control
-$C400        audio
+$C400-$C4FF  slot-4 dual-AY Mockingboard audio
 $C600-$C6FF  Disk II boot PROM
 $C800-$CFFF  RAM2
 $D000-$FFFF  ROM / monitor / OS / DOS shell

--- a/codegen/platform/platform-ref.json
+++ b/codegen/platform/platform-ref.json
@@ -17,6 +17,7 @@
     "MM_SS_BASIC_ROM_ON": 49158,
     "MM_SS_BASIC_ROM_OFF": 49159,
     "MM_SS_KEYBD_STROBE": 49168,
+    "MM_SS_SPEAKER": 49200,
     "MM_SS_GRAPHICS": 49232,
     "MM_SS_TEXT": 49233,
     "MM_SS_FULLSCREEN": 49234,
@@ -122,6 +123,11 @@
       "name": "KEYBD_STROBE",
       "addr": 49168,
       "desc": "Clear the keyboard strobe"
+    },
+    {
+      "name": "SPEAKER",
+      "addr": 49200,
+      "desc": "Toggle the system speaker (any read or write access)"
     },
     {
       "name": "GRAPHICS",

--- a/codegen/platform/platform-ref.md
+++ b/codegen/platform/platform-ref.md
@@ -22,6 +22,7 @@ Text/lo-res video page 1 is $0400-$07FF (page 2 $0800-$0BFF); hi-res page 1 $200
 | --- | --- | --- |
 | $C000 | KEYBOARD | Keyboard data (bit7 = key-ready strobe) |
 | $C010 | KEYBD_STROBE | Clear the keyboard strobe |
+| $C030 | SPEAKER | Toggle the system speaker (any read or write access) |
 | $C050 | GRAPHICS | Switch to graphics |
 | $C051 | TEXT | Switch to text |
 | $C052 | FULLSCREEN | Full-screen (clear mixed) |

--- a/codegen/tools/gen_platform_ref.mjs
+++ b/codegen/tools/gen_platform_ref.mjs
@@ -110,6 +110,7 @@ const REGION_KEYS = [
 const SOFTSWITCH_KEYS = [
   ["MM_SS_KEYBOARD", "Keyboard data (bit7 = key-ready strobe)"],
   ["MM_SS_KEYBD_STROBE", "Clear the keyboard strobe"],
+  ["MM_SS_SPEAKER", "Toggle the system speaker (any read or write access)"],
   ["MM_SS_GRAPHICS", "Switch to graphics"],
   ["MM_SS_TEXT", "Switch to text"],
   ["MM_SS_FULLSCREEN", "Full-screen (clear mixed)"],

--- a/emulator/Badger6502VMLib/mockingboard.cpp
+++ b/emulator/Badger6502VMLib/mockingboard.cpp
@@ -16,8 +16,6 @@ void Mockingboard::Reset()
 		_resetAsserted[channel] = false;
 		_ayBusMode[channel] = 0;
 	}
-	_sampleAccumulator = 0;
-	_audio.clear();
 }
 
 size_t Mockingboard::ChannelForAddress(uint16_t address) const
@@ -96,23 +94,6 @@ void Mockingboard::Tick()
 			_ay[channel].Tick();
 		}
 	}
-
-	if (!_audioEnabled)
-	{
-		return;
-	}
-
-	_sampleAccumulator += (uint64_t)_sampleRate * PHI2_DIVISOR;
-	if (_sampleAccumulator >= VGA_DOT_CLOCK_HZ)
-	{
-		_sampleAccumulator -= VGA_DOT_CLOCK_HZ;
-		const size_t maximumSamples = (size_t)_sampleRate * 2;
-		if (_audio.size() + 2 <= maximumSamples)
-		{
-			_audio.push_back(_ay[0].Sample());
-			_audio.push_back(_ay[1].Sample());
-		}
-	}
 }
 
 bool Mockingboard::IRQAsserted() const
@@ -120,37 +101,9 @@ bool Mockingboard::IRQAsserted() const
 	return _via[0].IRQAsserted() || _via[1].IRQAsserted();
 }
 
-bool Mockingboard::EnableAudio(uint32_t sampleRate)
+float Mockingboard::Sample(size_t channel)
 {
-	if (sampleRate < 8000 || sampleRate > 192000)
-	{
-		return false;
-	}
-
-	_audioEnabled = true;
-	_sampleRate = sampleRate;
-	_sampleAccumulator = 0;
-	_audio.clear();
-	_audio.reserve((size_t)sampleRate / 5);
-	return true;
-}
-
-void Mockingboard::DisableAudio()
-{
-	_audioEnabled = false;
-	_sampleAccumulator = 0;
-	_audio.clear();
-}
-
-std::vector<float> Mockingboard::DrainAudio()
-{
-	std::vector<float> result;
-	result.swap(_audio);
-	if (_audioEnabled)
-	{
-		_audio.reserve((size_t)_sampleRate / 5);
-	}
-	return result;
+	return channel < CHANNEL_COUNT ? _ay[channel].Sample() : 0.0f;
 }
 
 VIA* Mockingboard::GetVIA(size_t channel)

--- a/emulator/Badger6502VMLib/mockingboard.h
+++ b/emulator/Badger6502VMLib/mockingboard.h
@@ -5,14 +5,10 @@
 
 #include <array>
 #include <cstdint>
-#include <vector>
 
 class Mockingboard
 {
 public:
-	static constexpr uint32_t VGA_DOT_CLOCK_HZ = 25175000;
-	static constexpr uint32_t PHI2_DIVISOR = 16;
-
 	Mockingboard();
 
 	void Reset();
@@ -20,10 +16,7 @@ public:
 	void Write(uint16_t address, uint8_t data);
 	void Tick();
 	bool IRQAsserted() const;
-
-	bool EnableAudio(uint32_t sampleRate);
-	void DisableAudio();
-	std::vector<float> DrainAudio();
+	float Sample(size_t channel);
 
 	VIA* GetVIA(size_t channel);
 	const AY38910* GetAY(size_t channel) const;
@@ -39,9 +32,4 @@ private:
 	std::array<AY38910, CHANNEL_COUNT> _ay;
 	std::array<bool, CHANNEL_COUNT> _resetAsserted = { false, false };
 	std::array<uint8_t, CHANNEL_COUNT> _ayBusMode = { 0, 0 };
-
-	bool _audioEnabled = false;
-	uint32_t _sampleRate = 0;
-	uint64_t _sampleAccumulator = 0;
-	std::vector<float> _audio;
 };

--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -74,6 +74,15 @@ void VM::Reset()
 	_lores = false;
 	_nmiPending = false;
 	_via1IRQAsserted = false;
+	_speakerLevel = false;
+	_audioSampleAccumulator = 0;
+	_audio.clear();
+	_speakerDcSum = 0.0f;
+	_speakerDcPosition = 0;
+	for (float& sample : _speakerDcBuffer)
+	{
+		sample = 0.0f;
+	}
 
 	_cpu->Reset();
 	_acia->Reset();
@@ -126,6 +135,7 @@ void VM::TickDevices(uint32_t cycles)
 		_gamepads->UpdatePortB(_via1->GetPortBOutput());
 		UpdateVIA1NMI();
 		_mockingboard->Tick();
+		TickAudio();
 	}
 }
 
@@ -192,6 +202,85 @@ Mockingboard* VM::GetMockingboard()
 	return _mockingboard;
 }
 
+bool VM::EnableAudio(uint32_t sampleRate)
+{
+	if (sampleRate < 8000 || sampleRate > 192000)
+	{
+		return false;
+	}
+
+	_audioEnabled = true;
+	_audioSampleRate = sampleRate;
+	_audioSampleAccumulator = 0;
+	_audio.clear();
+	_audio.reserve((size_t)sampleRate / 5);
+
+	const float speakerInput = _speakerLevel ? 1.0f : 0.0f;
+	_speakerDcSum = speakerInput * (float)SPEAKER_DC_BUFFER_LENGTH;
+	_speakerDcPosition = 0;
+	for (float& sample : _speakerDcBuffer)
+	{
+		sample = speakerInput;
+	}
+	return true;
+}
+
+void VM::DisableAudio()
+{
+	_audioEnabled = false;
+	_audioSampleRate = 0;
+	_audioSampleAccumulator = 0;
+	_audio.clear();
+}
+
+std::vector<float> VM::DrainAudio()
+{
+	std::vector<float> result;
+	result.swap(_audio);
+	if (_audioEnabled)
+	{
+		_audio.reserve((size_t)_audioSampleRate / 5);
+	}
+	return result;
+}
+
+float VM::SampleSpeaker()
+{
+	const float input = _speakerLevel ? 1.0f : 0.0f;
+	_speakerDcSum -= _speakerDcBuffer[_speakerDcPosition];
+	_speakerDcSum += input;
+	_speakerDcBuffer[_speakerDcPosition] = input;
+	_speakerDcPosition =
+		(_speakerDcPosition + 1) & (SPEAKER_DC_BUFFER_LENGTH - 1);
+	return (input - (_speakerDcSum / (float)SPEAKER_DC_BUFFER_LENGTH))
+		* SPEAKER_GAIN;
+}
+
+void VM::TickAudio()
+{
+	if (!_audioEnabled)
+	{
+		return;
+	}
+
+	_audioSampleAccumulator += (uint64_t)_audioSampleRate * PHI2_DIVISOR;
+	if (_audioSampleAccumulator < VGA_DOT_CLOCK_HZ)
+	{
+		return;
+	}
+
+	_audioSampleAccumulator -= VGA_DOT_CLOCK_HZ;
+	const size_t maximumSamples = (size_t)_audioSampleRate * 2;
+	if (_audio.size() + 2 > maximumSamples)
+	{
+		return;
+	}
+
+	const float speaker = SampleSpeaker();
+	_audio.push_back(_mockingboard->Sample(0) + speaker);
+	_audio.push_back(_mockingboard->Sample(1) + speaker);
+}
+
 void VM::SetTestMode(bool mode)
 {
 	_testmode = mode;
@@ -224,6 +313,10 @@ void VM::DoSoftSwitches(uint16_t address, bool write)
 
 	case MM_SS_JOYSTICK:
 		SignalVIA1Pin(VIA::CB2);
+		break;
+
+	case MM_SS_SPEAKER:
+		_speakerLevel = !_speakerLevel;
 		break;
 
 	case MM_SS_GRAPHICS:
@@ -372,7 +465,7 @@ void VM::DoSoftSwitches(uint16_t address, bool write)
 	{
 		if (CallbackSetSoftSwitches)
 		{
-			if (address != 0xC070 && address != 0xC030) // skip joystick and speaker for now
+			if (address != MM_SS_JOYSTICK)
 			{
 				CallbackSetSoftSwitches(address, _graphics, _page2, _mixed, _lores);
 			}

--- a/emulator/Badger6502VMLib/vm.h
+++ b/emulator/Badger6502VMLib/vm.h
@@ -7,8 +7,10 @@
 #include "mockingboard.h"
 #include "snesgamepads.h"
 #include "ps2keyboard.h"
+#include <cstddef>
 #include <functional>
 #include <unordered_map>
+#include <vector>
 #include "badgervmpal.h"
 #include <DriveEmulator.h>
 
@@ -35,6 +37,7 @@ enum
 	MM_SS_BASIC_ROM_ON  = 0xC006,
 	MM_SS_BASIC_ROM_OFF = 0xC007,
 	MM_SS_KEYBD_STROBE  = 0xC010,
+	MM_SS_SPEAKER       = 0xC030,
 	MM_SS_GRAPHICS      = 0xC050,
 	MM_SS_TEXT          = 0xC051,
 	MM_SS_FULLSCREEN    = 0xC052,
@@ -153,6 +156,9 @@ public:
 	CPU* GetCPU();
 	VIA* GetVIA1();
 	Mockingboard* GetMockingboard();
+	bool EnableAudio(uint32_t sampleRate);
+	void DisableAudio();
+	std::vector<float> DrainAudio();
 	PS2Keyboard* GetPS2Keyboard();
 	DriveEmulator* GetDriveEmulator();
 	bool SimulateSerialKey(uint8_t key);
@@ -198,6 +204,13 @@ private:
 	void DoSoftSwitches(uint16_t address, bool write);
 	uint8_t DoDisk(uint16_t address, uint8_t data, bool write);
 	void UpdateVIA1NMI();
+	void TickAudio();
+	float SampleSpeaker();
+
+	static constexpr uint32_t VGA_DOT_CLOCK_HZ = 25175000;
+	static constexpr uint32_t PHI2_DIVISOR = 16;
+	static constexpr size_t SPEAKER_DC_BUFFER_LENGTH = 512;
+	static constexpr float SPEAKER_GAIN = 0.25f;
 
 	DriveEmulator _driveEmulator;
 
@@ -207,6 +220,15 @@ private:
 	SNESGamepads *	_gamepads;
 	Mockingboard *	_mockingboard;
 	PS2Keyboard *	_pPS2;
+
+	bool _speakerLevel = false;
+	bool _audioEnabled = false;
+	uint32_t _audioSampleRate = 0;
+	uint64_t _audioSampleAccumulator = 0;
+	std::vector<float> _audio;
+	float _speakerDcSum = 0.0f;
+	size_t _speakerDcPosition = 0;
+	float _speakerDcBuffer[SPEAKER_DC_BUFFER_LENGTH] = { 0.0f };
 	
 	uint8_t			_data[0x10000];  // 64KB address space
 	uint8_t			_basic[0x3000];  // 12KB basic bank ROM

--- a/emulator/Badger6502VMTest/MockingboardTests.cpp
+++ b/emulator/Badger6502VMTest/MockingboardTests.cpp
@@ -25,6 +25,16 @@ namespace
 		vm.WriteData(base + VIA::ORB_IRB, 0x06);
 		vm.WriteData(base + VIA::ORB_IRB, 0x04);
 	}
+
+	double ChannelEnergy(const std::vector<float>& audio, size_t channel)
+	{
+		double energy = 0.0;
+		for (size_t i = channel; i < audio.size(); i += 2)
+		{
+			energy += std::abs(audio[i]);
+		}
+		return energy;
+	}
 }
 
 namespace Badger6502VMTest
@@ -46,8 +56,7 @@ namespace Badger6502VMTest
 		TEST_METHOD(ProducesHardPannedStereoAtThe3ricClock)
 		{
 			VM vm(true);
-			Mockingboard* board = vm.GetMockingboard();
-			Assert::IsTrue(board->EnableAudio(48000));
+			Assert::IsTrue(vm.EnableAudio(48000));
 			PrepareAY(vm, MM_MOCKINGBOARD_VIA1_START);
 
 			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 0, 100);
@@ -56,19 +65,106 @@ namespace Badger6502VMTest
 			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 8, 0x0F);
 
 			vm.TickDevices(100000);
-			const std::vector<float> audio = board->DrainAudio();
+			const std::vector<float> audio = vm.DrainAudio();
 			Assert::IsTrue(audio.size() > 1000);
 
-			double leftEnergy = 0.0;
-			double rightEnergy = 0.0;
-			for (size_t i = 0; i + 1 < audio.size(); i += 2)
-			{
-				leftEnergy += std::abs(audio[i]);
-				rightEnergy += std::abs(audio[i + 1]);
-			}
+			const double leftEnergy = ChannelEnergy(audio, 0);
+			const double rightEnergy = ChannelEnergy(audio, 1);
 
 			Assert::IsTrue(leftEnergy > 10.0);
 			Assert::IsTrue(rightEnergy < 0.001);
+		}
+
+		TEST_METHOD(SystemSpeakerTogglesOnReadsWritesAndReset)
+		{
+			VM vm(true);
+			Assert::IsTrue(vm.EnableAudio(48000));
+
+			vm.ReadData(MM_SS_SPEAKER);
+			vm.TickDevices(20000);
+			const std::vector<float> afterRead = vm.DrainAudio();
+			float positivePeak = 0.0f;
+			bool centered = !afterRead.empty();
+			for (size_t i = 0; i + 1 < afterRead.size(); i += 2)
+			{
+				positivePeak = std::max(positivePeak, afterRead[i]);
+				centered = centered && afterRead[i] == afterRead[i + 1];
+			}
+			Assert::IsTrue(positivePeak > 0.20f);
+			Assert::IsTrue(centered);
+
+			vm.WriteData(MM_SS_SPEAKER, 0);
+			vm.TickDevices(1000);
+			const std::vector<float> afterWrite = vm.DrainAudio();
+			float negativePeak = 0.0f;
+			for (size_t i = 0; i + 1 < afterWrite.size(); i += 2)
+			{
+				negativePeak = std::min(negativePeak, afterWrite[i]);
+			}
+			Assert::IsTrue(negativePeak < -0.20f);
+
+			vm.ReadData(MM_SS_SPEAKER);
+			vm.Reset();
+			vm.TickDevices(2000);
+			const std::vector<float> afterReset = vm.DrainAudio();
+			Assert::IsTrue(std::all_of(
+				afterReset.begin(),
+				afterReset.end(),
+				[](float sample) { return sample == 0.0f; }));
+		}
+
+		TEST_METHOD(MixesSystemSpeakerWithMockingboardStereo)
+		{
+			constexpr uint32_t SAMPLE_RATE = 48000;
+			constexpr uint32_t HALF_PERIOD_CYCLES = 787;
+			constexpr uint32_t TOGGLES = 400;
+			constexpr double CPU_CLOCK_HZ = 25175000.0 / 16.0;
+
+			VM vm(true);
+			Assert::IsTrue(vm.EnableAudio(SAMPLE_RATE));
+			PrepareAY(vm, MM_MOCKINGBOARD_VIA1_START);
+			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 0, 100);
+			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 1, 0);
+			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 7, 0x3E);
+			WriteAY(vm, MM_MOCKINGBOARD_VIA1_START, 8, 0x0F);
+
+			for (uint32_t toggle = 0; toggle < TOGGLES; ++toggle)
+			{
+				if ((toggle & 1) == 0)
+				{
+					vm.ReadData(MM_SS_SPEAKER);
+				}
+				else
+				{
+					vm.WriteData(MM_SS_SPEAKER, 0);
+				}
+				vm.TickDevices(HALF_PERIOD_CYCLES);
+			}
+
+			const std::vector<float> audio = vm.DrainAudio();
+			const double speakerEnergy = ChannelEnergy(audio, 1);
+			double mockingboardEnergy = 0.0;
+			size_t risingEdges = 0;
+			float previous = audio.size() >= 2 ? audio[1] : 0.0f;
+			for (size_t i = 0; i + 1 < audio.size(); i += 2)
+			{
+				mockingboardEnergy += std::abs(audio[i] - audio[i + 1]);
+				if (previous <= 0.0f && audio[i + 1] > 0.0f)
+				{
+					++risingEdges;
+				}
+				previous = audio[i + 1];
+			}
+
+			const double frames = (double)audio.size() / 2.0;
+			const double measuredFrequency = risingEdges * SAMPLE_RATE / frames;
+			const double expectedFrequency =
+				CPU_CLOCK_HZ / (2.0 * HALF_PERIOD_CYCLES);
+			Assert::IsTrue(speakerEnergy > 50.0);
+			Assert::IsTrue(mockingboardEnergy > 10.0);
+			Assert::IsTrue(
+				std::abs(measuredFrequency - expectedFrequency)
+					/ expectedFrequency < 0.03);
 		}
 
 		TEST_METHOD(CombinesBothVIAInterruptsOntoIRQ)
@@ -122,8 +218,8 @@ namespace Badger6502VMTest
 			heldInReset.WriteData(base + VIA::ORB_IRB, 0x04);
 			reference.WriteData(base + VIA::ORB_IRB, 0x04);
 
-			Assert::IsTrue(heldInReset.GetMockingboard()->EnableAudio(48000));
-			Assert::IsTrue(reference.GetMockingboard()->EnableAudio(48000));
+			Assert::IsTrue(heldInReset.EnableAudio(48000));
+			Assert::IsTrue(reference.EnableAudio(48000));
 			WriteAY(heldInReset, base, 0, 100);
 			WriteAY(heldInReset, base, 1, 0);
 			WriteAY(heldInReset, base, 7, 0x3E);
@@ -135,10 +231,8 @@ namespace Badger6502VMTest
 
 			heldInReset.TickDevices(50000);
 			reference.TickDevices(50000);
-			const std::vector<float> heldAudio =
-				heldInReset.GetMockingboard()->DrainAudio();
-			const std::vector<float> referenceAudio =
-				reference.GetMockingboard()->DrainAudio();
+			const std::vector<float> heldAudio = heldInReset.DrainAudio();
+			const std::vector<float> referenceAudio = reference.DrainAudio();
 
 			Assert::AreEqual(referenceAudio.size(), heldAudio.size());
 			Assert::IsTrue(std::equal(

--- a/specs/CODEGEN.md
+++ b/specs/CODEGEN.md
@@ -27,7 +27,8 @@ graphics / registers → produce a `.PRG` that also `BRUN`s on real hardware.
 
 **Platform reference (`codegen/platform/`)** — the generator's machine/human contract:
 `prompt-system.md` (assembler dialect, entry/exit conventions), `platform-ref.md` +
-`platform-ref.json` (memory map, soft switches, zero page, ROM entry points). These are
+`platform-ref.json` (memory map, including the `$C030` speaker toggle, soft switches, zero
+page, ROM entry points). These are
 **generated** from the VM — regenerate after any `vm.h` `MM_*` or ROM-symbol change.
 
 **Assembler dialect:** `$hex` / `%bin` / decimal / char literals; labels; directives

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -10,9 +10,9 @@
 ## Purpose
 
 Faithfully emulate the 3ric machine: a WDC 65C02 CPU, 36 KB RAM, Microsoft BASIC + a 512 KB
-ROM (monitor/DOS), Apple-II-style text/lo-res/hi-res video, keyboard, a 6551 ACIA serial
-port, a 6522 VIA (I/O + bit-banged SPI micro-SD + two serial SNES gamepads), a slot-4
-dual-AY Mockingboard, and a Disk II 5.25″ floppy. It is the **reference implementation of
+ROM (monitor/DOS), Apple-II-style text/lo-res/hi-res video, keyboard, a `$C030` system
+speaker, a 6551 ACIA serial port, a 6522 VIA (I/O + bit-banged SPI micro-SD + two serial
+SNES gamepads), a slot-4 dual-AY Mockingboard, and a Disk II 5.25″ floppy. It is the **reference implementation of
 the target hardware** — the emulator is correct when it behaves like the real machine will.
 
 ## Contracts / Interfaces
@@ -24,7 +24,7 @@ the target hardware** — the emulator is correct when it behaves like the real 
 | `Badger6502VMLib` | The VM core: `vm`, `cpu`, `Instructions`, `acia`, `via`, `snesgamepads`, `mockingboard`, `ay38910`, `PS2Keyboard`, `badgervmpal` (video). Windows-only: `symbols`, `Disassemble`. |
 | `WozLib` | Disk II emulation: `DriveEmulator`, `WozDisk`, `WozFile` (`.woz` images). |
 | `MockMicroSD` | Bit-banged SPI SD card (`SDCard`) over a memory-mapped image (`MappedFile`). |
-| `Badger6502VMTest` | MSTest (native C++) CPU and peripheral tests, including VIA, SNES gamepads, and Mockingboard. |
+| `Badger6502VMTest` | MSTest (native C++) CPU and peripheral tests, including VIA, SNES gamepads, system speaker, and Mockingboard. |
 | `Console`, `Badger6502Emulator`(+Package) | Win32 console and WinUI hosts. |
 | `WozFileTestApp`, `dsk2woz2`, `picodisk` | WOZ tooling / disk conversion / Pico target. |
 
@@ -34,6 +34,7 @@ web bridge, and `codegen/platform-ref.*`):
 ```
 $0000–$8FFF  RAM (36 KB)          $2000–$5FFF  hi-res video pages
 $9000–$BFFF  Microsoft BASIC ROM  $C000        keyboard data / $C010 strobe clear
+$C030        system speaker toggle (any read or write access)
 $C050–$C057  display soft switches (GRAPHICS/TEXT/…/LORES/HIRES)
 $C080–$C08F  language-card bank switches
 $C100–$C10F  ACIA (6551 serial)   $C200–$C20F  VIA1 (SPI micro-SD)
@@ -67,9 +68,9 @@ bridge uses this to clock the SD card and advance the drive).
 
 - CPU is driven **cooperatively**: hosts call `VM::Step()` per instruction. The VM samples
   the shared level-sensitive IRQ line before the instruction and ticks the onboard VIA plus
-  both Mockingboard VIA/AY pairs for every returned CPU cycle. Presentation hosts may then
-  advance host-owned keyboard/disk plumbing. The blocking `VM::Run()` is not used by the web
-  build.
+  both Mockingboard VIA/AY pairs for every returned CPU cycle, then advances the VM-owned
+  PCM sample clock. Presentation hosts may then advance host-owned keyboard/disk plumbing.
+  The blocking `VM::Run()` is not used by the web build.
 - `reset()` loads PC from `$FFFC/$FFFD`. ROM load recipe (mirrored by every host): write the
   first `0x10000` bytes of `badger6502.bin` into `GetData()`, `seedBasicRom()` (copy
   `$9000..$BFFF`), `loadFont()`, then `reset()`.
@@ -84,6 +85,17 @@ bridge uses this to clock the SD card and advance the drive).
   asserted and receiver interrupts are enabled in the 6551 command register. A write to the
   status address performs a programmed reset independent of the written value, preserving
   the control register and command parity bits.
+
+**System speaker and mixed-audio contract:**
+
+- Any bus read or write at `MM_SS_SPEAKER` (`$C030`) toggles the one-bit system-speaker
+  latch, matching the schematic's address-decoded toggle circuit. Reset clears the latch.
+- The latch continues to respond while host audio collection is disabled. At each host PCM
+  sample point, its mono level passes through a DC blocker at 0.25 full-scale gain and is
+  added equally to left and right.
+- PCM scheduling and buffering belong to `VM`, not either sound device: the VM samples both
+  AY outputs and the speaker from the same PHI2-derived clock and exposes one interleaved
+  stereo stream. Enabling/disabling collection must not stop speaker, VIA, or AY state.
 
 **Slot-4 Mockingboard contract (matching `kicad/3ric/Mockingboard.kicad_sch`):**
 
@@ -106,16 +118,17 @@ bridge uses this to clock the SD card and advance the drive).
   VIA IRQ outputs.
 - SNES controller data is applied through VIA1's external PB5/PB4 input pins and obeys DDRB;
   software still performs the real `$C070` → CB2/NMI → ROM bit-bang scan.
-- AY 1 and AY 2 are separate left/right outputs. The shared core produces interleaved stereo
-  PCM; host muting disables sample collection without stopping VIA or AY state progression.
+- AY 1 and AY 2 remain separate left/right sources. The VM-level mixer combines them with
+  the centered system speaker without changing the board's hard-panned stereo behavior.
 
 ## Data flow
 
 `host controller state → VM::SetGamepadState() → SNES latch/clock on VIA1 PB6/PB7 →
 active-low PB5/PB4 → ROM NMI scan → GAMEPAD1/GAMEPAD2`; otherwise
 `6502 ROM/program → VM::Step() → memory/soft-switch access → device
-(video/ACIA/VIA/Mockingboard/SD/Disk II) → framebuffer + serial + stereo PCM + register
-state → host (native window or web bridge → canvas/audio)`.
+(video/ACIA/VIA/$C030 speaker/Mockingboard/SD/Disk II) → VM PCM mixer (mono speaker +
+left/right AY) + framebuffer + serial + register state → host (native window or web bridge
+→ canvas/audio)`.
 
 ## Dependencies
 
@@ -133,5 +146,6 @@ state → host (native window or web bridge → canvas/audio)`.
 | Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |
 | VIA1 + bit-banged SPI micro-SD | Shipped | `via` + `MockMicroSD`. |
 | Two serial SNES gamepads on VIA1 | Shipped | Shared native/WASM peripheral; latch/clock, active-low data, reset, and two-pad scans covered by MSTest. |
+| `$C030` system speaker + VM audio mixer | Shipped | Any read/write toggles the mono latch; centered PCM mixes with both AY channels; covered by native and WASM tests. |
 | Slot-4 dual-AY Mockingboard | Shipped | Exact 3RIC `$C400/$C480`, 1.5734375 MHz, VIA IRQ, and hard-panned stereo; covered by native and WASM tests. |
 | Disk II 5.25″ floppy (WozLib) | Shipped | `$C600` boot PROM + `$C0E0–$C0EF`. |

--- a/specs/HARDWARE.md
+++ b/specs/HARDWARE.md
@@ -11,8 +11,8 @@
 ## Purpose
 
 Define the real 3ric computer at the board and chip level: CPU, RAM/ROM, the video circuit,
-I/O (VIA/ACIA), the Disk II and micro-SD interfaces, and the glue logic that decodes the
-address bus. The goal is a buildable Apple-II-class 65C02 machine whose behavior matches the
+I/O (VIA/ACIA), the `$C030` system speaker, the Disk II and micro-SD interfaces, and the
+glue logic that decodes the address bus. The goal is a buildable Apple-II-class 65C02 machine whose behavior matches the
 emulator.
 
 ## Contracts / Interfaces
@@ -29,8 +29,9 @@ emulator.
 **The load-bearing contract:** the 22V10 address decoder (`3ricDecoder.PLD` /
 `EB6502 DECODER.PLD`) and the color GAL (`A2COLOR.PLD`) must decode exactly the regions in
 the emulator's `MM_*` map (`emulator/Badger6502VMLib/vm.h`) — RAM, BASIC ROM, the `$C0xx`
-device/soft-switch page (keyboard, ACIA `$C1xx`, VIA1 `$C2xx`, ROM disk `$C3xx`, audio
-`$C4xx`, Disk II PROM `$C6xx`), RAM2, and ROM `$D000–$FFFF`.
+device/soft-switch page (keyboard, system speaker `$C030`, ACIA `$C1xx`, VIA1 `$C2xx`,
+ROM disk `$C3xx`, Mockingboard `$C4xx`, Disk II PROM `$C6xx`), RAM2, and ROM
+`$D000–$FFFF`.
 
 ## Behaviour / Rules
 
@@ -46,6 +47,13 @@ device/soft-switch page (keyboard, ACIA `$C1xx`, VIA1 `$C2xx`, ROM disk `$C3xx`,
 `CPU address/data bus → 22V10 decoder → chip selects (RAM / ROM / BASIC / $C0xx devices) →
 device responds; video circuit + A2COLOR GAL → composite/color output`. The emulator models
 this same routing in `VM::DoSoftSwitches` and the device handlers.
+
+### System speaker
+
+- `kicad/3ric/softswitches.kicad_sch` decodes `$C030` without qualifying the access by
+  read/write; every access clocks the one-bit latch in `kicad/3ric/banking.kicad_sch`.
+- That latch drives the onboard `Y_SPEAKER`. The emulator models the same toggling and
+  presents this physical mono source equally in its left/right host PCM channels.
 
 ### SNES gamepads
 
@@ -86,6 +94,7 @@ this same routing in `VM::DoSoftSwitches` and the device handlers.
 | 22V10 address-decode GAL | In progress | `3ricDecoder.PLD` / `EB6502 DECODER.PLD`; mirrors `MM_*`. |
 | Apple-II color GAL | In progress | `A2COLOR.PLD` + `logisim/apple2color.circ`. |
 | Address-map validation | Present | `test/memory_map_test`. |
+| `$C030` system speaker | Shipped (schematic + emulator) | Address-decoded toggle latch drives `Y_SPEAKER`; the emulator exposes its centered mono signal in the combined PCM stream. |
 | Dual SNES controller interface | Shipped (schematic + emulator) | Shared PB6/PB7 latch/clock and active-low PB5/PB4 data; browser controllers exercise the same serial contract. |
 | Slot-4 dual-AY Mockingboard | Shipped | `$C400/$C480`, direct PHI2 clock, dual IRQ, hard stereo; shared emulator and browser implementation matches the schematic. |
 | PCB fabrication / bring-up | Tracked in build series | Emulator is the reference until hardware is verified. |

--- a/specs/SYSTEM.md
+++ b/specs/SYSTEM.md
@@ -12,8 +12,9 @@
 schematics, a custom PCB, and 22V10 GAL address-decode logic) plus a cycle-honest **C++
 emulator** of the same machine. The emulator also compiles to **WebAssembly**, so the exact
 same VM core boots the real 512 KB ROM in any browser — text/lo-res/hi-res video on a
-canvas, keyboard and USB/Bluetooth gamepad input, a Disk II 5.25″ floppy, and a bit-banged
-micro-SD card. A small Node **codegen** toolchain assembles 65C02 programs and validates
+canvas, keyboard and USB/Bluetooth gamepad input, the `$C030` system speaker, a slot-4
+Mockingboard, a Disk II 5.25″ floppy, and a bit-banged micro-SD card. A small Node
+**codegen** toolchain assembles 65C02 programs and validates
 them headlessly on the same WASM core. The "why" lives in `docs/MISSION.md`.
 
 ## Architecture at a glance
@@ -25,7 +26,7 @@ them headlessly on the same WASM core. The "why" lives in `docs/MISSION.md`.
    Emulator core — 65C02 VM in C++  (emulator/Badger6502VMLib)
      ├─ WozLib       — Disk II 5.25" floppy (.woz)        ┐ shared sources,
      ├─ MockMicroSD  — bit-banged SPI FAT32 card          ├ guarded for both
-     └─ video / keyboard / SNES pads / ACIA / VIA         ┘ native + WASM
+     └─ video / keyboard / speaker / SNES / ACIA / VIA   ┘ native + WASM
                  │                              │
    native hosts (Windows/WinUI,        Emscripten bridge (web/web_bridge.cpp)
    Console) via Badger6502VM.sln                │
@@ -78,6 +79,7 @@ them headlessly on the same WASM core. The "why" lives in `docs/MISSION.md`.
 | Text / lo-res / hi-res video rendering | Shipped |
 | Keyboard (`$C000`/`$C010`, physical + web virtual keyboard) + ACIA serial | Shipped |
 | Two SNES pads via VIA1 + browser Gamepad API | Shipped |
+| System speaker (`$C030`) | Shipped |
 | Disk II 5.25″ WOZ boot (self-booting machine-code disks) | Shipped |
 | Micro-SD FAT32 + ROM DOS shell | Shipped |
 | Slot-4 dual-AY Mockingboard | Shipped |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -10,8 +10,9 @@
 ## Purpose
 
 Boot the real 512 KB ROM in any browser: render Apple-II text/lo-res/hi-res video to a
-`<canvas>`, feed keyboard and standard Gamepad API input through the machine's real input
-paths, run Disk II and micro-SD images, and assemble/run 65C02 source client-side — all 100%
+`<canvas>`, play the `$C030` system speaker and slot-4 Mockingboard, feed keyboard and
+standard Gamepad API input through the machine's real input paths, run Disk II and
+micro-SD images, and assemble/run 65C02 source client-side — all 100%
 client-side so GitHub Pages can host it as static files.
 
 ## Contracts / Interfaces
@@ -27,12 +28,14 @@ client-side so GitHub Pages can host it as static files.
   `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
   `runCycles(cycleBudget)`, `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial),
   `setGamepadState(index, pressedMask)`,
-  `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM),
+  `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM:
+  centered system speaker summed with hard-panned Mockingboard AY channels),
   `renderFrame()` (RGBA framebuffer), `pc/sp/regA/regX/regY/status`, `sdReadCount()`.
 - **Compat shims (`web_compat.h`):** map MSVC-isms (`OutputDebugString`, `sprintf_s`,
   `fopen_s`, `_ASSERT`, …) onto Emscripten so `WozLib`/`MockMicroSD` compile unchanged.
 - **UI (`index.html`):** `requestAnimationFrame` driver, physical/virtual keyboard and gamepad
-  input, disk/SD/clock/sound controls, and the in-browser **Assembler** panel (imports
+  input, disk/SD/clock/sound controls (one opt-in control for both system-speaker and
+  Mockingboard output), and the in-browser **Assembler** panel (imports
   `assemble()` from the staged
   `asm6502.mjs`). Honors optional `window.ASSET_BASE` / `?assets=` for CDN/R2 offload and
   `?src=` / `?prg=` / `?code=` deep links, plus a **Share** button that builds a one-click
@@ -119,12 +122,15 @@ client-side so GitHub Pages can host it as static files.
   displays. A wall-clock execution cap keeps the tab responsive; **Max** remains unthrottled
   within that cap. Timing debt is reset after a machine reset, speed change, or hidden-tab
   transition rather than replaying a stale wall-clock interval.
-- Sound is opt-in because browsers require a user gesture to start `AudioContext`.
+- Sound is opt-in because browsers require a user gesture to start `AudioContext`. The
+  bridge drains the VM's combined stream: `$C030` is centered mono and the two AYs retain
+  their left/right placement.
   `audio-worklet.js` consumes transferable Float32 chunks from the bridge without requiring
   `SharedArrayBuffer` or cross-origin isolation. It prebuffers a short bounded lead before
   playback, renders without per-sample allocation, and discards only the oldest queued frames
   if a stalled producer exceeds the latency bound. Sound is generated only at 1x speed;
-  changing speed mutes and flushes PCM while the emulated VIA/AY state continues to advance.
+  changing speed mutes and flushes PCM while the speaker latch and emulated VIA/AY state
+  continue to advance.
 - Gamepad state is sampled once per rendered frame, independently of CPU speed. Disconnecting
   a pad releases every button immediately; reconnecting fills the first free player slot.
   The shared VM, not JavaScript, performs the SNES latch/clock protocol and active-low VIA
@@ -195,7 +201,8 @@ client-side so GitHub Pages can host it as static files.
 `build.ps1 → badger6502.js/.wasm + data/ → index.html loads WASM → boot recipe (loadData /
 seedBasicRom / loadFont / reset) → Gamepad API→gamepad.js mapping→setGamepadState()→shared
 SNES/VIA peripheral; elapsed-time budget→runCycles() per frame →
-renderFrame()→canvas, drainOutput()→log, drainAudio()→AudioWorklet→speakers; canvas keydown or
+renderFrame()→canvas, drainOutput()→log, `$C030` + AYs→VM mixer→drainAudio()→AudioWorklet→
+speakers; canvas keydown or
 virtual-keyboard button→shared input queue→strobe-clear frame→keyDown()→$C000;
 Boot Disk/Mount SD →
 insertDisk()/loadSD() → C600G / EC5CG`.
@@ -234,6 +241,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | `llms.txt` discoverability | Shipped | `<link rel="alternate">` + footer links in `index.html`/`gallery.html`; `robots.txt` + `sitemap.xml` staged (advisory on the project-page root; authoritative under a custom domain). |
 | Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |
 | Adjustable CPU clock | Shipped | frontend-only pacing; native **1× ≈ 1.57 MHz** (25.175 MHz VGA dot clock ÷ 16) default. |
-| Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the shared dual-AY stereo PCM; sound enabled only at 1x. |
+| `$C030` system speaker audio | Shipped | Centered mono output shares the VM PCM clock and browser sound control with the Mockingboard; covered by `test_system_speaker.cjs`. |
+| Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the combined speaker/dual-AY stereo PCM; sound enabled only at 1x. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/input/audio/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -47,6 +47,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web/test_audio_pacing.cjs        # real WASM PCM rate at 60/144 Hz displays
 & $node web/test_audio_worklet.cjs       # prebuffer + bounded PCM queue
 & $node web/test_mockingboard.cjs        # slot-4 mirrors, stereo PCM, 3RIC clock, VIA IRQ
+& $node web/test_system_speaker.cjs     # $C030 read/write toggles + mixed speaker/AY PCM
 & $node web/test_gamepad.cjs             # browser mapping, VIA serial pads, ROM tables
 & $node web/test_sd.cjs                  # mount SD + DIR lists the FAT32 root
 & $node web/test_disk.cjs                # boot a WOZ floppy via C600G into a hi-res title
@@ -79,9 +80,10 @@ secrets. Nothing to configure and nothing to commit. (The only "secret" is the s
 
 - **Emulator:** boots the unmodified 512 KB ROM to the monitor; text/lo-res/hi-res color
   video; keyboard; two serial SNES pads; ACIA serial; Disk II WOZ boot; micro-SD FAT32 DOS
-  shell; slot-4 dual-AY Mockingboard at the hardware's 1.5734375 MHz clock; adjustable CPU
-  clock. The browser maps standard USB/Bluetooth controllers through the SNES/VIA path.
-  Shared VM core runs identically on Windows and in the browser.
+  shell; `$C030` system speaker centered into the slot-4 dual-AY Mockingboard stereo stream
+  at the hardware's 1.5734375 MHz clock; adjustable CPU clock. The browser maps standard
+  USB/Bluetooth controllers through the SNES/VIA path. Shared VM core runs identically on
+  Windows and in the browser.
 - **In-browser assembler:** assembles 65C02 source client-side with the project's own
   `asm6502.mjs` and runs it like `BRUN`; ships ~11 sample programs; deep-linkable via `?src=`.
   Exports the assembled program as a raw **.PRG** or a bootable **.woz** disk image

--- a/web/README.md
+++ b/web/README.md
@@ -5,7 +5,8 @@ Apple-II-clone emulator. It compiles the existing C++ VM core
 (`emulator/Badger6502VMLib`) and disk library (`emulator/WozLib`) to WebAssembly,
 boots the real 512KB ROM, renders Apple-II text/hi-res/lo-res video to an HTML
 `<canvas>`, feeds keyboard and gamepad input through the machine's hardware paths,
-and plays the slot-4 dual-AY Mockingboard through Web Audio.
+and plays both the `$C030` system speaker and slot-4 dual-AY Mockingboard through
+Web Audio.
 
 The VM peripherals remain in the shared C++ core so native and WASM builds behave
 identically. Browser-only presentation code stays in the bridge and JavaScript.
@@ -32,10 +33,11 @@ identically. Browser-only presentation code stays in the bridge and JavaScript.
   Applesoft for their auto-run greeting — see below).
 - **Adjustable CPU clock** (**Speed** selector): 0.5× / 1× (≈1.57 MHz, native) /
   2× / 4× / 8× / Max, with a per-frame wall-clock cap so the page stays responsive.
-- **3RIC Mockingboard audio**: two AY-3-8910s at `$C400/$C480`, clocked directly
-  from 1.5734375 MHz PHI2 and hard-panned stereo. **Enable Sound** creates the
-  browser audio context after a user gesture. Audio plays at 1× and pauses at
-  other speed settings while the emulated chips continue to advance.
+- **3RIC audio**: the mono `$C030` system speaker is centered and mixed with two
+  AY-3-8910s at `$C400/$C480`, clocked directly from 1.5734375 MHz PHI2 and
+  hard-panned stereo. **Enable Sound** creates the browser audio context after a
+  user gesture. Audio plays at 1× and pauses at other speed settings while the
+  emulated latch and chips continue to advance.
 - **In-browser assembler** (**Assemble & Run**): edit 65C02 source in the page,
   assemble it client-side with the very same assembler the CLI uses
   (`codegen/tools/asm6502.mjs`), run the resulting image like **Load .PRG**, and
@@ -114,8 +116,9 @@ the DOS shell — it runs the monitor command `EC5CG` (Go to `$EC5C`, the `dos`
 routine) which mounts the FAT32 image and prints a `>` prompt, then auto-runs
 `DIR`. Type `CAT`, `CD <dir>`, `BRUN <file>`, etc. to load games and programs
 from the card. The **Speed** selector sets the CPU clock (0.5×–8× or Max).
-Press **Enable Sound** to start stereo Mockingboard playback. Browser autoplay
-rules require this click; sound is intentionally generated only at native 1×.
+Press **Enable Sound** to start the system-speaker and stereo Mockingboard mix.
+Browser autoplay rules require this click; sound is intentionally generated only
+at native 1×.
 
 > Port 8011 is used because 8000 is taken on this machine.
 
@@ -214,6 +217,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web\test_audio_pacing.cjs # real WASM PCM rate at 60/144 Hz displays
 & $node web\test_audio_worklet.cjs # prebuffer + bounded PCM queue
 & $node web\test_mockingboard.cjs # mirrors, stereo PCM, 3RIC clock, timer IRQ
+& $node web\test_system_speaker.cjs # $C030 read/write toggles + mixed PCM
 & $node web\test_gamepad.cjs    # mapping, VIA serialization, ROM GAMEPAD1/2 scan
 & $node web\test_sd.cjs          # mount the SD card + DIR lists the FAT32 root
 & $node web\test_disk.cjs        # boot a WOZ floppy via C600G into a hi-res title
@@ -230,8 +234,8 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 
 The CPU is driven cooperatively: each animation frame calls `run(maxSteps)`,
 which calls shared `VM::Step()` to sample IRQ and tick the onboard VIA plus both
-Mockingboard VIA/AY pairs per returned cycle, then advances keyboard plumbing
-(the blocking `VM::Run()` is never used).
+Mockingboard VIA/AY pairs and the combined PCM mixer per returned cycle, then
+advances keyboard plumbing (the blocking `VM::Run()` is never used).
 
 ## How the micro-SD card works
 

--- a/web/index.html
+++ b/web/index.html
@@ -168,7 +168,7 @@
         <option value="max">Max</option>
       </select></span>
     <button id="sound" type="button" aria-pressed="false"
-      title="Enable the slot-4 dual-AY Mockingboard at native 1x speed">Enable Sound</button>
+      title="Enable the system speaker and slot-4 Mockingboard at native 1x speed">Enable Sound</button>
     <span class="regs" id="regs">PC:---- A:-- X:-- Y:-- SP:-- P:--</span>
     <span class="regs" id="mode">mode:---</span>
     <span class="hint" id="gamepads">gamepads: detecting&hellip;</span>
@@ -235,8 +235,8 @@
   <footer>
     65C02 emulator core (C++) + WozLib compiled to WebAssembly via Emscripten. Boots the real 512KB ROM,
     renders Apple-II text/hi-res to the canvas, feeds keystrokes through the memory-mapped keyboard ($C000),
-    maps up to two USB/Bluetooth gamepads through the real SNES/VIA interface, and emulates the 3RIC
-    slot-4 dual-AY Mockingboard in stereo.
+    maps up to two USB/Bluetooth gamepads through the real SNES/VIA interface, and emulates both
+    the $C030 system speaker and 3RIC slot-4 dual-AY Mockingboard.
     Click the screen and type, open the <strong>Virtual Keyboard</strong> on a phone, or pair a controller and press a button. &ldquo;Boot Disk&rdquo; boots the bundled 5.25&Prime; floppy (or pick a .woz with
     &ldquo;Insert&rdquo;) through the Disk&nbsp;II ROM at $C600. &ldquo;Mount SD&rdquo; enters the DOS shell
     (prompt &ldquo;&gt;&rdquo;) and lists the micro-SD card &mdash; load games and programs from there.
@@ -424,13 +424,13 @@
       soundButton.setAttribute("aria-pressed", soundRequested ? "true" : "false");
       if (!soundRequested) {
         soundButton.textContent = "Enable Sound";
-        soundButton.title = "Enable the slot-4 dual-AY Mockingboard at native 1x speed";
+        soundButton.title = "Enable the system speaker and slot-4 Mockingboard at native 1x speed";
       } else if (speedMul !== 1) {
         soundButton.textContent = "Sound Paused";
-        soundButton.title = "Mockingboard audio is available at native 1x speed";
+        soundButton.title = "System-speaker and Mockingboard audio is available at native 1x speed";
       } else {
         soundButton.textContent = "Disable Sound";
-        soundButton.title = "Disable Mockingboard audio";
+        soundButton.title = "Disable system-speaker and Mockingboard audio";
       }
     }
 

--- a/web/test_system_speaker.cjs
+++ b/web/test_system_speaker.cjs
@@ -1,0 +1,125 @@
+// Combined-audio contract test for the $C030 system speaker and Mockingboard.
+//
+// Run with:
+//   C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe web\test_system_speaker.cjs
+
+const assert = require("node:assert/strict");
+const createBadgerVM = require("./badger6502.js");
+
+const CPU_CLOCK_HZ = 25_175_000 / 16;
+const SAMPLE_RATE = 48_000;
+const HALF_PERIOD_CYCLES = 787;
+const TOGGLES = 400;
+const SPEAKER = 0xc030;
+const MOCKINGBOARD = 0xc400;
+const VIA = {
+  ORB: 0,
+  ORA: 1,
+  DDRB: 2,
+  DDRA: 3,
+};
+
+function prepareIdleLoop(vm) {
+  vm.poke(0x0800, 0x4c); // JMP $0800
+  vm.poke(0x0801, 0x00);
+  vm.poke(0x0802, 0x08);
+  vm.setPC(0x0800);
+}
+
+function writeAY(vm, reg, data) {
+  vm.writeBus(MOCKINGBOARD + VIA.ORA, reg);
+  vm.writeBus(MOCKINGBOARD + VIA.ORB, 0x07);
+  vm.writeBus(MOCKINGBOARD + VIA.ORB, 0x04);
+  vm.writeBus(MOCKINGBOARD + VIA.ORA, data);
+  vm.writeBus(MOCKINGBOARD + VIA.ORB, 0x06);
+  vm.writeBus(MOCKINGBOARD + VIA.ORB, 0x04);
+}
+
+function programLeftTone(vm) {
+  vm.writeBus(MOCKINGBOARD + VIA.DDRA, 0xff);
+  vm.writeBus(MOCKINGBOARD + VIA.DDRB, 0x07);
+  vm.writeBus(MOCKINGBOARD + VIA.ORB, 0x04);
+  writeAY(vm, 0, 100);
+  writeAY(vm, 1, 0);
+  writeAY(vm, 7, 0x3e);
+  writeAY(vm, 8, 0x0f);
+}
+
+function channelEnergy(samples, channel) {
+  let energy = 0;
+  for (let i = channel; i < samples.length; i += 2) {
+    energy += Math.abs(samples[i]);
+  }
+  return energy;
+}
+
+createBadgerVM().then((Module) => {
+  const vm = new Module.WebVM();
+  vm.reset();
+  prepareIdleLoop(vm);
+  assert.equal(vm.enableAudio(SAMPLE_RATE), true);
+
+  vm.readBus(SPEAKER);
+  vm.runCycles(20_000);
+  const afterRead = vm.drainAudio();
+  let positivePeak = 0;
+  for (let i = 0; i + 1 < afterRead.length; i += 2) {
+    positivePeak = Math.max(positivePeak, afterRead[i]);
+    assert.equal(afterRead[i], afterRead[i + 1]);
+  }
+  assert.ok(positivePeak > 0.20, "read access did not raise the speaker");
+
+  vm.writeBus(SPEAKER, 0);
+  vm.runCycles(1_000);
+  const afterWrite = vm.drainAudio();
+  let negativePeak = 0;
+  for (let i = 0; i < afterWrite.length; i += 2) {
+    negativePeak = Math.min(negativePeak, afterWrite[i]);
+  }
+  assert.ok(negativePeak < -0.20, "write access did not lower the speaker");
+
+  vm.readBus(SPEAKER);
+  vm.reset();
+  prepareIdleLoop(vm);
+  vm.runCycles(2_000);
+  assert.ok(
+    vm.drainAudio().every((sample) => sample === 0),
+    "reset did not clear the speaker latch and filter");
+
+  programLeftTone(vm);
+  let executedCycles = 0;
+  for (let toggle = 0; toggle < TOGGLES; toggle++) {
+    if ((toggle & 1) === 0) vm.readBus(SPEAKER);
+    else vm.writeBus(SPEAKER, 0);
+    executedCycles += vm.runCycles(HALF_PERIOD_CYCLES);
+  }
+
+  const mixed = vm.drainAudio();
+  const speakerEnergy = channelEnergy(mixed, 1);
+  let mockingboardEnergy = 0;
+  let risingEdges = 0;
+  let previous = mixed.length >= 2 ? mixed[1] : 0;
+  for (let i = 0; i + 1 < mixed.length; i += 2) {
+    mockingboardEnergy += Math.abs(mixed[i] - mixed[i + 1]);
+    if (previous <= 0 && mixed[i + 1] > 0) risingEdges++;
+    previous = mixed[i + 1];
+  }
+
+  const frames = mixed.length / 2;
+  const measuredFrequency = risingEdges * SAMPLE_RATE / frames;
+  const averageHalfPeriod = executedCycles / TOGGLES;
+  const expectedFrequency = CPU_CLOCK_HZ / (2 * averageHalfPeriod);
+  assert.ok(speakerEnergy > 50, "centered speaker is missing from the mix");
+  assert.ok(mockingboardEnergy > 10, "left AY is missing from the mix");
+  assert.ok(
+    Math.abs(measuredFrequency - expectedFrequency) / expectedFrequency < 0.03,
+    `speaker frequency ${measuredFrequency} did not match ${expectedFrequency}`);
+
+  vm.disableAudio();
+  vm.delete();
+  console.log(
+    `PASS: $C030 speaker ${measuredFrequency.toFixed(1)} Hz mixed with Mockingboard stereo`);
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -266,22 +266,22 @@ public:
     }
     bool irqAsserted() { return _vm->IRQAsserted(); }
 
-    // --- Mockingboard audio ------------------------------------------------
+    // --- system speaker + Mockingboard audio -------------------------------
 
     bool enableAudio(int sampleRate)
     {
         if (sampleRate < 0) return false;
-        return _vm->GetMockingboard()->EnableAudio((uint32_t)sampleRate);
+        return _vm->EnableAudio((uint32_t)sampleRate);
     }
 
     void disableAudio()
     {
-        _vm->GetMockingboard()->DisableAudio();
+        _vm->DisableAudio();
     }
 
     val drainAudio()
     {
-        std::vector<float> audio = _vm->GetMockingboard()->DrainAudio();
+        std::vector<float> audio = _vm->DrainAudio();
         if (audio.empty())
         {
             return val::global("Float32Array").new_(0);


### PR DESCRIPTION
## Summary
- emulate the Apple-II-style `$C030` system-speaker latch on every bus read or write
- mix its DC-blocked mono signal into both channels of the existing hard-panned Mockingboard PCM stream
- update the WASM bridge/UI, generated platform reference, specs, and native/browser coverage

## Validation
- native `Badger6502VMTest`: 199 passed
- `web/build.ps1`
- `web/test_system_speaker.cjs`
- `web/test_mockingboard.cjs`
- `web/test_audio_pacing.cjs`
- `web/test_audio_worklet.cjs`
- pre-push assembler and boot gates

## Baseline note
`web/test_woz_download.cjs` still fails its unrelated `swarm` attract-screen text assertion after a byte-perfect load; the same case fails identically on a separately built, untouched `HEAD` snapshot.