### PR TITLE
web: add cookieless GoatCounter usage analytics to all site pages

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -199,6 +199,15 @@ client-side so GitHub Pages can host it as static files.
   `build.ps1`) plus an entry in `gallery.json` — so every featured program credits its author
   and turns a visitor into a contributor. The page builds card text with `textContent` only:
   the manifest is repo-reviewed, but no entry field is ever injected as HTML.
+- **Usage analytics are privacy-first and cookieless.** Every staged HTML page
+  (`index.html`, `gallery.html`, `tutorials.html`, `story.html`) loads one async GoatCounter
+  snippet in `<head>` — `data-goatcounter="https://3ric.goatcounter.com/count"`, script
+  `//gc.zgo.at/count.js`. It sets no cookies, stores no personal data, and needs no server: a
+  page hit is a fire-and-forget beacon and nothing else. Totals live on the owner-only
+  dashboard at <https://3ric.goatcounter.com>. It is inert if blocked (ad blocker/offline) and
+  the emulator never depends on it. The pages declare no `Content-Security-Policy`, so no CSP
+  allowlist entry is required today; if one is ever added it must allow `gc.zgo.at` and
+  `*.goatcounter.com`.
 
 ## Data flow
 
@@ -214,6 +223,10 @@ insertDisk()/loadSD() → C600G / EC5CG`.
 Gallery: `gallery.html → fetch gallery.json → render cards → click Run & Remix →
 index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 
+Analytics: `any page load → async GoatCounter beacon (//gc.zgo.at/count.js) →
+POST https://3ric.goatcounter.com/count`. Fire-and-forget; no cookies, no PII, and no effect
+on the emulator whether it succeeds, is blocked, or 404s.
+
 ## Dependencies
 
 - **Upstream:** the VM core (`EMULATOR.md`), the ROM/font/disk/SD data (`ROM-SOFTWARE.md`),
@@ -226,6 +239,11 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
   + `story.html` + `llms.txt` + `robots.txt` + `sitemap.xml` (alongside `index.html` and
   `programs/`) into `_site/`; the public users of the demo, and AI coding tools that fetch
   `llms.txt`.
+- **External (analytics):** GoatCounter — the `//gc.zgo.at/count.js` script and the
+  `https://3ric.goatcounter.com/count` endpoint. A privacy-friendly, third-party hit counter
+  loaded by every staged HTML page; best-effort and non-essential — the site behaves
+  identically if it is blocked or the snippet is removed. Owner-managed account (the login is
+  ebadger's; nothing about it is committed to the repo).
 
 ## Implementation Status
 
@@ -249,3 +267,4 @@ index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 | Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the combined speaker/dual-AY stereo PCM; sound enabled only at 1x. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/input/audio/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |
+| Usage analytics (GoatCounter) | Shipped | Cookieless, privacy-first hit counter on all staged pages (`index`/`gallery`/`tutorials`/`story`); async `//gc.zgo.at/count.js` → `3ric.goatcounter.com`; no cookies/PII, no server, no CSP change. Owner dashboard `https://3ric.goatcounter.com` (register the `3ric` code once to claim it). |

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -5,7 +5,7 @@
 > no status. Move historical detail to `status/CHANGELOG.md` and deep runbooks to
 > `docs/runbooks/`.
 
-_Last updated: 2026-07-14 — ebadger (via Copilot)_
+_Last updated: 2026-07-15 — ebadger (via Copilot)_
 
 ---
 
@@ -93,5 +93,9 @@ secrets. Nothing to configure and nothing to commit. (The only "secret" is the s
   Self-booting machine-code disks work.
 - **CI:** `deploy-pages.yml` rebuilds and publishes to GitHub Pages on every push to `main`
   that touches the emulator/web/codegen sources it lists.
+- **Usage analytics:** every staged page loads a privacy-first, cookieless **GoatCounter**
+  counter (`//gc.zgo.at/count.js` → `https://3ric.goatcounter.com/count`); no cookies, no PII,
+  no server, and the site is unaffected if it is blocked. Totals live on the owner dashboard at
+  <https://3ric.goatcounter.com> — **register the `3ric` code there once to claim the stats.**
 - **Hardware:** schematics, PCB, and 22V10 GAL logic are in progress and tracked through the
   YouTube build series; the emulator is the reference implementation of the target machine.

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Privacy-first, cookieless usage analytics (GoatCounter): no cookies, no PII, no server;
+     the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
+<script data-goatcounter="https://3ric.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 <title>3ric — Program Gallery</title>
 <style>
   :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Privacy-first, cookieless usage analytics (GoatCounter): no cookies, no PII, no server;
+     the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
+<script data-goatcounter="https://3ric.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 <title>3ric — Apple-II-clone 65C02 (WebAssembly)</title>
 <style>
   :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; --key-alt:#75bd89; }

--- a/web/story.html
+++ b/web/story.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Privacy-first, cookieless usage analytics (GoatCounter): no cookies, no PII, no server;
+     the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
+<script data-goatcounter="https://3ric.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 <title>3ric — The Story: I built a 6502 computer that speaks Apple II</title>
 <meta name="description" content="The story of 3ric — I set out to learn how 8-bit computers really work, so I built one from a pile of chips. It's an original design, not an Apple II clone, but it speaks enough Apple II to run Lode Runner and finish Ultima IV — hardware-generated VGA with artifact color reproduced in logic I designed. Run it in your browser, and export bootable .woz disks that boot on a real Apple II." />
 <meta property="og:type" content="website" />

--- a/web/tutorials.html
+++ b/web/tutorials.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Privacy-first, cookieless usage analytics (GoatCounter): no cookies, no PII, no server;
+     the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
+<script data-goatcounter="https://3ric.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 <title>3ric — 65C02 Game Dev Tutorials</title>
 <meta name="description" content="Learn 65C02 assembly game programming on the 3ric, from Hello World to Space Invaders — eight browser-runnable lessons." />
 <style>


### PR DESCRIPTION
## What & why

You asked how to measure usage of the live site (<https://ebadger.github.io/3ric/>). GitHub Pages has **no built-in visitor analytics** (the repo's Insights → Traffic only counts github.com repo views/clones, not visits to the deployed site), so measuring it needs a small client-side snippet.

This adds **GoatCounter** — a privacy-friendly, **cookieless**, open-source hit counter — as a single async `<script>` in the `<head>` of every staged page:

- `web/index.html` (emulator)
- `web/gallery.html`
- `web/tutorials.html`
- `web/story.html`

```html
<script data-goatcounter="https://3ric.goatcounter.com/count"
        async src="//gc.zgo.at/count.js"></script>
```

No cookies, no server. The site behaves identically if the beacon is blocked/offline — the emulator never depends on it. The snippet is inline, so the deploy workflow needs no change (all four pages are already staged).

## ✅ Analytics account registered

The owner has **registered the `3ric` GoatCounter code**, so hits appear on the owner-only dashboard at <https://3ric.goatcounter.com> once this deploys. The setup snippet GoatCounter provides matches the one added here verbatim.

## Layers touched (per §1 checklist)

Web client only — static HTML. No memory-map / C++ / 6502 / codegen impact.

## Specs updated in the same commit (§3/§4)

- `specs/WEB-CLIENT.md` — new Behaviour rule, Data-flow line, Dependencies entry, Implementation-Status row.
- `status/SYSTEM-STATUS.md` — usage-analytics note.

## Verification

- Snippet present in the `<head>` of all four pages; official current GoatCounter form (`//gc.zgo.at/count.js`).
- Pages declare no `Content-Security-Policy`, so no allowlist change is required.
- Pre-push gate green (learnings budget OK; 65C02 assembler tests PASS). HTML-only change; unaffected WASM/boot tests not exercised.

## Second-model review

- Reviewed diff: `9a288541...b49b25d3`
- GPT Reviewer (`gpt-5.6-sol`): **BLOCK** — 3 findings
- Gemini Reviewer (`gemini-3.1-pro-preview`): **BLOCK** — 3 findings
- Resolved: **0 fixed, 4 accepted/overridden** per the owner's decision to ship as-is:
  - **Ownership** (BLOCK, both) — **RESOLVED**: owner registered the `3ric` code.
  - **Query-string leak** (HIGH, GPT) — accepted/overridden: verified real — the editor's Share/Remix `?code=`/`?src=`/`?prg=` deep links send program source in the URL, which GoatCounter records. Accepted as a known caveat (usage counting only; don't share sensitive `?code=` links if that matters).
  - **No SRI/CSP on third-party `count.js`** (MED, both) — accepted/overridden: SRI on GoatCounter's *rolling* file breaks on their updates; a strict CSP risks breaking Emscripten/WASM + AudioWorklet and needs dedicated testing.
  - **Protocol-relative URL** (MED, Gemini) — accepted/overridden: `https` resolves correctly on the deployed HTTPS Pages site.
- Full **verbatim** reviewer output, per-finding tags, and per-model `Scorecard` lines: see the [review-record PR comment](https://github.com/ebadger/3ric/pull/52#issuecomment-4984403595).

## Alternatives considered

Cloudflare Web Analytics (also free/cookieless), Plausible/Fathom (paid), GA4 (free but cookies + privacy overhead — rejected for the project's privacy-first, no-secrets ethos).