### PR TITLE
Fix virtual keyboard width on phones

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -53,7 +53,9 @@ client-side so GitHub Pages can host it as static files.
   bottom-row spacers preserve the remaining keys' physical positions. One-shot Shift and
   Control modifiers complete the emulator's character set. Key buttons enqueue the same
   7-bit bytes as physical `keydown` events; the frame driver remains the single writer to
-  `keyDown()` and waits for the `$C000` strobe to clear before delivering each byte.
+  `keyDown()` and waits for the `$C000` strobe to clear before delivering each byte. At
+  phone widths (480 CSS pixels or less), each row fits the keyboard panel's available width
+  without horizontal scrolling while retaining the diagram's relative key widths.
 - **Browser gamepads (`gamepad.js` + `index.html`):** the frame driver polls the standard
   Gamepad API before running the CPU, keeps the first two connected devices in stable player
   slots, maps each to the 12-button SNES mask, and calls `setGamepadState()` for both slots.
@@ -143,7 +145,9 @@ client-side so GitHub Pages can host it as static files.
   ROM, so the virtual keycaps show uppercase letters. The IIe Caps Lock key is displayed in
   its physical position but disabled with an explicit uppercase-only label; it does not fake
   a lowercase mode the bridge cannot deliver. Both the virtual IIe Delete key and a physical
-  keyboard's Delete key emit ASCII DEL (`$7F`).
+  keyboard's Delete key emit ASCII DEL (`$7F`). On phone-width viewports, key and spacer
+  minimums collapse so the flex-unit layout scales to the panel rather than overflowing it;
+  wider viewports retain the full-size 530-pixel keyboard and its horizontal fallback.
 - Pointer/touch activation returns focus to the canvas after expanding the panel or pressing
   any virtual key, preserving immediate physical-keyboard input. Keyboard and assistive-
   technology activation retains focus on the activated control so consecutive accessible
@@ -229,7 +233,7 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 |------|--------|-------|
 | WASM build of the VM core + WozLib + SD | Shipped | `web/build.ps1`, Emscripten 6.0.1. |
 | Canvas video + keyboard | Shipped | text/lo-res/hi-res, `$C000` input. |
-| Mobile virtual keyboard | Shipped | Exact 1983 Apple IIe Figure 2-1 key order/widths below the canvas, minus Reset and both Apple keys; full emulator character set, one-shot Shift/Control, and the same strobe-aware `$C000` queue as physical input. |
+| Mobile virtual keyboard | Shipped | Exact 1983 Apple IIe Figure 2-1 key order/widths below the canvas, minus Reset and both Apple keys; full emulator character set, one-shot Shift/Control, the same strobe-aware `$C000` queue as physical input, and viewport-fitting rows without phone-width horizontal scrolling. |
 | USB/Bluetooth gamepads | Shipped | Two stable player slots through the standard Gamepad API and shared SNES/VIA peripheral; covered by browser-mapping, serial-protocol, and ROM-table tests. |
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
 | In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. Sample sources fetched with `cache:"no-cache"` (revalidate) so a new deploy isn't masked by the browser cache. |

--- a/web/index.html
+++ b/web/index.html
@@ -62,7 +62,10 @@
     image-rendering: pixelated; image-rendering: crisp-edges;
     background: #000; border: 1px solid var(--dim); outline: none;
   }
-  #virtual-keyboard { border: 1px solid var(--dim); border-radius: 4px; background: var(--panel); }
+  #virtual-keyboard {
+    width: 100%; min-width: 0; max-width: 100%;
+    border: 1px solid var(--dim); border-radius: 4px; background: var(--panel);
+  }
   #virtual-keyboard summary {
     padding: 7px 9px; cursor: pointer; color: var(--fg); font-size: 11px;
     letter-spacing: .6px; touch-action: manipulation; user-select: none;
@@ -137,9 +140,18 @@
   #ide .remix.show { display: block; }
   @media (max-width: 480px) {
     main { gap: 12px; padding: 8px; }
-    #virtual-keyboard-keys { gap: 3px; padding: 6px; }
-    .vk-row { gap: 3px; }
-    .vk-key { min-height: 38px; font-size: 11px; }
+    #virtual-keyboard-keys { gap: 3px; padding: 6px; overflow-x: hidden; }
+    .vk-row { gap: 3px; min-width: 0; width: 100%; }
+    /* Let the flex-unit widths shrink proportionally instead of forcing a 530px row. */
+    #virtual-keyboard .vk-key, #virtual-keyboard .vk-spacer { min-width: 0; }
+    .vk-key {
+      min-height: 38px; overflow: hidden;
+      font-size: clamp(8px, 3vw, 11px);
+    }
+    #virtual-keyboard .vk-key.delete,
+    #virtual-keyboard .vk-key.control,
+    #virtual-keyboard .vk-key.return { font-size: clamp(6px, 2.2vw, 9px); }
+    #virtual-keyboard .vk-key.caps { font-size: clamp(5px, 1.9vw, 8px); }
     #ide { min-width: 0; }
   }
 </style>

--- a/web/test_virtual_keyboard.cjs
+++ b/web/test_virtual_keyboard.cjs
@@ -152,6 +152,24 @@ assert(
   skipControlIndex < canvasIndex && canvasIndex < keyboardSummaryIndex,
   "skip control, emulator canvas, and virtual-keyboard summary must remain in focus order",
 );
+const phoneStylesIndex = pageHtml.indexOf("@media (max-width: 480px)");
+assert(phoneStylesIndex >= 0, "page must include phone-width styles");
+const phoneStyles = pageHtml.slice(phoneStylesIndex, pageHtml.indexOf("</style>", phoneStylesIndex));
+assert.match(
+  phoneStyles,
+  /#virtual-keyboard-keys\s*\{[^}]*overflow-x:\s*hidden;/s,
+  "phone keyboard must not scroll horizontally",
+);
+assert.match(
+  phoneStyles,
+  /\.vk-row\s*\{[^}]*min-width:\s*0;/s,
+  "phone keyboard rows must fit their container",
+);
+assert.match(
+  phoneStyles,
+  /#virtual-keyboard \.vk-key,\s*#virtual-keyboard \.vk-spacer\s*\{[^}]*min-width:\s*0;/s,
+  "phone key and spacer minimums must collapse so flex units can scale",
+);
 
 const document = new FakeDocument();
 const mountPoint = new FakeElement(document);


### PR DESCRIPTION
## Summary
- fit virtual-keyboard rows to the available panel width at 480px and below
- preserve Apple IIe relative key widths while scaling labels for narrow screens
- document and regression-test the no-horizontal-scroll contract

## Verification
- web/test_virtual_keyboard.cjs
- headless Edge layout measurements at 320px, 390px, and 480px