### PR TITLE
Add browser source debugger

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -72,6 +72,7 @@ jobs:
           node web/test_mockingboard.cjs
           node web/test_gamepad.cjs
           node web/test_virtual_keyboard.cjs
+          node web/test_debugger.cjs
           node web/test_keyboard.cjs
           node web/test_boot.cjs
 
@@ -79,7 +80,7 @@ jobs:
       - name: Stage site
         run: |
           mkdir -p _site
-          cp web/index.html web/emulation-clock.js web/audio-worklet.js web/gamepad.js web/virtual-keyboard.js web/gallery.html web/tutorials.html web/story.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
+          cp web/index.html web/emulation-clock.js web/audio-worklet.js web/gamepad.js web/virtual-keyboard.js web/debugger.js web/gallery.html web/tutorials.html web/story.html web/gallery.json web/llms.txt web/robots.txt web/sitemap.xml web/badger6502.js web/badger6502.wasm _site/
           cp web/asm6502.mjs web/wozgen.mjs _site/
           cp -r web/data _site/data
           cp -r web/programs _site/programs

--- a/codegen/SPEC.md
+++ b/codegen/SPEC.md
@@ -36,6 +36,7 @@ in a headless harness."
 | `seedBasicRom()`, `loadFont(bytes)`, `loadSD(bytes)` | Standard boot setup + attach the FAT32 SD sparse image |
 | `reset()` | Load PC from the reset vector `$FFFC` |
 | `run(maxSteps)` | Cooperatively step the CPU (never uses the blocking `VM::Run`) |
+| `step()` / breakpoint methods | Execute exactly one instruction or stop `run*` before a configured PC (browser debugger) |
 | `setPC(addr)` | Jump directly to an address (for RAM-loaded test runs) |
 | `poke(addr,v)` / `peek(addr)` | Byte access to the bus |
 | `keyDown(code)` | Memory-mapped `$C000` keyboard strobe (drives the DOS shell) |
@@ -127,6 +128,27 @@ The generated program therefore just needs to be assembled at a chosen ORG and
 be entered at that ORG; the manifest records that ORG as the `BRUN` address.
 (The exact `BSAVE` argument form used to *write* a file from the shell is still
 confirmed empirically in Phase 0 (§10); `BRUN` itself is settled.)
+
+### 2.5 Browser debugger metadata
+
+The dependency-free assembler's result includes a `listing` record for each statement that
+emits bytes:
+
+```js
+{ pc: 0x0800, bytes: [0xA9, 0x01], line: 12, kind: "instruction" }
+```
+
+`line` is one-based and `kind` is either `instruction` or `data`. This is additive to the
+existing `org`, `bytes`, and `symbols` result, remains browser-safe, and is the authoritative
+map used by 3RIC Studio for source breakpoints and current-PC highlighting. Directives are
+shown for context but are not offered as executable breakpoints.
+
+The browser's WebVM wrapper keeps breakpoint tests inside its C++ instruction loops and
+exposes a one-instruction `step()` operation. This preserves normal execution throughput
+while allowing exact pre-instruction stops. Separately, the web build stages the existing
+ca65 `emulator/Data/badger6502.dbg`; a dependency-free browser parser can map ROM PCs to
+symbols and source filename/line coordinates. The corresponding ROM source text is not
+present in this repository and is therefore not part of the browser payload.
 
 ## 3. How the physical-SD requirement changes the original plan
 

--- a/codegen/tools/asm6502.mjs
+++ b/codegen/tools/asm6502.mjs
@@ -267,7 +267,7 @@ export function assemble(source, opts = {}) {
       const items = args.map((a) => a[0] === '"' ? { str: a } : { expr: a });
       let len = 0;
       for (const it of items) len += it.str ? parseString(it.str, lineNo).length : 1;
-      records.push({ pc: startPc, len, gen: (sym) => {
+      records.push({ pc: startPc, len, line: lineNo, kind: "data", gen: (sym) => {
         const b = [];
         for (const it of items) {
           if (it.str) b.push(...parseString(it.str, lineNo));
@@ -283,7 +283,7 @@ export function assemble(source, opts = {}) {
       const startPc = pc;
       let len = 1;
       for (const a of args) len += a[0] === '"' ? parseString(a, lineNo).length : 1;
-      records.push({ pc: startPc, len, gen: (sym) => {
+      records.push({ pc: startPc, len, line: lineNo, kind: "data", gen: (sym) => {
         const b = [];
         for (const a of args) b.push(...(a[0] === '"' ? parseString(a, lineNo) : [evalExpr(a, sym, startPc, lineNo) & 0xFF]));
         b.push(0); return b;
@@ -294,7 +294,7 @@ export function assemble(source, opts = {}) {
       requireOrg(lineNo);
       const args = splitArgs(parsed.operand);
       const startPc = pc;
-      records.push({ pc: startPc, len: args.length * 2, gen: (sym) => {
+      records.push({ pc: startPc, len: args.length * 2, line: lineNo, kind: "data", gen: (sym) => {
         const b = [];
         for (const a of args) { const v = evalExpr(a, sym, startPc, lineNo) & 0xFFFF; b.push(v & 0xFF, (v >> 8) & 0xFF); }
         return b;
@@ -306,7 +306,7 @@ export function assemble(source, opts = {}) {
       const args = splitArgs(parsed.operand);
       const n = evalExpr(args[0], symbols, pc, lineNo);
       const fill = args.length > 1 ? evalExpr(args[1], symbols, pc, lineNo) & 0xFF : 0;
-      records.push({ pc, len: n, gen: () => new Array(n).fill(fill) });
+      records.push({ pc, len: n, line: lineNo, kind: "data", gen: () => new Array(n).fill(fill) });
       pc += n; return;
     }
     if (dir[0] === ".") throw new AsmError(`unknown directive "${mnem}"`, lineNo);
@@ -349,7 +349,7 @@ export function assemble(source, opts = {}) {
     const opcode = table[mode];
     const startPc = pc;
     const expr = po.expr;
-    records.push({ pc: startPc, len: size, gen: (sym) => {
+    records.push({ pc: startPc, len: size, line: lineNo, kind: "instruction", gen: (sym) => {
       if (mode === "imp" || mode === "acc") return [opcode];
       const v = evalExpr(expr, sym, startPc, lineNo);
       if (["imm","zp","zpx","zpy","izx","izy","izp"].includes(mode)) return [opcode, v & 0xFF];
@@ -375,7 +375,7 @@ export function assemble(source, opts = {}) {
     const bytes = r.gen(symbols);
     if (bytes.length !== r.len) throw new AsmError(`internal size mismatch at $${r.pc.toString(16)} (${bytes.length} != ${r.len})`);
     for (let k = 0; k < bytes.length; k++) out[r.pc - base + k] = bytes[k] & 0xFF;
-    listing.push({ pc: r.pc, bytes });
+    listing.push({ pc: r.pc, bytes, line: r.line, kind: r.kind });
   }
   return { org, bytes: out, symbols, listing };
 }

--- a/codegen/tools/asm6502.test.mjs
+++ b/codegen/tools/asm6502.test.mjs
@@ -9,6 +9,14 @@ function eqBytes(name, got, expected) {
   console.log(`${ok ? "PASS" : "FAIL"}  ${name}`);
   if (!ok) { console.log("   got     :", g); console.log("   expected:", e); }
 }
+function eqJson(name, got, expected) {
+  const g = JSON.stringify(got);
+  const e = JSON.stringify(expected);
+  const ok = g === e;
+  if (!ok) fails++;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}`);
+  if (!ok) { console.log("   got     :", g); console.log("   expected:", e); }
+}
 
 // 1) The full "HI via COUT" loop — verifies labels, abs,X, branches, .byte string.
 const hi = `
@@ -23,8 +31,21 @@ loop:   lda msg,x
 done:   brk
 msg:    .byte "HI", $8D, 0
 `;
-eqBytes("HI loop", assemble(hi).bytes,
+const hiResult = assemble(hi);
+eqBytes("HI loop", hiResult.bytes,
   [0xA2,0x00, 0xBD,0x0E,0x08, 0xF0,0x06, 0x20,0xED,0xFD, 0xE8, 0xD0,0xF5, 0x00, 0x48,0x49,0x8D,0x00]);
+eqJson("source listing metadata",
+  hiResult.listing.map(({ pc, line, kind }) => ({ pc, line, kind })),
+  [
+    { pc:0x0800, line:4, kind:"instruction" },
+    { pc:0x0802, line:5, kind:"instruction" },
+    { pc:0x0805, line:6, kind:"instruction" },
+    { pc:0x0807, line:7, kind:"instruction" },
+    { pc:0x080A, line:8, kind:"instruction" },
+    { pc:0x080B, line:9, kind:"instruction" },
+    { pc:0x080D, line:10, kind:"instruction" },
+    { pc:0x080E, line:11, kind:"data" },
+  ]);
 
 // 2) Addressing-mode coverage.
 const modes = `

--- a/specs/CODEGEN.md
+++ b/specs/CODEGEN.md
@@ -34,6 +34,9 @@ page, ROM entry points). These are
 **Assembler dialect:** `$hex` / `%bin` / decimal / char literals; labels; directives
 `.org`/`*=`, `.byte`, `.word`, `.res`, `.asciiz`; full 65C02 ISA + addressing modes;
 zero-page forcing; branch resolution. A source's own origin directive is authoritative.
+`assemble()` returns `listing` records for every emitted source statement. Each record
+contains its start PC, emitted bytes, one-based source line, and `instruction`/`data` kind;
+the browser debugger uses only instruction records as source-breakpoint targets.
 
 **Validation channels** (a program declares which it uses): serial (`drainOutput()`), text
 screen (decode `$0400`, 40×24 interleaved), graphics (`renderFrame()` RGBA), CPU/memory
@@ -56,8 +59,10 @@ screen (decode `$0400`, 40×24 interleaved), graphics (`renderFrame()` RGBA), CP
 
 ## Data flow
 
-`.s source → asm6502.assemble() → bytes + symbols → harness loads into RAM at --org → run →
-capture serial/text/gfx/regs → checks PASS/FAIL → optional .PRG (+ manifest)`.
+`.s source → asm6502.assemble() → bytes + symbols + source listing metadata → harness loads
+into RAM at --org → run → capture serial/text/gfx/regs → checks PASS/FAIL → optional .PRG
+(+ manifest)`. The browser additionally maps listing instruction PCs back to source rows for
+breakpoints and current-PC highlighting.
 
 ## Dependencies
 
@@ -71,6 +76,7 @@ capture serial/text/gfx/regs → checks PASS/FAIL → optional .PRG (+ manifest)
 | Item | Status | Notes |
 |------|--------|-------|
 | `asm6502` assembler + encoding tests | Shipped | dual-use; `asm6502.test.mjs`. |
+| Source listing metadata | Shipped | Each emitted record reports PC, bytes, source line, and instruction/data kind for browser debugging; covered by `asm6502.test.mjs`. |
 | `harness` + `run6502` validation loop | Shipped | serial/text/gfx/register checks + `.PRG`. |
 | `gen_platform_ref` platform reference | Shipped | from `vm.h` + `badger6502.dbg`. |
 | Sample programs | Shipped | `codegen/programs/hello.s`; games under `emulator/AICodeGen/`. |

--- a/specs/SYSTEM.md
+++ b/specs/SYSTEM.md
@@ -84,5 +84,6 @@ them headlessly on the same WASM core. The "why" lives in `docs/MISSION.md`.
 | Micro-SD FAT32 + ROM DOS shell | Shipped |
 | Slot-4 dual-AY Mockingboard | Shipped |
 | WebAssembly browser build + in-browser assembler | Shipped |
+| Browser source debugger + ROM debug correlation | Shipped |
 | DOS 3.3 / Applesoft-dependent disks | Not supported (this clone's BASIC is generic MS-BASIC, not Applesoft) |
 | Hardware (KiCad/PCB/GAL) | In progress (documented in the build series) |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -26,7 +26,8 @@ client-side so GitHub Pages can host it as static files.
   `web/badger6502.js` + `web/badger6502.wasm` (git-ignored — regenerated).
 - **Bridge API (embind, `web_bridge.cpp`):** `loadData(addr, bytes)`, `seedBasicRom()`,
   `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
-  `runCycles(cycleBudget)`, `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial),
+  `runCycles(cycleBudget)`, `step()`, instruction-address breakpoint add/remove/clear/query
+  methods, `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial),
   `setGamepadState(index, pressedMask)`,
   `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM:
   centered system speaker summed with hard-panned Mockingboard AY channels),
@@ -74,6 +75,18 @@ client-side so GitHub Pages can host it as static files.
   disk image of the current program, generated fully client-side by `wozgen.mjs` (a
   dependency-free JS port of the `emulator/dsk2woz2` nibbliser). The `.woz` boots the program
   on a real Apple II or via `C600G` in the emulator.
+- **Source debugger (`index.html` + `debugger.js`):** assembled programs expose a source
+  listing whose instruction rows carry their generated address and can be toggled as
+  breakpoints. The debugger can pause/continue, step one instruction, step over an absolute
+  `JSR`, add an arbitrary hexadecimal PC breakpoint, inspect raw memory without triggering
+  device side effects, and display the live register set already exposed by the bridge.
+  Breakpoint checks stay inside `WebVM`'s native instruction loop so normal-speed and Max
+  execution do not cross the JS/WASM boundary once per instruction. The checked-in ca65
+  `badger6502.dbg` is staged as a lazy-loaded data asset; while execution is outside the
+  assembled image, `debugger.js` correlates a ROM PC to an exact symbol and/or source
+  filename/line when that metadata exists. The ROM source text is not shipped in this
+  repository, so the browser identifies its listing coordinate rather than displaying the
+  original ROM source line.
 - **SD image:** `make_sd_sparse.py` streams `emulator/Data/sd.zip` (2 GB, mostly-zero FAT32)
   into `data/sd.sparse` (~11.5 MB `SDSP` container), fetched lazily.
 - **Gallery (`gallery.html` + `gallery.json`):** a lightweight, WASM-free showcase page that
@@ -173,6 +186,16 @@ client-side so GitHub Pages can host it as static files.
 - **Parity is the rule:** the WASM build must behave like the native build. Do not add
   behavior in the bridge that isn't in the shared core unless it's a genuinely
   presentation-only concern (canvas, clock pacing) — and never behind an unguarded fork.
+- Debugger stops are cooperative and instruction-boundary exact. `run()` and `runCycles()`
+  stop before executing an address breakpoint and expose that stop separately from
+  `WAI`/`STP`; `step()` deliberately executes one instruction even when the current PC has a
+  breakpoint. Continue first steps past a breakpoint at the current PC so it cannot
+  immediately retrigger. A PC held dormant by `WAI`/`STP` is not breakpoint-eligible until
+  the CPU can execute there, so continuing a waiting machine cannot loop on the same stop.
+  Step-over enters an absolute `JSR` once, then runs to its
+  three-byte fall-through address using a temporary breakpoint; every other opcode behaves
+  as step-into. Resetting or loading a program clears transient stop state but does not
+  silently discard user breakpoints.
 - Assets are relative so the site works under `/<repo>/` on Pages; the mandatory first-load
   payload is ~1.26 MB, with `disk.woz`/`sd.sparse` fetched only on demand.
 - **Share / Remix loop.** The editor's **Share** button copies a self-contained deep link
@@ -225,6 +248,11 @@ virtual-keyboard button→shared input queue→strobe-clear frame→keyDown()→
 Boot Disk/Mount SD →
 insertDisk()/loadSD() → C600G / EC5CG`.
 
+Debugger: `asm6502 listing metadata → source/address rows → user breakpoint set → WebVM
+instruction-loop check → cooperative pause before PC → registers + raw peek memory + source
+row highlight`; outside the assembled image, `badger6502.dbg → debugger.js ca65 parser →
+ROM symbol/file:line`.
+
 Gallery: `gallery.html → fetch gallery.json → render cards → click Run & Remix →
 index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
 
@@ -260,6 +288,7 @@ on the emulator whether it succeeds, is blocked, or 404s.
 | USB/Bluetooth gamepads | Shipped | Two stable player slots through the standard Gamepad API and shared SNES/VIA peripheral; covered by browser-mapping, serial-protocol, and ROM-table tests. |
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
 | In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. Sample sources fetched with `cache:"no-cache"` (revalidate) so a new deploy isn't masked by the browser cache. |
+| Source debugger | Shipped | Browser-assembled source listing with instruction breakpoints, pause/continue, step into/over, register and raw-memory inspection, plus lazy ca65 ROM symbol/file:line correlation; covered by `test_debugger.cjs`. |
 | Program downloads (.PRG / .woz) | Shipped | **Download .PRG** (raw bytes) + **Download .woz** (bootable WOZ2 via `wozgen.mjs`, a port of `dsk2woz2`, with a multi-track boot loader); verified by `web/test_woz_download.cjs`. |
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -5,7 +5,7 @@
 > no status. Move historical detail to `status/CHANGELOG.md` and deep runbooks to
 > `docs/runbooks/`.
 
-_Last updated: 2026-07-15 — ebadger (via Copilot)_
+_Last updated: 2026-07-16 — ebadger (via Copilot)_
 
 ---
 
@@ -49,6 +49,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web/test_mockingboard.cjs        # slot-4 mirrors, stereo PCM, 3RIC clock, VIA IRQ
 & $node web/test_system_speaker.cjs     # $C030 read/write toggles + mixed speaker/AY PCM
 & $node web/test_gamepad.cjs             # browser mapping, VIA serial pads, ROM tables
+& $node web/test_debugger.cjs            # breakpoints, stepping, source map, ROM debug lookup
 & $node web/test_sd.cjs                  # mount SD + DIR lists the FAT32 root
 & $node web/test_disk.cjs                # boot a WOZ floppy via C600G into a hi-res title
 & $node web/test_woz_download.cjs        # "Download .woz" builds a bootable disk that boots via C600G
@@ -88,6 +89,9 @@ secrets. Nothing to configure and nothing to commit. (The only "secret" is the s
   `asm6502.mjs` and runs it like `BRUN`; ships ~11 sample programs; deep-linkable via `?src=`.
   Exports the assembled program as a raw **.PRG** or a bootable **.woz** disk image
   (`wozgen.mjs`, a JS port of `dsk2woz2` with a multi-track boot loader) that boots via `C600G`.
+- **Browser debugger:** source-correlated instruction breakpoints for assembled programs,
+  pause/continue, step into/over, live registers, raw-memory inspection, arbitrary PC
+  breakpoints, and lazy ROM symbol/source-file:line correlation from `badger6502.dbg`.
 - **Disk gap:** DOS 3.3 / Quick-DOS and games that chain through an Applesoft auto-run
   greeting don't run — this clone's `$E000` BASIC is generic Microsoft BASIC, not Applesoft.
   Self-booting machine-code disks work.

--- a/web/README.md
+++ b/web/README.md
@@ -45,6 +45,10 @@ identically. Browser-only presentation code stays in the bridge and JavaScript.
   download the `.PRG`. Ships the project's sample programs; deep-linkable with
   `?src=` / `?code=`, and a **Share** button that copies a one-click link to the
   current program.
+- **Source debugger**: instruction breakpoints on the assembled source listing,
+  pause/continue, step into/over, live registers, arbitrary-address breakpoints, and
+  raw-memory inspection. PCs in the ROM are correlated to ca65 symbol and
+  source-file/line metadata from `badger6502.dbg`.
 
 ## Layout
 
@@ -53,12 +57,13 @@ identically. Browser-only presentation code stays in the bridge and JavaScript.
 | `web_bridge.cpp` | embind bridge: wraps `VM`, exposes load/run/keyboard/gamepad/registers/audio, drives the SD card, and produces the RGBA framebuffer. |
 | `gamepad.js` | Dependency-free standard-layout browser controller mapping and stable two-player assignment. |
 | `virtual-keyboard.js` | Touch-keyboard layout, one-shot Shift/Control state, physical-key mapping, and DOM renderer. |
+| `debugger.js` | Dependency-free assembled-source mapper and ca65 `.dbg` parser for ROM symbol/file:line correlation. |
 | `emulation-clock.js` | Elapsed-time cycle pacer that keeps finite CPU speeds independent of display refresh rate and carries instruction overshoot between frames. |
 | `audio-worklet.js` | Stereo PCM queue on the browser audio-rendering thread; no `SharedArrayBuffer` or cross-origin isolation required. |
 | `web_compat.h` | Tiny shims so `WozLib` + `MockMicroSD`'s MSVC-isms (`OutputDebugString`, `sprintf_s`, `swprintf_s`, `fopen_s`, `_ASSERT`, …) compile under Emscripten. |
 | `make_sd_sparse.py` | Streams `emulator/Data/sd.zip` (a 2GB, mostly-zero FAT32 image) into a compact `data/sd.sparse` keeping only the ~11.5MB of non-zero sectors. |
 | `build.ps1` | Compiles the core + WozLib + MockMicroSD + bridge to `badger6502.js` / `.wasm`, stages the data files, generates `sd.sparse`, and stages the demo `disk.woz`. |
-| `index.html` | Canvas UI + `requestAnimationFrame` driver + keyboard + clock-speed/disk/sound controls + the in-browser assembler/editor. Honors an optional `ASSET_BASE` (R2/CDN offload). |
+| `index.html` | Canvas UI + `requestAnimationFrame` driver + keyboard + clock-speed/disk/sound controls + the in-browser assembler/editor/debugger. Honors an optional `ASSET_BASE` (R2/CDN offload). |
 | `asm6502.mjs` | The 65C02 assembler, staged from `codegen/tools/asm6502.mjs` (git-ignored). Dual-use: the same file is a Node CLI and a browser ES module — `index.html` imports its `assemble()` for **Assemble & Run**. |
 | `serve.ps1` | Starts `python -m http.server` (defaults to port 8011) for local dev. |
 | `Caddyfile` | Production static server config (compression + cache headers) for hosting behind a Cloudflare Tunnel. |
@@ -97,7 +102,7 @@ bridge:          web_bridge.cpp
 `symbols.cpp` and `Disassemble.cpp` are excluded (Windows-only). Key flags:
 `-std=c++17 -O2 -lembind -sMODULARIZE=1 -sEXPORT_NAME=createBadgerVM
 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,node`. The data files
-(`badger6502.bin`, `fontrom.dat`) are copied from
+(`badger6502.bin`, `fontrom.dat`, `badger6502.dbg`) are copied from
 `emulator/Data` into `web/data`, `sd.sparse` is generated from
 `emulator/Data/sd.zip` (first run only; ~20s), and the demo `disk.woz` is staged
 from the in-repo WOZ test images.
@@ -149,6 +154,9 @@ the browser and runs it in the emulator — no CLI, no server round-trip:
    Assembler errors show as `line N: …` and are non-fatal.
 3. **Download .PRG** saves the assembled image so you can `BRUN` it on real
    hardware or off the SD card.
+4. Expand **Debugger** to click instruction rows as breakpoints, pause/continue,
+   step into or over an absolute `JSR`, add a breakpoint by address, and inspect
+   128 bytes of memory from any hexadecimal address.
 
 Implementation notes:
 
@@ -169,6 +177,12 @@ Implementation notes:
 - `build.ps1` stages `asm6502.mjs` and every `codegen/programs/*.s` plus the ten
   `emulator/AICodeGen` sample sources into `web/` and `web/programs/` (git-ignored,
   regenerated each build; CI does the same before publishing).
+- `assemble()` listing records carry the emitted PC/bytes, one-based source line,
+  and instruction/data kind. Breakpoint checks remain in the C++ `WebVM` loop so
+  normal and Max-speed execution do not cross the JS/WASM boundary per instruction.
+  The ROM `.dbg` map is fetched only when the debugger is opened; the source files
+  named by that map are not in this repository, so the UI shows their file/line
+  coordinate rather than the ROM source text.
 
 ## Community Gallery
 
@@ -220,6 +234,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web\test_mockingboard.cjs # mirrors, stereo PCM, 3RIC clock, timer IRQ
 & $node web\test_system_speaker.cjs # $C030 read/write toggles + mixed PCM
 & $node web\test_gamepad.cjs    # mapping, VIA serialization, ROM GAMEPAD1/2 scan
+& $node web\test_debugger.cjs   # source map, ROM lookup, breakpoints, step-over
 & $node web\test_sd.cjs          # mount the SD card + DIR lists the FAT32 root
 & $node web\test_disk.cjs        # boot a WOZ floppy via C600G into a hi-res title
 ```

--- a/web/build.ps1
+++ b/web/build.ps1
@@ -96,11 +96,11 @@ if ($onWindows) {
 }
 if ($LASTEXITCODE -ne 0) { throw "Build failed with exit code $LASTEXITCODE" }
 
-# Stage the ROM + font images next to the page for fetch() at runtime.
+# Stage the ROM, font, and ca65 debug map next to the page for fetch() at runtime.
 # These copies are gitignored (the originals live in emulator\Data).
 $webData = Join-Path $web "data"
 New-Item -ItemType Directory -Force -Path $webData | Out-Null
-foreach ($f in @("badger6502.bin", "fontrom.dat")) {
+foreach ($f in @("badger6502.bin", "fontrom.dat", "badger6502.dbg")) {
     $src = Join-Path $data $f
     if (Test-Path $src) {
         Copy-Item $src (Join-Path $webData $f) -Force

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -1,0 +1,148 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else root.BadgerDebugger = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function buildSourceListing(source, listing) {
+    const sourceLines = String(source).split(/\r?\n/);
+    return listing.map((record) => ({
+      address: record.pc & 0xFFFF,
+      bytes: Array.from(record.bytes),
+      line: record.line,
+      kind: record.kind,
+      source: sourceLines[record.line - 1] || "",
+    }));
+  }
+
+  function parsePairs(text) {
+    const pairs = Object.create(null);
+    const pattern = /([A-Za-z][A-Za-z0-9_]*)=("(?:[^"\\]|\\.)*"|[^,]*)/g;
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      const raw = match[2];
+      pairs[match[1]] = raw[0] === '"' ? raw.slice(1, -1) : raw;
+    }
+    return pairs;
+  }
+
+  function decimal(value) {
+    return value == null || value === "" ? null : parseInt(value, 10);
+  }
+
+  function hexadecimal(value) {
+    return value == null || value === "" ? null : parseInt(value, 16);
+  }
+
+  function sourcePriority(line, file) {
+    if (!file || file.startsWith("/share/")) return 0;
+    return line.type == null ? 2 : 1;
+  }
+
+  function symbolPriority(symbol) {
+    let score = symbol.type === "lab" ? 4 : 1;
+    if (symbol.def != null) score += 2;
+    if (/^L[0-9A-F]+$/i.test(symbol.name)) score -= 6;
+    if (/^__/.test(symbol.name)) score -= 2;
+    return score;
+  }
+
+  function parseCa65Debug(text) {
+    const files = new Map();
+    const segments = new Map();
+    const spans = new Map();
+    const lines = new Map();
+    const rawSymbols = [];
+
+    for (const rawLine of String(text).split(/\r?\n/)) {
+      const tab = rawLine.indexOf("\t");
+      if (tab < 0) continue;
+      const tag = rawLine.slice(0, tab);
+      const fields = parsePairs(rawLine.slice(tab + 1));
+
+      if (tag === "file") {
+        files.set(decimal(fields.id), fields.name);
+      } else if (tag === "seg") {
+        segments.set(decimal(fields.id), { start: hexadecimal(fields.start) });
+      } else if (tag === "span") {
+        spans.set(decimal(fields.id), {
+          segment: decimal(fields.seg),
+          start: decimal(fields.start),
+          size: decimal(fields.size) || 1,
+        });
+      } else if (tag === "line") {
+        lines.set(decimal(fields.id), {
+          file: decimal(fields.file),
+          line: decimal(fields.line),
+          type: decimal(fields.type),
+          spans: fields.span
+            ? fields.span.split("+").map((id) => parseInt(id, 10))
+            : [],
+        });
+      } else if (tag === "sym" && fields.val && fields.name) {
+        rawSymbols.push({
+          address: hexadecimal(fields.val),
+          name: fields.name,
+          type: fields.type,
+          def: decimal(fields.def),
+        });
+      }
+    }
+
+    const locations = new Array(0x10000);
+    for (const line of lines.values()) {
+      const file = files.get(line.file) || null;
+      const priority = sourcePriority(line, file);
+      for (const spanId of line.spans) {
+        const span = spans.get(spanId);
+        const segment = span && segments.get(span.segment);
+        if (!span || !segment || segment.start == null) continue;
+        const start = segment.start + span.start;
+        const location = { file, line: line.line };
+        for (let offset = 0; offset < span.size; offset++) {
+          const address = start + offset;
+          if (address < 0 || address > 0xFFFF) continue;
+          const current = locations[address];
+          if (!current || priority > current.priority) {
+            locations[address] = { ...location, priority };
+          }
+        }
+      }
+    }
+
+    const symbols = new Array(0x10000);
+    for (const raw of rawSymbols) {
+      if (raw.address == null || raw.address < 0 || raw.address > 0xFFFF) continue;
+      const definition = raw.def == null ? null : lines.get(raw.def);
+      const symbol = {
+        address: raw.address,
+        name: raw.name,
+        file: definition ? (files.get(definition.file) || null) : null,
+        line: definition ? definition.line : null,
+        priority: symbolPriority(raw),
+      };
+      const current = symbols[raw.address];
+      if (!current || symbol.priority > current.priority) symbols[raw.address] = symbol;
+    }
+
+    function lookup(address) {
+      if (!Number.isInteger(address) || address < 0 || address > 0xFFFF) return null;
+      const location = locations[address];
+      const symbol = symbols[address];
+      return {
+        address,
+        location: location ? { file: location.file, line: location.line } : null,
+        symbol: symbol ? {
+          name: symbol.name,
+          file: symbol.file,
+          line: symbol.line,
+        } : null,
+      };
+    }
+
+    return { lookup };
+  }
+
+  return { buildSourceListing, parseCa65Debug };
+});

--- a/web/index.html
+++ b/web/index.html
@@ -144,6 +144,45 @@
     background: var(--panel); color: var(--fg); font-size: 12px; line-height: 1.4;
   }
   #ide .remix.show { display: block; }
+  #debugger {
+    border: 1px solid var(--dim); border-radius: 4px; background: var(--panel);
+  }
+  #debugger summary {
+    padding: 7px 9px; cursor: pointer; font-size: 11px; letter-spacing: .6px;
+  }
+  #debugstate { float: right; color: var(--key-alt); letter-spacing: 0; }
+  #debugger .debug-body { display: flex; flex-direction: column; gap: 8px; padding: 8px; border-top: 1px solid var(--dim); }
+  #debugger .debug-toolbar { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+  #debugger .debug-location, #debugger .debug-breakpoints { color: var(--key-alt); font-size: 11px; }
+  #debugger .debug-grid {
+    display: grid; grid-template-columns: minmax(0, 2fr) minmax(240px, 1fr); gap: 8px;
+  }
+  #debugger .debug-pane { min-width: 0; }
+  #debugger .debug-pane-title { margin-bottom: 4px; color: var(--dim); font-size: 10px; letter-spacing: .6px; }
+  #debuglisting {
+    max-height: 300px; overflow: auto; border: 1px solid var(--dim); background: #000;
+    font-size: 11px;
+  }
+  .debug-row {
+    display: grid; grid-template-columns: 24px 52px 88px minmax(0, 1fr);
+    min-height: 20px; align-items: start; border-bottom: 1px solid #102016;
+  }
+  .debug-row:last-child { border-bottom: 0; }
+  .debug-row.current { background: #193d23; color: #fff; }
+  .debug-row.breakpoint { color: #ffcf66; }
+  .debug-row .debug-marker {
+    width: 20px; min-height: 18px; margin: 1px; padding: 0; border: 0;
+    color: inherit; background: transparent; font: inherit; text-align: center;
+  }
+  .debug-row .debug-marker:disabled { opacity: .35; }
+  .debug-row .debug-address, .debug-row .debug-bytes, .debug-row .debug-source {
+    padding: 2px 4px; white-space: pre; overflow: hidden; text-overflow: ellipsis;
+  }
+  .debug-row .debug-source { color: inherit; }
+  #debugmemory {
+    min-height: 154px; margin: 4px 0 0; padding: 6px; overflow: auto;
+    border: 1px solid var(--dim); background: #000; color: var(--fg); font-size: 11px;
+  }
   @media (max-width: 480px) {
     main { gap: 12px; padding: 8px; }
     #virtual-keyboard-keys { gap: 3px; padding: 6px; overflow-x: hidden; }
@@ -159,6 +198,9 @@
     #virtual-keyboard .vk-key.return { font-size: clamp(6px, 2.2vw, 9px); }
     #virtual-keyboard .vk-key.caps { font-size: clamp(5px, 1.9vw, 8px); }
     #ide { min-width: 0; }
+  }
+  @media (max-width: 760px) {
+    #debugger .debug-grid { grid-template-columns: 1fr; }
   }
 </style>
 <link rel="alternate" type="text/markdown" title="llms.txt — 65C02 codegen guide for AI tools" href="llms.txt" />
@@ -248,6 +290,37 @@
       <textarea id="src" wrap="off" spellcheck="false" autocomplete="off" autocapitalize="off"
         aria-label="6502 assembly source" placeholder="; write 65C02 assembly here, then Assemble & Run"></textarea>
       <pre id="asmout">Pick a sample or write 65C02 assembly, then Assemble &amp; Run.</pre>
+      <details id="debugger">
+        <summary>DEBUGGER <span id="debugstate">running</span></summary>
+        <div class="debug-body">
+          <div class="debug-toolbar">
+            <button id="debugpause" type="button">Pause</button>
+            <button id="debugcontinue" type="button" disabled>Continue</button>
+            <button id="debugstep" type="button" disabled>Step Into</button>
+            <button id="debugover" type="button" title="step over an absolute JSR; other opcodes step once" disabled>Step Over</button>
+            <span class="hint">break&nbsp;@$</span>
+            <input class="addr" id="debugbreakaddr" value="0800" spellcheck="false" aria-label="hex breakpoint address" />
+            <button id="debugtogglebreak" type="button">Toggle Breakpoint</button>
+            <button id="debugclearbreaks" type="button">Clear Breakpoints</button>
+          </div>
+          <div id="debuglocation" class="debug-location">PC not mapped to assembled source.</div>
+          <div id="debugbreakpoints" class="debug-breakpoints">breakpoints: none</div>
+          <div class="debug-grid">
+            <section class="debug-pane" aria-label="assembled source listing">
+              <div class="debug-pane-title">ASSEMBLED SOURCE (click B to toggle an instruction breakpoint)</div>
+              <div id="debuglisting"><div class="debug-row"><span></span><span></span><span></span><span class="debug-source">Assemble a program to create a source map.</span></div></div>
+            </section>
+            <section class="debug-pane" aria-label="memory inspector">
+              <div class="debug-toolbar">
+                <span class="debug-pane-title">MEMORY&nbsp;$</span>
+                <input class="addr" id="debugmemaddr" value="0000" spellcheck="false" aria-label="hex memory start address" />
+                <button id="debugrefreshmemory" type="button">Refresh</button>
+              </div>
+              <pre id="debugmemory">Pause execution to inspect memory.</pre>
+            </section>
+          </div>
+        </div>
+      </details>
     </section>
   </main>
   <footer>
@@ -271,6 +344,9 @@
     resulting <code>.PRG</code> to <code>BRUN</code> on hardware. Hit <strong>Share</strong>
     to copy a one-click link to your program (a short <code>?src=</code> for the built-in
     samples, or your source inlined in <code>?code=</code>).
+    Open <strong>Debugger</strong> to set breakpoints on assembled source lines, pause/continue,
+    step into or over subroutines, and inspect memory. ROM execution is identified from the
+    machine&rsquo;s ca65 debug map when available.
     <br />Building with an AI tool? Point it at <a href="llms.txt"><code>llms.txt</code></a>
     &mdash; a machine-readable 65C02 codegen guide &mdash; or see
     <a href="https://github.com/ebadger/3ric/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING</a>.
@@ -283,6 +359,7 @@
   <script src="emulation-clock.js"></script>
   <script src="gamepad.js"></script>
   <script src="virtual-keyboard.js"></script>
+  <script src="debugger.js"></script>
   <script src="badger6502.js"></script>
   <script>
     // The 3ric clocks its 65C02 from the 25.175 MHz VGA dot clock divided by 16,
@@ -315,6 +392,7 @@
     let audioNode = null;
     let soundRequested = false;
     let audioGenerating = false;
+    let debuggerController = null;
     const inputQueue = [];
 
     function hex(n, w) { return (n >>> 0).toString(16).toUpperCase().padStart(w, "0"); }
@@ -530,21 +608,32 @@
       pollGamepads();
 
       // Feed one queued key when the keyboard strobe is clear (bit 7 of $C000).
-      if (inputQueue.length && (vm.peek(0xC000) & 0x80) === 0) {
+      if (!debuggerController?.isPaused() &&
+          inputQueue.length && (vm.peek(0xC000) & 0x80) === 0) {
         vm.keyDown(inputQueue.shift());
       }
 
       const start = performance.now();
-      if (speedMul === Infinity) {
+      if (!debuggerController?.isPaused() && speedMul === Infinity) {
         do {
-          vm.run(1000);
+          const cycles = vm.run(1000);
+          if (vm.breakpointHit()) {
+            debuggerController?.onBreakpoint();
+            break;
+          }
+          if (cycles <= 0) break;
         } while (performance.now() - start <= FRAME_BUDGET_MS);
-      } else {
+      } else if (!debuggerController?.isPaused()) {
         let cyclesDue = emulationClock.advance(timestamp, speedMul);
         while (cyclesDue > 0) {
           const cycles = vm.runCycles(Math.min(cyclesDue, RUN_CYCLE_BATCH));
+          const breakpointHit = vm.breakpointHit();
+          if (cycles > 0) emulationClock.consume(cycles);
+          if (breakpointHit) {
+            debuggerController?.onBreakpoint();
+            break;
+          }
           if (cycles <= 0) break;
-          emulationClock.consume(cycles);
           if (performance.now() - start > FRAME_BUDGET_MS) break;
           cyclesDue = emulationClock.cyclesDue();
         }
@@ -560,6 +649,7 @@
       ctx.putImageData(imageData, 0, 0);
 
       updateRegs();
+      debuggerController?.refresh();
       requestAnimationFrame(frame);
     }
 
@@ -580,6 +670,7 @@
       vm.reset();
       emulationClock.reset();
       clearAudioQueue();
+      debuggerController?.onMachineReset();
     }
 
     // Boot a 5.25" floppy: re-seed a clean machine (back to the monitor), insert
@@ -603,15 +694,21 @@
     // the monitor initialize first, so COUT's output vector ($36/$37) is live
     // before the program runs; otherwise a program that calls COUT would jump
     // through an uninitialized vector.
-    async function loadPrg(bytes, org, label) {
+    async function loadPrg(bytes, org, label, preserveDebugListing = false) {
       inputQueue.length = 0;
-      await loadRom();                              // clean reset to the monitor
-      for (let i = 0; i < 25; i++) vm.run(50000);   // settle into the "*" monitor
-      if (audioGenerating) vm.drainAudio();          // discard pre-program silence
-      vm.loadData(org & 0xFFFF, bytes);
-      vm.setPC(org & 0xFFFF);
-      statusEl.textContent = `running ${label || ".PRG"} @ $${hex(org, 4)}`;
-      canvas.focus();
+      if (!preserveDebugListing) debuggerController?.setProgram("", []);
+      debuggerController?.beginProgramLoad();
+      try {
+        await loadRom();                              // clean reset to the monitor
+        for (let i = 0; i < 25; i++) vm.run(50000);   // settle into the "*" monitor
+        if (audioGenerating) vm.drainAudio();          // discard pre-program silence
+        vm.loadData(org & 0xFFFF, bytes);
+        vm.setPC(org & 0xFFFF);
+        statusEl.textContent = `running ${label || ".PRG"} @ $${hex(org, 4)}`;
+        canvas.focus();
+      } finally {
+        debuggerController?.endProgramLoad();
+      }
     }
 
     // ---- in-browser assembler / editor ------------------------------------
@@ -656,6 +753,336 @@
       return wozgenFn;
     }
 
+    function createDebuggerController() {
+      const detailsEl = document.getElementById("debugger");
+      const stateEl = document.getElementById("debugstate");
+      const locationEl = document.getElementById("debuglocation");
+      const breakpointsEl = document.getElementById("debugbreakpoints");
+      const listingEl = document.getElementById("debuglisting");
+      const pauseBtn = document.getElementById("debugpause");
+      const continueBtn = document.getElementById("debugcontinue");
+      const stepBtn = document.getElementById("debugstep");
+      const overBtn = document.getElementById("debugover");
+      const breakAddrEl = document.getElementById("debugbreakaddr");
+      const toggleBreakBtn = document.getElementById("debugtogglebreak");
+      const clearBreaksBtn = document.getElementById("debugclearbreaks");
+      const memoryAddrEl = document.getElementById("debugmemaddr");
+      const memoryEl = document.getElementById("debugmemory");
+      const refreshMemoryBtn = document.getElementById("debugrefreshmemory");
+
+      const manualBreakpoints = new Set();
+      const sourceBreakpointLines = new Set();
+      const sourceBreakpoints = new Set();
+      let rows = [];
+      let rowElements = new Map();
+      let paused = false;
+      let suspended = false;
+      let temporaryBreakpoint = null;
+      let currentAddress = -1;
+      let memoryDirty = true;
+      let romDebug = null;
+      let romDebugLoading = null;
+
+      function parseDebuggerAddress(value) {
+        const match = String(value).trim().match(/^\$?([0-9a-f]{1,4})$/i);
+        return match ? parseInt(match[1], 16) : null;
+      }
+
+      function rebuildSourceBreakpoints() {
+        sourceBreakpoints.clear();
+        for (const row of rows) {
+          if (row.kind === "instruction" && sourceBreakpointLines.has(row.line)) {
+            sourceBreakpoints.add(row.address);
+          }
+        }
+      }
+
+      function allBreakpointAddresses() {
+        return new Set([...manualBreakpoints, ...sourceBreakpoints]);
+      }
+
+      function renderBreakpointSummary() {
+        const addresses = Array.from(allBreakpointAddresses()).sort((a, b) => a - b);
+        breakpointsEl.textContent = addresses.length
+          ? `breakpoints: ${addresses.map((address) => "$" + hex(address, 4)).join(" ")}`
+          : "breakpoints: none";
+      }
+
+      function refreshBreakpointRows() {
+        for (const [address, item] of rowElements) {
+          const enabled = sourceBreakpointLines.has(item.row.line);
+          item.element.classList.toggle("breakpoint", enabled);
+          item.button.textContent = enabled ? "B" : ".";
+          item.button.setAttribute("aria-pressed", enabled ? "true" : "false");
+          item.button.title = `${enabled ? "remove" : "set"} breakpoint at $${hex(address, 4)}`;
+        }
+      }
+
+      function syncBreakpoints() {
+        vm.clearBreakpoints();
+        rebuildSourceBreakpoints();
+        if (!suspended) {
+          for (const address of allBreakpointAddresses()) vm.addBreakpoint(address);
+          if (temporaryBreakpoint != null) vm.addBreakpoint(temporaryBreakpoint);
+        }
+        refreshBreakpointRows();
+        renderBreakpointSummary();
+      }
+
+      function renderListing() {
+        listingEl.textContent = "";
+        rowElements = new Map();
+        if (!rows.length) {
+          const empty = document.createElement("div");
+          empty.className = "debug-row";
+          const message = document.createElement("span");
+          message.className = "debug-source";
+          message.style.gridColumn = "1 / -1";
+          message.textContent = "Assemble a program to create a source map.";
+          empty.appendChild(message);
+          listingEl.appendChild(empty);
+          return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        for (const row of rows) {
+          const element = document.createElement("div");
+          element.className = "debug-row";
+
+          const marker = document.createElement("button");
+          marker.type = "button";
+          marker.className = "debug-marker";
+          marker.disabled = row.kind !== "instruction";
+          marker.textContent = row.kind === "instruction" ? "." : "-";
+          marker.setAttribute("aria-label", row.kind === "instruction"
+            ? `toggle breakpoint at $${hex(row.address, 4)}, source line ${row.line}`
+            : `data at $${hex(row.address, 4)}`);
+          if (row.kind === "instruction") {
+            marker.addEventListener("click", () => {
+              if (sourceBreakpointLines.has(row.line)) sourceBreakpointLines.delete(row.line);
+              else sourceBreakpointLines.add(row.line);
+              syncBreakpoints();
+            });
+          }
+
+          const address = document.createElement("span");
+          address.className = "debug-address";
+          address.textContent = "$" + hex(row.address, 4);
+
+          const bytes = document.createElement("span");
+          bytes.className = "debug-bytes";
+          const shown = row.bytes.slice(0, 6).map((byte) => hex(byte, 2)).join(" ");
+          bytes.textContent = shown + (row.bytes.length > 6 ? " ..." : "");
+
+          const source = document.createElement("span");
+          source.className = "debug-source";
+          source.textContent = `${String(row.line).padStart(4, " ")}  ${row.source}`;
+
+          element.append(marker, address, bytes, source);
+          fragment.appendChild(element);
+          if (row.kind === "instruction") {
+            rowElements.set(row.address, { row, element, button: marker });
+          }
+        }
+        listingEl.appendChild(fragment);
+        refreshBreakpointRows();
+      }
+
+      function renderMemory() {
+        const start = parseDebuggerAddress(memoryAddrEl.value);
+        if (start == null) {
+          memoryEl.textContent = "Enter a hexadecimal address from 0000 through FFFF.";
+          return;
+        }
+        const output = [];
+        for (let row = 0; row < 8; row++) {
+          const address = (start + row * 16) & 0xFFFF;
+          const bytes = [];
+          let ascii = "";
+          for (let column = 0; column < 16; column++) {
+            const value = vm.peek((address + column) & 0xFFFF);
+            bytes.push(hex(value, 2));
+            ascii += value >= 32 && value <= 126 ? String.fromCharCode(value) : ".";
+          }
+          output.push(`${hex(address, 4)}  ${bytes.join(" ")}  |${ascii}|`);
+        }
+        memoryEl.textContent = output.join("\n");
+        memoryDirty = false;
+      }
+
+      function removeTemporaryBreakpoint() {
+        if (temporaryBreakpoint == null) return;
+        temporaryBreakpoint = null;
+        syncBreakpoints();
+      }
+
+      function setPaused(value, reason) {
+        paused = value;
+        pauseBtn.disabled = value;
+        continueBtn.disabled = !value;
+        stepBtn.disabled = !value;
+        overBtn.disabled = !value;
+        stateEl.textContent = value ? `paused${reason ? ": " + reason : ""}` : (reason || "running");
+        if (value) {
+          memoryDirty = true;
+          clearAudioQueue();
+        }
+        emulationClock.reset();
+        refresh(true);
+      }
+
+      function formatRomLocation(address) {
+        const info = romDebug && romDebug.lookup(address);
+        if (!info) return `$${hex(address, 4)} (outside assembled source)`;
+        const parts = [`$${hex(address, 4)}`];
+        if (info.symbol) parts.push(info.symbol.name);
+        const location = info.location ||
+          (info.symbol && info.symbol.file ? { file: info.symbol.file, line: info.symbol.line } : null);
+        if (location && location.file) parts.push(`${location.file}:${location.line}`);
+        if (parts.length === 1) parts.push("(outside assembled source)");
+        return parts.join("  ");
+      }
+
+      function refresh(force = false) {
+        const address = vm.pc() & 0xFFFF;
+        if (force || address !== currentAddress) {
+          const previous = rowElements.get(currentAddress);
+          if (previous) previous.element.classList.remove("current");
+          currentAddress = address;
+          const current = rowElements.get(address);
+          if (current) {
+            current.element.classList.add("current");
+            locationEl.textContent =
+              `$${hex(address, 4)}  assembled source line ${current.row.line}: ${current.row.source.trim()}`;
+            if (paused) current.element.scrollIntoView({ block: "nearest" });
+          } else {
+            locationEl.textContent = formatRomLocation(address);
+          }
+        }
+        if (paused && (force || memoryDirty)) renderMemory();
+      }
+
+      async function ensureRomDebug() {
+        if (romDebug || romDebugLoading) return romDebugLoading;
+        locationEl.textContent = "loading ROM debug map...";
+        romDebugLoading = fetch(assetUrl("data/badger6502.dbg"))
+          .then((response) => {
+            if (!response.ok) throw new Error(`fetch ROM debug map: ${response.status}`);
+            return response.text();
+          })
+          .then((text) => {
+            romDebug = BadgerDebugger.parseCa65Debug(text);
+            refresh(true);
+            return romDebug;
+          })
+          .catch((error) => {
+            locationEl.textContent = "ROM debug map unavailable: " + error.message;
+            console.error(error);
+            throw error;
+          });
+        return romDebugLoading;
+      }
+
+      pauseBtn.addEventListener("click", () => setPaused(true, "manual"));
+      continueBtn.addEventListener("click", () => {
+        removeTemporaryBreakpoint();
+        if (vm.hasBreakpoint(vm.pc())) vm.step();
+        setPaused(false, "running");
+      });
+      stepBtn.addEventListener("click", () => {
+        removeTemporaryBreakpoint();
+        vm.step();
+        setPaused(true, "step");
+      });
+      overBtn.addEventListener("click", () => {
+        removeTemporaryBreakpoint();
+        const address = vm.pc() & 0xFFFF;
+        if (vm.peek(address) !== 0x20) {
+          vm.step();
+          setPaused(true, "step");
+          return;
+        }
+        const returnAddress = (address + 3) & 0xFFFF;
+        vm.step();
+        temporaryBreakpoint = returnAddress;
+        syncBreakpoints();
+        setPaused(false, `step over to $${hex(returnAddress, 4)}`);
+      });
+      toggleBreakBtn.addEventListener("click", () => {
+        const address = parseDebuggerAddress(breakAddrEl.value);
+        if (address == null) {
+          locationEl.textContent = "Breakpoint address must be hexadecimal 0000 through FFFF.";
+          return;
+        }
+        if (manualBreakpoints.has(address)) manualBreakpoints.delete(address);
+        else manualBreakpoints.add(address);
+        syncBreakpoints();
+      });
+      breakAddrEl.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          toggleBreakBtn.click();
+        }
+      });
+      clearBreaksBtn.addEventListener("click", () => {
+        manualBreakpoints.clear();
+        sourceBreakpointLines.clear();
+        temporaryBreakpoint = null;
+        syncBreakpoints();
+      });
+      refreshMemoryBtn.addEventListener("click", () => {
+        memoryDirty = true;
+        renderMemory();
+      });
+      memoryAddrEl.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          memoryDirty = true;
+          renderMemory();
+        }
+      });
+      detailsEl.addEventListener("toggle", () => {
+        if (detailsEl.open) {
+          ensureRomDebug().catch(() => {});
+          refresh(true);
+        }
+      });
+
+      syncBreakpoints();
+      return {
+        isPaused: () => paused,
+        onBreakpoint() {
+          const address = vm.pc() & 0xFFFF;
+          if (temporaryBreakpoint === address) removeTemporaryBreakpoint();
+          detailsEl.open = true;
+          setPaused(true, `breakpoint $${hex(address, 4)}`);
+        },
+        onMachineReset() {
+          temporaryBreakpoint = null;
+          if (!suspended) syncBreakpoints();
+          setPaused(false, "running");
+        },
+        beginProgramLoad() {
+          suspended = true;
+          temporaryBreakpoint = null;
+          vm.clearBreakpoints();
+          setPaused(false, "loading");
+        },
+        endProgramLoad() {
+          suspended = false;
+          syncBreakpoints();
+          setPaused(false, "running");
+        },
+        setProgram(source, listing) {
+          rows = BadgerDebugger.buildSourceListing(source, listing);
+          renderListing();
+          syncBreakpoints();
+          refresh(true);
+        },
+        refresh,
+      };
+    }
+
     async function loadSampleSrc(name) {
       // Revalidate rather than trust the browser's cached copy: sample sources
       // are static files served with max-age=600, so a repeat visitor could
@@ -681,6 +1108,7 @@
       let loadedRef = null;  // { name, text }: set while the editor holds an unmodified sample
 
       const setOut = (msg, cls) => { outEl.textContent = msg; outEl.className = cls || ""; };
+      debuggerController = createDebuggerController();
       const save = () => {
         try { localStorage.setItem(LS_SRC, srcEl.value); localStorage.setItem(LS_ORG, addrEl.value); } catch (e) {}
       };
@@ -709,9 +1137,10 @@
         wozBtn.disabled = false;
         const nsym = Object.keys(res.symbols).length;
         const okMsg = `assembled ${res.bytes.length} bytes @ $${hex(res.org, 4)} \u2014 ${nsym} symbols.`;
+        debuggerController.setProgram(src, res.listing);
         setOut(okMsg + " running\u2026", "ok");
         try {
-          await loadPrg(res.bytes, res.org, "editor");
+          await loadPrg(res.bytes, res.org, "editor", true);
           setOut(okMsg + " running now \u2014 click the screen and play.", "ok");
           canvas.focus();
         } catch (e) {

--- a/web/test_debugger.cjs
+++ b/web/test_debugger.cjs
@@ -1,0 +1,94 @@
+const fs = require("fs");
+const path = require("path");
+const createBadgerVM = require("./badger6502.js");
+const { buildSourceListing, parseCa65Debug } = require("./debugger.js");
+
+let failures = 0;
+function check(name, condition, detail = "") {
+  const ok = Boolean(condition);
+  if (!ok) failures++;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${ok || !detail ? "" : `: ${detail}`}`);
+}
+
+(async () => {
+  const { assemble } = await import("../codegen/tools/asm6502.mjs");
+  const source = [
+    ".org $0800",
+    "start: lda #1",
+    "       jsr sub",
+    "       sta $2000",
+    "       brk",
+    "sub:   inx",
+    "       rts",
+  ].join("\n");
+  const assembled = assemble(source);
+  const listing = buildSourceListing(source, assembled.listing);
+  check("source listing maps line to PC",
+    listing[1].address === 0x0802 && listing[1].line === 3 && listing[1].source.includes("jsr sub"));
+  check("source listing marks executable rows",
+    listing.every((row) => row.kind === "instruction"));
+
+  const debugText = fs.readFileSync(
+    path.join(__dirname, "..", "emulator", "Data", "badger6502.dbg"), "utf8");
+  const romDebug = parseCa65Debug(debugText);
+  const cout = romDebug.lookup(0xFDED);
+  check("ROM debug resolves COUT symbol",
+    cout && cout.symbol && cout.symbol.name === "COUT",
+    JSON.stringify(cout));
+  check("ROM debug resolves COUT source coordinate",
+    cout && cout.symbol && cout.symbol.file === "apple2rom.s" && cout.symbol.line === 1058,
+    JSON.stringify(cout));
+
+  const Module = await createBadgerVM();
+  const vm = new Module.WebVM();
+  vm.loadData(assembled.org, assembled.bytes);
+  vm.poke(0xFFFC, 0x00);
+  vm.poke(0xFFFD, 0x08);
+  vm.reset();
+
+  check("rejects invalid breakpoint", vm.addBreakpoint(-1) === false);
+  check("adds instruction breakpoint", vm.addBreakpoint(0x0802) && vm.hasBreakpoint(0x0802));
+  const firstCycles = vm.run(20);
+  check("run stops before breakpoint",
+    firstCycles > 0 && vm.breakpointHit() && vm.pc() === 0x0802,
+    `cycles=${firstCycles} pc=${vm.pc().toString(16)}`);
+
+  vm.step();
+  check("step executes through current breakpoint", !vm.breakpointHit() && vm.pc() === 0x0809);
+
+  vm.addBreakpoint(0x0805);
+  const overCycles = vm.run(20);
+  check("temporary return breakpoint supports step-over",
+    overCycles > 0 && vm.breakpointHit() && vm.pc() === 0x0805,
+    `cycles=${overCycles} pc=${vm.pc().toString(16)}`);
+
+  vm.removeBreakpoint(0x0805);
+  vm.step();
+  check("memory inspection sees program write", vm.peek(0x2000) === 1);
+
+  vm.addBreakpoint(0x0808);
+  const stoppedCycles = vm.runCycles(100);
+  check("cycle runner reports immediate breakpoint",
+    stoppedCycles === 0 && vm.breakpointHit() && vm.pc() === 0x0808);
+
+  vm.clearBreakpoints();
+  check("clear removes all breakpoints",
+    !vm.hasBreakpoint(0x0802) && !vm.hasBreakpoint(0x0808) && !vm.breakpointHit());
+
+  vm.poke(0x0900, 0xCB); // WAI
+  vm.poke(0x0901, 0xEA); // NOP after the interrupt wakes the CPU
+  vm.setPC(0x0900);
+  vm.step();
+  vm.addBreakpoint(0x0901);
+  const waitCycles = vm.runCycles(20);
+  check("dormant WAI PC does not retrigger breakpoint",
+    waitCycles >= 20 && vm.waiting() && vm.pc() === 0x0901 && !vm.breakpointHit(),
+    `cycles=${waitCycles} pc=${vm.pc().toString(16)}`);
+
+  vm.delete();
+  console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILED`);
+  process.exitCode = failures === 0 ? 0 : 1;
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -26,6 +26,7 @@
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
+#include <array>
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
@@ -138,7 +139,11 @@ public:
 
     // --- lifecycle ---------------------------------------------------------
 
-    void reset() { _vm->Reset(); }
+    void reset()
+    {
+        _vm->Reset();
+        _breakpointHit = false;
+    }
 
     // --- loaders -----------------------------------------------------------
 
@@ -237,9 +242,15 @@ public:
     // Execute up to maxSteps instructions. Kept for headless tools and Max speed.
     int run(int maxSteps)
     {
+        _breakpointHit = false;
         int cycles = 0;
         for (int i = 0; i < maxSteps; i++)
         {
+            if (breakpointAtPC())
+            {
+                _breakpointHit = true;
+                break;
+            }
             cycles += stepOnce();
         }
         return cycles;
@@ -249,15 +260,55 @@ public:
     // The browser carries the final instruction's overshoot into its next budget.
     int runCycles(int cycleBudget)
     {
+        _breakpointHit = false;
         if (cycleBudget <= 0) return 0;
 
         int cycles = 0;
         do
         {
+            if (breakpointAtPC())
+            {
+                _breakpointHit = true;
+                break;
+            }
             cycles += stepOnce();
         } while (cycles < cycleBudget);
         return cycles;
     }
+
+    // Execute exactly one instruction even if the current PC has a breakpoint.
+    int step()
+    {
+        _breakpointHit = false;
+        return stepOnce();
+    }
+
+    bool addBreakpoint(int addr)
+    {
+        if (addr < 0 || addr > 0xFFFF) return false;
+        _breakpoints[(size_t)addr] = 1;
+        return true;
+    }
+
+    bool removeBreakpoint(int addr)
+    {
+        if (addr < 0 || addr > 0xFFFF) return false;
+        _breakpoints[(size_t)addr] = 0;
+        return true;
+    }
+
+    void clearBreakpoints()
+    {
+        _breakpoints.fill(0);
+        _breakpointHit = false;
+    }
+
+    bool hasBreakpoint(int addr)
+    {
+        return addr >= 0 && addr <= 0xFFFF && _breakpoints[(size_t)addr] != 0;
+    }
+
+    bool breakpointHit() { return _breakpointHit; }
 
     bool waiting()
     {
@@ -323,7 +374,11 @@ public:
     void writeBus(int addr, int value) { _vm->WriteData((uint16_t)(addr & 0xFFFF), (uint8_t)(value & 0xFF)); }
 
     // Set the program counter (e.g. to launch a freshly loaded program).
-    void setPC(int addr) { _vm->GetCPU()->PC = (uint16_t)(addr & 0xFFFF); }
+    void setPC(int addr)
+    {
+        _vm->GetCPU()->PC = (uint16_t)(addr & 0xFFFF);
+        _breakpointHit = false;
+    }
 
     // --- serial log (optional) --------------------------------------------
 
@@ -400,6 +455,13 @@ public:
     }
 
 private:
+    bool breakpointAtPC()
+    {
+        CPU* cpu = _vm->GetCPU();
+        if (cpu->waitForInterrupt || cpu->stopped) return false;
+        return _breakpoints[(size_t)cpu->PC] != 0;
+    }
+
     int stepOnce()
     {
         const uint8_t cycles = _vm->Step();
@@ -559,6 +621,8 @@ private:
 
     uint64_t _cycles        = 0;
     uint64_t _lastDiskCycle = 0;
+    std::array<uint8_t, 0x10000> _breakpoints = {};
+    bool _breakpointHit = false;
 
     SDCard _sd;     // bit-banged SPI micro-SD card (sparse-backed image)
 };
@@ -578,6 +642,12 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("diskPresent",  &WebVM::diskPresent)
         .function("run",          &WebVM::run)
         .function("runCycles",    &WebVM::runCycles)
+        .function("step",         &WebVM::step)
+        .function("addBreakpoint", &WebVM::addBreakpoint)
+        .function("removeBreakpoint", &WebVM::removeBreakpoint)
+        .function("clearBreakpoints", &WebVM::clearBreakpoints)
+        .function("hasBreakpoint", &WebVM::hasBreakpoint)
+        .function("breakpointHit", &WebVM::breakpointHit)
         .function("waiting",      &WebVM::waiting)
         .function("irqAsserted",  &WebVM::irqAsserted)
         .function("enableAudio",  &WebVM::enableAudio)


### PR DESCRIPTION
## Summary
- add fast instruction-boundary breakpoints and single-step execution to the WebAssembly bridge
- add pause/continue, step into/over, clickable assembled-source breakpoints, arbitrary PC breakpoints, and raw-memory inspection to 3RIC Studio
- correlate ROM PCs to ca65 symbols and source file/line metadata from `badger6502.dbg`
- enrich assembler listings with source line and instruction/data metadata and stage/test the debugger in Pages CI

## Testing
- `pwsh -File web/build.ps1`
- `node codegen/tools/asm6502.test.mjs`
- `node web/test_debugger.cjs`
- `node web/test_boot.cjs`
- `node web/test_mockingboard.cjs`
- rendered browser interaction pass for source breakpoint, pause state, ROM location, and memory view