### PR TITLE
Rebrand web experience as 3RIC Studio

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -44,6 +44,11 @@ client-side so GitHub Pages can host it as static files.
   against Pages instead of serving a stale `max-age=600` copy — a freshly deployed program
   shows up on the next selection without a hard refresh. (There is no service worker, and
   GitHub Pages purges its CDN on every deploy, so the revalidation returns the new source.)
+- **Site identity:** the published web experience is branded **3RIC Studio** in page titles,
+  visible page headers and footers, social metadata, the gallery manifest, and `llms.txt`.
+  **3RIC** remains the name of the computer itself. Existing repository/Page URLs, the
+  `3ric.goatcounter.com` analytics endpoint, and `3ric.editor.*` local-storage keys stay
+  unchanged so the rebrand does not break links, metrics, or browser-saved source.
 - **Mobile virtual keyboard (`virtual-keyboard.js` + `index.html`):** a collapsed
   `<details>` panel directly below the emulator canvas renders the five-row keyboard from
   the **1983 Apple IIe Owner's Manual, Figure 2-1**, without invoking the phone's incomplete
@@ -259,6 +264,7 @@ on the emulator whether it succeeds, is blocked, or 404s.
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |
 | Story / landing page | Shipped | `story.html` — narrative of 3ric + the wider hardware-hacking journey; lite-embed YouTube chapters (facade → `youtube-nocookie` iframe on click); a curated real-time **Reddit timeline** (16 `r/beneater`/maker milestone posts, 2020–2025, each linking to its permalink); links to emulator/gallery/tutorials + `r/beneater` / `u/ebadger1973` / 6502.org. Linked from the `index.html`/`gallery.html`/`tutorials.html` headers; staged by the deploy workflow. |
+| 3RIC Studio site identity | Shipped | Published page titles, headers, footers, metadata, gallery attribution, and `llms.txt` use **3RIC Studio**; machine references remain **3RIC**, and compatibility-sensitive URLs/storage keys remain unchanged. |
 | AI-contributor entry point (`llms.txt`) | Shipped | machine-readable 65C02 codegen quickstart + links; published at the site root, staged by the deploy workflow. |
 | `llms.txt` discoverability | Shipped | `<link rel="alternate">` + footer links in `index.html`/`gallery.html`; `robots.txt` + `sitemap.xml` staged (advisory on the project-page root; authoritative under a custom domain). |
 | Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |

--- a/web/README.md
+++ b/web/README.md
@@ -1,7 +1,8 @@
-# 3ric — Apple-II-clone 65C02 emulator in the browser (WebAssembly)
+# 3RIC Studio — 65C02 emulator and editor in the browser (WebAssembly)
 
-This folder is a self-contained Emscripten/WebAssembly port of the `3ric` 65C02
-Apple-II-clone emulator. It compiles the existing C++ VM core
+This folder powers **3RIC Studio**, the browser-based emulator, editor, gallery, and
+learning hub for the `3RIC` Apple-II-class 65C02 computer. It compiles the existing C++
+VM core
 (`emulator/Badger6502VMLib`) and disk library (`emulator/WozLib`) to WebAssembly,
 boots the real 512KB ROM, renders Apple-II text/hi-res/lo-res video to an HTML
 `<canvas>`, feeds keyboard and gamepad input through the machine's hardware paths,
@@ -171,7 +172,7 @@ Implementation notes:
 
 ## Community Gallery
 
-`gallery.html` is a lightweight, WASM-free showcase of programs written for 3ric,
+`gallery.html` is a lightweight, WASM-free showcase of programs written for 3RIC,
 linked from the emulator header. It fetches the committed **`gallery.json`** manifest
 and renders one card per program; each card's **&#9654; Run & Remix** button is just a
 `?src=`/`?code=` deep link into `index.html`, so a click loads the source into the

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -7,7 +7,9 @@
      the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
 <script data-goatcounter="https://3ric.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<title>3ric — Program Gallery</title>
+<title>3RIC Studio — Program Gallery</title>
+<meta name="application-name" content="3RIC Studio" />
+<meta name="description" content="Browse, run, remix, and share 65C02 programs in the 3RIC Studio community gallery." />
 <style>
   :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }
   * { box-sizing: border-box; }
@@ -58,7 +60,7 @@
 </head>
 <body>
   <header>
-    <h1>3ric&nbsp;&mdash;&nbsp;Program&nbsp;Gallery</h1>
+    <h1>3RIC&nbsp;Studio&nbsp;&mdash;&nbsp;Program&nbsp;Gallery</h1>
     <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
     <a class="nav" href="story.html">&#9654;&nbsp;Story</a>
     <a class="nav" href="tutorials.html">&#9654;&nbsp;Tutorials</a>
@@ -66,7 +68,7 @@
   </header>
   <main>
     <p class="intro">
-      Programs written for 3ric &mdash; the from-scratch Apple-II-class 65C02 machine that
+      Programs written for 3RIC &mdash; the from-scratch Apple-II-class 65C02 machine that
       runs in your browser. Pick one to <strong>run it instantly</strong> and open its source
       in the editor, where you can tweak it and <strong>Share your own remix</strong>.
       Made something cool? <a href="index.html">Build it in the editor</a> and add it below.
@@ -74,7 +76,7 @@
     <div id="grid" role="list"></div>
   </main>
   <footer>
-    3ric Program Gallery &middot;
+    3RIC Studio Program Gallery &middot;
     <a href="index.html">Emulator</a> &middot;
     <a href="story.html">Story</a> &middot;
     <a href="https://github.com/ebadger/3ric" target="_blank" rel="noopener noreferrer">Source</a> &middot;

--- a/web/gallery.json
+++ b/web/gallery.json
@@ -1,19 +1,19 @@
 {
   "version": 1,
-  "_readme": "Community Gallery manifest for the 3ric web client. Each entry becomes a card on gallery.html with a one-click 'Run & Remix' link into the in-browser editor. To feature your own program: add its .s source under codegen/programs/ (build.ps1 stages every codegen/programs/*.s into web/programs/) and append an entry below, then open a pull request. Fields: title (required), author, authorUrl, mode (Hi-res|Lo-res|Text|Serial), description, tags[]; and a run target of either src ('programs/<name>.s') or an inline code (URL-safe base64 for ?code=), plus an optional org (hex load address, only when the source has no .org directive).",
+  "_readme": "Community Gallery manifest for 3RIC Studio. Each entry becomes a card on gallery.html with a one-click 'Run & Remix' link into the in-browser editor. To feature your own program: add its .s source under codegen/programs/ (build.ps1 stages every codegen/programs/*.s into web/programs/) and append an entry below, then open a pull request. Fields: title (required), author, authorUrl, mode (Hi-res|Lo-res|Text|Serial), description, tags[]; and a run target of either src ('programs/<name>.s') or an inline code (URL-safe base64 for ?code=), plus an optional org (hex load address, only when the source has no .org directive).",
   "entries": [
     {
       "title": "Hello, KansasFest 2026",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/kfest.s",
-      "description": "3ric's zero-install greeting to the Apple II crowd for KansasFest 2026 — a framed text welcome you can run, remix, and re-share right in the browser. No install, no account.",
+      "description": "3RIC Studio's zero-install greeting to the Apple II crowd for KansasFest 2026 — a framed text welcome you can run, remix, and re-share right in the browser. No install, no account.",
       "tags": ["demo", "text", "kansasfest", "greeting"]
     },
     {
       "title": "Swarm",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Hi-res",
       "src": "programs/swarm.s",
@@ -22,7 +22,7 @@
     },
     {
       "title": "Rocks",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Hi-res",
       "src": "programs/rocks.s",
@@ -31,7 +31,7 @@
     },
     {
       "title": "Jungle Quest: Sunstone Run",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Hi-res",
       "src": "programs/jungle.s",
@@ -40,7 +40,7 @@
     },
     {
       "title": "Snake",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Lo-res",
       "src": "programs/snake.s",
@@ -49,7 +49,7 @@
     },
     {
       "title": "Game of Life",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Lo-res",
       "src": "programs/life.s",
@@ -58,7 +58,7 @@
     },
     {
       "title": "Blocks",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/blocks.s",
@@ -67,7 +67,7 @@
     },
     {
       "title": "Bricks",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/bricks.s",
@@ -76,7 +76,7 @@
     },
     {
       "title": "Paddles",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/paddles.s",
@@ -85,7 +85,7 @@
     },
     {
       "title": "2048",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/2048.s",
@@ -94,7 +94,7 @@
     },
     {
       "title": "Minesweeper",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Text",
       "src": "programs/mines.s",
@@ -103,11 +103,11 @@
     },
     {
       "title": "Hello, world",
-      "author": "3ric",
+      "author": "3RIC Studio",
       "authorUrl": "https://github.com/ebadger/3ric",
       "mode": "Serial",
       "src": "programs/hello.s",
-      "description": "A tiny greeting printed via COUT ($FDED), then BRK back to the monitor — the perfect starting point for your first 3ric program.",
+      "description": "A tiny greeting printed via COUT ($FDED), then BRK back to the monitor — the perfect starting point for your first 3RIC program.",
       "tags": ["demo", "serial", "starter"]
     }
   ]

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,9 @@
      the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
 <script data-goatcounter="https://3ric.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<title>3ric — Apple-II-clone 65C02 (WebAssembly)</title>
+<title>3RIC Studio — 65C02 Emulator &amp; Editor</title>
+<meta name="application-name" content="3RIC Studio" />
+<meta name="description" content="3RIC Studio is a zero-install browser emulator and 65C02 development environment for the from-scratch 3RIC computer." />
 <style>
   :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; --key-alt:#75bd89; }
   * { box-sizing: border-box; }
@@ -163,8 +165,8 @@
 </head>
 <body>
   <header>
-    <h1>3ric&nbsp;&mdash;&nbsp;Apple-II-clone&nbsp;65C02&nbsp;(WebAssembly)</h1>
-    <a class="nav" href="story.html" title="The story of 3ric + the build series">&#9654;&nbsp;Story</a>
+    <h1>3RIC&nbsp;Studio&nbsp;&mdash;&nbsp;65C02&nbsp;Emulator&nbsp;&amp;&nbsp;Editor</h1>
+    <a class="nav" href="story.html" title="The story of 3RIC + the build series">&#9654;&nbsp;Story</a>
     <a class="nav" href="tutorials.html" title="Learn 65C02 game programming step by step">&#9654;&nbsp;Tutorials</a>
     <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
     <button id="reset">Reset</button>
@@ -197,7 +199,7 @@
       <details id="virtual-keyboard">
         <summary id="virtual-keyboard-summary">VIRTUAL KEYBOARD <span class="vk-summary-hint">1983 Apple IIe layout</span></summary>
         <div id="virtual-keyboard-keys" role="group" aria-label="Virtual emulator keyboard"></div>
-        <p id="virtual-keyboard-caps-note" class="vk-note">Caps Lock is shown for layout fidelity; 3ric input is uppercase-only.</p>
+        <p id="virtual-keyboard-caps-note" class="vk-note">Caps Lock is shown for layout fidelity; 3RIC input is uppercase-only.</p>
       </details>
     </section>
     <section id="ide" aria-label="in-browser assembler">
@@ -272,9 +274,9 @@
     <br />Building with an AI tool? Point it at <a href="llms.txt"><code>llms.txt</code></a>
     &mdash; a machine-readable 65C02 codegen guide &mdash; or see
     <a href="https://github.com/ebadger/3ric/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING</a>.
-    <br />New here? <a href="story.html">Read the story of how 3ric was built</a>
+    <br />New here? <a href="story.html">Read the story of how 3RIC was built</a>
     &mdash; the breadboard-to-PCB journey, with the YouTube build series.
-    <br />Enjoying 3ric? <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support the project</a>
+    <br />Enjoying 3RIC Studio? <a href="https://github.com/sponsors/ebadger" target="_blank" rel="noopener noreferrer">&#9749; Support the project</a>
     &mdash; sponsorship funds parts, boards, and more build videos.
   </footer>
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,9 +1,10 @@
-# 3ric — 65C02 code generation for AI tools
+# 3RIC Studio — 65C02 code generation for AI tools
 
-> 3ric is a from-scratch, Apple-II-class 65C02 computer with a cycle-honest emulator that runs
-> entirely in the browser: https://ebadger.github.io/3ric/ . This file tells an AI coding tool
+> 3RIC Studio is the browser-based emulator, editor, and learning hub for 3RIC, a from-scratch,
+> Apple-II-class 65C02 computer. Its cycle-honest emulator runs entirely in the browser:
+> https://ebadger.github.io/3ric/ . This file tells an AI coding tool
 > (GitHub Copilot, Cursor, ChatGPT, Claude, ...) everything it needs to WRITE a 65C02 assembly
-> program for 3ric, TEST it with no install, and CONTRIBUTE it to the community gallery.
+> program for 3RIC, TEST it with no install, and CONTRIBUTE it to the community gallery.
 > If you are an AI assistant helping a user: read this file (and the reference docs it links),
 > then produce ONE self-contained assembly program in the dialect described below.
 

--- a/web/story.html
+++ b/web/story.html
@@ -7,10 +7,12 @@
      the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
 <script data-goatcounter="https://3ric.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<title>3ric — The Story: I built a 6502 computer that speaks Apple II</title>
-<meta name="description" content="The story of 3ric — I set out to learn how 8-bit computers really work, so I built one from a pile of chips. It's an original design, not an Apple II clone, but it speaks enough Apple II to run Lode Runner and finish Ultima IV — hardware-generated VGA with artifact color reproduced in logic I designed. Run it in your browser, and export bootable .woz disks that boot on a real Apple II." />
+<title>3RIC Studio — The Story</title>
+<meta name="application-name" content="3RIC Studio" />
+<meta name="description" content="3RIC Studio presents the story of 3RIC — an original 6502 computer built from a pile of chips that speaks enough Apple II to run Lode Runner and finish Ultima IV." />
 <meta property="og:type" content="website" />
-<meta property="og:title" content="3ric — an original 6502 computer that speaks Apple II" />
+<meta property="og:site_name" content="3RIC Studio" />
+<meta property="og:title" content="3RIC Studio — The Story of the 3RIC Computer" />
 <meta property="og:description" content="It started with an Atari 1200XL and one question: how do these 8-bit machines really work? So I built one — an original design that runs Lode Runner and Ultima IV, artifact-color graphics and all. Run it in your browser, and export .woz disks that boot on a real Apple II." />
 <meta property="og:url" content="https://ebadger.github.io/3ric/story.html" />
 <meta property="og:image" content="https://i.ytimg.com/vi/e65qVK7zNGM/hqdefault.jpg" />
@@ -122,7 +124,7 @@
 </head>
 <body>
   <header>
-    <h1>3ric&nbsp;&mdash;&nbsp;The&nbsp;Story</h1>
+    <h1>3RIC&nbsp;Studio&nbsp;&mdash;&nbsp;The&nbsp;Story</h1>
     <a class="nav" href="index.html" title="Run the machine in your browser">&#9654;&nbsp;Emulator &amp; Editor</a>
     <a class="nav" href="tutorials.html" title="Learn 65C02 game programming">&#9654;&nbsp;Tutorials</a>
     <a class="nav" href="gallery.html" title="Browse the community program gallery">&#9654;&nbsp;Gallery</a>
@@ -147,7 +149,7 @@
         now in your browser</strong> &mdash; and even build Apple&nbsp;II software with it.
       </p>
       <div class="cta">
-        <a class="btn" href="index.html">&#9654;&nbsp;Run 3ric in your browser</a>
+        <a class="btn" href="index.html">&#9654;&nbsp;Run 3RIC in your browser</a>
         <a class="btn ghost" href="https://www.youtube.com/playlist?list=PLbYLt1iawSBLK4w46Kn7cxxuoeVt7Zepq" target="_blank" rel="noopener noreferrer">Watch the build series</a>
       </div>
     </section>
@@ -557,7 +559,7 @@
   </main>
 
   <footer>
-    3ric &mdash; The Story &middot;
+    3RIC Studio &mdash; The Story &middot;
     <a href="index.html">Emulator</a> &middot;
     <a href="tutorials.html">Tutorials</a> &middot;
     <a href="gallery.html">Gallery</a> &middot;

--- a/web/tutorials.html
+++ b/web/tutorials.html
@@ -7,8 +7,9 @@
      the site works identically if it is blocked/offline. Owner dashboard: https://3ric.goatcounter.com -->
 <script data-goatcounter="https://3ric.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<title>3ric — 65C02 Game Dev Tutorials</title>
-<meta name="description" content="Learn 65C02 assembly game programming on the 3ric, from Hello World to Space Invaders — eight browser-runnable lessons." />
+<title>3RIC Studio — 65C02 Game Dev Tutorials</title>
+<meta name="application-name" content="3RIC Studio" />
+<meta name="description" content="Learn 65C02 assembly game programming on 3RIC, from Hello World to Space Invaders — eight browser-runnable lessons in 3RIC Studio." />
 <style>
   :root { --bg:#0b0e0c; --fg:#33ff66; --dim:#1d6b33; --panel:#11140f; }
   * { box-sizing: border-box; }
@@ -59,16 +60,16 @@
 </head>
 <body>
   <header>
-    <h1>3ric&nbsp;&mdash;&nbsp;65C02&nbsp;Game&nbsp;Dev&nbsp;Tutorials</h1>
+    <h1>3RIC&nbsp;Studio&nbsp;&mdash;&nbsp;65C02&nbsp;Game&nbsp;Dev&nbsp;Tutorials</h1>
     <a class="nav" href="index.html">&#9654;&nbsp;Emulator &amp; Editor</a>
     <a class="nav" href="story.html">&#9654;&nbsp;Story</a>
     <a class="nav" href="gallery.html">&#9654;&nbsp;Gallery</a>
   </header>
   <main>
     <p class="intro">
-      An eight-lesson course in <strong>65C02 assembly game programming</strong> on 3ric &mdash;
+      An eight-lesson course in <strong>65C02 assembly game programming</strong> on 3RIC &mdash;
       the from-scratch Apple-II-class machine that runs in your browser. Start at
-      <em>Hello, 3ric</em> and build up to a playable <strong>Space Invaders</strong>. Every
+      <em>Hello, 3RIC</em> and build up to a playable <strong>Space Invaders</strong>. Every
       lesson comes with a small, fully-commented program you can <strong>run with one click</strong>,
       edit in the <a href="index.html">in-browser editor</a>, and re-share. No install, no account.
       Read the lessons in order &mdash; each one reuses the routines from the last.
@@ -76,7 +77,7 @@
     <div id="grid" role="list">
 
       <div class="card" role="listitem">
-        <div class="cardhead"><span class="badge">Lesson 1</span><h2>Hello, 3ric</h2></div>
+        <div class="cardhead"><span class="badge">Lesson 1</span><h2>Hello, 3RIC</h2></div>
         <p class="desc">Your first program end-to-end: type it, assemble it, run it. Print
           text with the ROM&rsquo;s character-out routine.</p>
         <p class="learn">New: the assembler, <code>COUT</code>, the run loop.</p>
@@ -166,7 +167,7 @@
     </div>
   </main>
   <footer>
-    3ric Game Dev Tutorials &middot;
+    3RIC Studio Game Dev Tutorials &middot;
     <a href="index.html">Emulator</a> &middot;
     <a href="story.html">Story</a> &middot;
     <a href="gallery.html">Gallery</a> &middot;


### PR DESCRIPTION
## Summary
- brand every published web page as **3RIC Studio** across titles, visible headers and footers, descriptions, and social metadata
- keep **3RIC** as the computer name while preserving repository/Page URLs, GoatCounter, and existing editor local-storage keys
- update gallery attribution, `llms.txt`, the web README, and the web-client specification

## Validation
- static branding contract check across all four HTML pages and 12 gallery entries
- `web/test_virtual_keyboard.cjs`
- repository pre-push test gate

## Second-model review
- Reviewed diff: `ca93c6798e98739261afcf1d9af12c79aee7ec57...96617fe0b2dac0e04d82592beea475b1775483ea`
- GPT Reviewer (`gpt-5.6-sol`): LGTM — 0 findings
- Gemini Reviewer (`gemini-3.1-pro-preview`): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden