### PR TITLE
Enable browser sound by default

### DIFF
--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -146,7 +146,9 @@ client-side so GitHub Pages can host it as static files.
   `AudioContext`, the first pointer or keyboard interaction activates it; the sound control
   can opt out before activation or disable/re-enable audio afterward. The bridge drains the
   VM's combined stream: `$C030` is centered mono and the two AYs retain their left/right
-  placement.
+  placement. Synthetic and non-activating events do not consume the pending activation;
+  autoplay rejection remains armed for the next interaction, while initialization failures
+  stay visible on the sound control and can be retried explicitly.
   `audio-worklet.js` consumes transferable Float32 chunks from the bridge without requiring
   `SharedArrayBuffer` or cross-origin isolation. It prebuffers a short bounded lead before
   playback, renders without per-sample allocation, and discards only the oldest queued frames

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -148,13 +148,15 @@ client-side so GitHub Pages can host it as static files.
   VM's combined stream: `$C030` is centered mono and the two AYs retain their left/right
   placement. Synthetic and non-activating events do not consume the pending activation;
   autoplay rejection remains armed for the next interaction, while initialization failures
-  stay visible on the sound control and can be retried explicitly.
+  stay visible on the sound control and can be retried explicitly. Disabling sound disconnects
+  the AudioWorklet renderer and suspends its `AudioContext`; re-enabling resumes and reconnects
+  them.
   `audio-worklet.js` consumes transferable Float32 chunks from the bridge without requiring
   `SharedArrayBuffer` or cross-origin isolation. It prebuffers a short bounded lead before
   playback, renders without per-sample allocation, and discards only the oldest queued frames
   if a stalled producer exceeds the latency bound. Sound is generated only at 1x speed;
-  changing speed mutes and flushes PCM while the speaker latch and emulated VIA/AY state
-  continue to advance.
+  changing speed disconnects the renderer and flushes PCM while the speaker latch and emulated
+  VIA/AY state continue to advance.
 - Gamepad state is sampled once per rendered frame, independently of CPU speed. Disconnecting
   a pad releases every button immediately; reconnecting fills the first free player slot.
   The shared VM, not JavaScript, performs the SNES latch/clock protocol and active-low VIA

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -35,7 +35,7 @@ client-side so GitHub Pages can host it as static files.
 - **Compat shims (`web_compat.h`):** map MSVC-isms (`OutputDebugString`, `sprintf_s`,
   `fopen_s`, `_ASSERT`, …) onto Emscripten so `WozLib`/`MockMicroSD` compile unchanged.
 - **UI (`index.html`):** `requestAnimationFrame` driver, physical/virtual keyboard and gamepad
-  input, disk/SD/clock/sound controls (one opt-in control for both system-speaker and
+  input, disk/SD/clock/sound controls (one on-by-default control for both system-speaker and
   Mockingboard output), and the in-browser **Assembler** panel (imports
   `assemble()` from the staged
   `asm6502.mjs`). Honors optional `window.ASSET_BASE` / `?assets=` for CDN/R2 offload and
@@ -142,9 +142,11 @@ client-side so GitHub Pages can host it as static files.
   displays. A wall-clock execution cap keeps the tab responsive; **Max** remains unthrottled
   within that cap. Timing debt is reset after a machine reset, speed change, or hidden-tab
   transition rather than replaying a stale wall-clock interval.
-- Sound is opt-in because browsers require a user gesture to start `AudioContext`. The
-  bridge drains the VM's combined stream: `$C030` is centered mono and the two AYs retain
-  their left/right placement.
+- Sound is requested by default. Because browsers require a user gesture to start
+  `AudioContext`, the first pointer or keyboard interaction activates it; the sound control
+  can opt out before activation or disable/re-enable audio afterward. The bridge drains the
+  VM's combined stream: `$C030` is centered mono and the two AYs retain their left/right
+  placement.
   `audio-worklet.js` consumes transferable Float32 chunks from the bridge without requiring
   `SharedArrayBuffer` or cross-origin isolation. It prebuffers a short bounded lead before
   playback, renders without per-sample allocation, and discards only the oldest queued frames
@@ -299,7 +301,7 @@ on the emulator whether it succeeds, is blocked, or 404s.
 | Support / funding link | Shipped | GitHub Sponsors call-to-action in the `index.html`/`gallery.html` footers; target declared in `.github/FUNDING.yml`. |
 | Adjustable CPU clock | Shipped | frontend-only pacing; native **1× ≈ 1.57 MHz** (25.175 MHz VGA dot clock ÷ 16) default. |
 | `$C030` system speaker audio | Shipped | Centered mono output shares the VM PCM clock and browser sound control with the Mockingboard; covered by `test_system_speaker.cjs`. |
-| Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the combined speaker/dual-AY stereo PCM; sound enabled only at 1x. |
+| Slot-4 Mockingboard audio | Shipped | User-gesture AudioWorklet sink for the combined speaker/dual-AY stereo PCM; defaults enabled, unlocks on the first pointer/keyboard interaction, and generates sound only at 1x. |
 | Headless smoke tests | Shipped | `web/test_*.cjs` (boot/render/input/audio/screen/sd/disk). |
 | GitHub Pages CI deploy | Shipped | on push to `main` touching emulator/web/codegen sources. |
 | Usage analytics (GoatCounter) | Shipped | Cookieless, privacy-first hit counter on all staged pages (`index`/`gallery`/`tutorials`/`story`); async `//gc.zgo.at/count.js` → `3ric.goatcounter.com`; no cookies/PII, no server, no CSP change. Owner dashboard `https://3ric.goatcounter.com` (register the `3ric` code once to claim it). |

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -44,6 +44,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web/test_virtual_keyboard.cjs    # touch layout covers symbols/modifiers/key codes
 & $node web/test_screen_text.cjs         # decode the 40x24 text screen to ASCII
 & $node web/test_emulation_clock.cjs     # 1x timing at 60/120/144 Hz displays
+& $node web/test_sound_default.cjs       # default-on UI + first-gesture activation
 & $node web/test_audio_pacing.cjs        # real WASM PCM rate at 60/144 Hz displays
 & $node web/test_audio_worklet.cjs       # prebuffer + bounded PCM queue
 & $node web/test_mockingboard.cjs        # slot-4 mirrors, stereo PCM, 3RIC clock, VIA IRQ

--- a/web/README.md
+++ b/web/README.md
@@ -36,9 +36,10 @@ identically. Browser-only presentation code stays in the bridge and JavaScript.
   2× / 4× / 8× / Max, with a per-frame wall-clock cap so the page stays responsive.
 - **3RIC audio**: the mono `$C030` system speaker is centered and mixed with two
   AY-3-8910s at `$C400/$C480`, clocked directly from 1.5734375 MHz PHI2 and
-  hard-panned stereo. **Enable Sound** creates the browser audio context after a
-  user gesture. Audio plays at 1× and pauses at other speed settings while the
-  emulated latch and chips continue to advance.
+  hard-panned stereo. Sound is enabled by default; the first pointer or keyboard
+  interaction creates the browser audio context, and **Disable Sound** opts out.
+  Audio plays at 1× and pauses at other speed settings while the emulated latch
+  and chips continue to advance.
 - **In-browser assembler** (**Assemble & Run**): edit 65C02 source in the page,
   assemble it client-side with the very same assembler the CLI uses
   (`codegen/tools/asm6502.mjs`), run the resulting image like **Load .PRG**, and
@@ -122,9 +123,9 @@ the DOS shell — it runs the monitor command `EC5CG` (Go to `$EC5C`, the `dos`
 routine) which mounts the FAT32 image and prints a `>` prompt, then auto-runs
 `DIR`. Type `CAT`, `CD <dir>`, `BRUN <file>`, etc. to load games and programs
 from the card. The **Speed** selector sets the CPU clock (0.5×–8× or Max).
-Press **Enable Sound** to start the system-speaker and stereo Mockingboard mix.
-Browser autoplay rules require this click; sound is intentionally generated only
-at native 1×.
+The system-speaker and stereo Mockingboard mix is enabled by default. Browser
+autoplay rules delay it until the first pointer or keyboard interaction; press
+**Disable Sound** to opt out. Sound is intentionally generated only at native 1×.
 
 > Port 8011 is used because 8000 is taken on this machine.
 
@@ -229,6 +230,7 @@ $node = "C:\Users\ebadger\emsdk\node\22.16.0_64bit\bin\node.exe"
 & $node web\test_keyboard.cjs    # monitor echoes typed commands
 & $node web\test_screen_text.cjs # decode the text screen to ASCII
 & $node web\test_emulation_clock.cjs # 1x timing at 60/120/144 Hz displays
+& $node web\test_sound_default.cjs # default-on UI + first-gesture activation
 & $node web\test_audio_pacing.cjs # real WASM PCM rate at 60/144 Hz displays
 & $node web\test_audio_worklet.cjs # prebuffer + bounded PCM queue
 & $node web\test_mockingboard.cjs # mirrors, stereo PCM, 3RIC clock, timer IRQ

--- a/web/index.html
+++ b/web/index.html
@@ -227,8 +227,8 @@
         <option value="8">8&times; (12.6&nbsp;MHz)</option>
         <option value="max">Max</option>
       </select></span>
-    <button id="sound" type="button" aria-pressed="false"
-      title="Enable the system speaker and slot-4 Mockingboard at native 1x speed">Enable Sound</button>
+    <button id="sound" type="button" aria-pressed="true"
+      title="Disable system-speaker and Mockingboard audio">Disable Sound</button>
     <span class="regs" id="regs">PC:---- A:-- X:-- Y:-- SP:-- P:--</span>
     <span class="regs" id="mode">mode:---</span>
     <span class="hint" id="gamepads">gamepads: detecting&hellip;</span>
@@ -336,8 +336,9 @@
     <code>?prg=programs/hello.prg&amp;org=0800</code>).
     &ldquo;Speed&rdquo; sets the CPU clock (native 1&times; &asymp; 1.57&nbsp;MHz &mdash; the 25.175&nbsp;MHz VGA
     dot clock &divide;&nbsp;16; &ldquo;Max&rdquo; runs as fast as the frame allows).
-    &ldquo;Enable Sound&rdquo; starts browser audio at native 1&times; speed; other speeds pause and flush audio
-    while the emulated sound hardware continues to run.
+    Sound is enabled by default and starts on the first pointer or keyboard interaction;
+    &ldquo;Disable Sound&rdquo; opts out. Other speeds pause and flush audio while the emulated sound
+    hardware continues to run.
     The <strong>Assembler</strong> panel assembles 65C02 source in your browser (the same assembler the
     project uses on the command line) and runs it just like &ldquo;Load&nbsp;.PRG&rdquo; &mdash; pick a sample,
     edit it, <code>Assemble&nbsp;&amp;&nbsp;Run</code> (or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>), and download the
@@ -390,8 +391,9 @@
     let demoDisk = null;
     let audioContext = null;
     let audioNode = null;
-    let soundRequested = false;
+    let soundRequested = true;
     let audioGenerating = false;
+    let audioActivation = null;
     let debuggerController = null;
     const inputQueue = [];
 
@@ -517,6 +519,12 @@
     }
 
     function updateSoundButton() {
+      if (soundButton.disabled) {
+        soundButton.setAttribute("aria-pressed", "false");
+        soundButton.textContent = "Sound Unavailable";
+        soundButton.title = "Web Audio is not supported";
+        return;
+      }
       soundButton.setAttribute("aria-pressed", soundRequested ? "true" : "false");
       if (!soundRequested) {
         soundButton.textContent = "Enable Sound";
@@ -544,7 +552,7 @@
     }
 
     function syncAudioForSpeed() {
-      const shouldGenerate = soundRequested && speedMul === 1;
+      const shouldGenerate = soundRequested && speedMul === 1 && audioNode !== null;
       if (!setAudioGeneration(shouldGenerate)) {
         soundRequested = false;
         setAudioGeneration(false);
@@ -553,17 +561,13 @@
       updateSoundButton();
     }
 
-    async function toggleSound() {
-      if (soundRequested) {
-        soundRequested = false;
-        syncAudioForSpeed();
-        return;
-      }
-
+    async function startSound() {
+      if (!soundRequested) return;
       const AudioContextClass = window.AudioContext || window.webkitAudioContext;
       if (!AudioContextClass) {
+        soundRequested = false;
         soundButton.disabled = true;
-        soundButton.textContent = "Sound Unavailable";
+        updateSoundButton();
         statusEl.textContent = "sound unavailable: Web Audio is not supported";
         return;
       }
@@ -574,6 +578,7 @@
           if (!audioContext.audioWorklet) {
             throw new Error("AudioWorklet is not supported");
           }
+          await audioContext.resume();
           await audioContext.audioWorklet.addModule(
             new URL("audio-worklet.js", document.baseURI));
           audioNode = new AudioWorkletNode(audioContext, "badger-audio", {
@@ -582,9 +587,9 @@
             outputChannelCount: [2],
           });
           audioNode.connect(audioContext.destination);
+        } else {
+          await audioContext.resume();
         }
-        await audioContext.resume();
-        soundRequested = true;
         syncAudioForSpeed();
       } catch (error) {
         soundRequested = false;
@@ -598,11 +603,57 @@
           audioContext = null;
           audioNode = null;
         }
+        soundButton.setAttribute("aria-pressed", "false");
         soundButton.textContent = "Sound Unavailable";
+        soundButton.title = "Browser audio could not be started";
         statusEl.textContent = "sound unavailable: " + error.message;
         console.error(error);
       }
     }
+
+    async function activateSound() {
+      if (!soundRequested) return;
+      if (!audioActivation) {
+        audioActivation = startSound().finally(() => {
+          audioActivation = null;
+        });
+      }
+      await audioActivation;
+    }
+
+    function disarmDefaultSoundActivation() {
+      document.removeEventListener("click", activateDefaultSound, true);
+      document.removeEventListener("keydown", activateDefaultSound, true);
+    }
+
+    function activateDefaultSound(event) {
+      if (soundButton.contains(event.target)) return;
+      disarmDefaultSoundActivation();
+      void activateSound();
+    }
+
+    function armDefaultSoundActivation() {
+      document.addEventListener("click", activateDefaultSound, true);
+      document.addEventListener("keydown", activateDefaultSound, true);
+    }
+
+    async function toggleSound() {
+      if (soundRequested) {
+        soundRequested = false;
+        disarmDefaultSoundActivation();
+        syncAudioForSpeed();
+        return;
+      }
+
+      disarmDefaultSoundActivation();
+      soundRequested = true;
+      updateSoundButton();
+      await activateSound();
+    }
+
+    soundButton.addEventListener("click", toggleSound);
+    updateSoundButton();
+    armDefaultSoundActivation();
 
     function frame(timestamp) {
       pollGamepads();
@@ -1294,6 +1345,7 @@
       await loadRom();
       statusEl.textContent = "running";
       canvas.focus();
+      if (audioContext && !audioActivation && soundRequested) syncAudioForSpeed();
 
       BadgerVirtualKeyboard.mount(
         document.getElementById("virtual-keyboard-keys"),
@@ -1324,9 +1376,6 @@
         await loadRom();
         canvas.focus();
       });
-
-      soundButton.addEventListener("click", toggleSound);
-      updateSoundButton();
 
       // Mount the micro-SD card and drop into the ROM's DOS shell. "EC5CG" is
       // the monitor's Go command pointed at $EC5C (the `dos` routine), which

--- a/web/index.html
+++ b/web/index.html
@@ -394,6 +394,7 @@
     let soundRequested = true;
     let audioGenerating = false;
     let audioActivation = null;
+    let audioConnected = false;
     let audioError = null;
     let debuggerController = null;
     const inputQueue = [];
@@ -519,6 +520,31 @@
       if (audioNode) audioNode.port.postMessage({ type: "clear" });
     }
 
+    function clearSoundStatus() {
+      if (statusEl.textContent.startsWith("sound unavailable:") ||
+          statusEl.textContent.startsWith("sound disable warning:")) {
+        statusEl.textContent = vm ? "running" : "loading wasm\u2026";
+      }
+    }
+
+    function setAudioConnection(enabled) {
+      if (!audioNode || enabled === audioConnected) return;
+      if (enabled) audioNode.connect(audioContext.destination);
+      else audioNode.disconnect();
+      audioConnected = enabled;
+    }
+
+    async function suspendAudioContext() {
+      setAudioConnection(false);
+      if (!audioContext || audioContext.state !== "running") return;
+      try {
+        await audioContext.suspend();
+      } catch (error) {
+        statusEl.textContent = "sound disable warning: " + error.message;
+        console.error(error);
+      }
+    }
+
     function updateSoundButton() {
       if (soundButton.disabled) {
         soundButton.setAttribute("aria-pressed", "false");
@@ -562,12 +588,16 @@
 
     function syncAudioForSpeed() {
       const shouldGenerate = soundRequested && speedMul === 1 && audioNode !== null;
+      if (!shouldGenerate) setAudioConnection(false);
       if (!setAudioGeneration(shouldGenerate)) {
         soundRequested = false;
         audioError = "Unsupported audio sample rate";
         setAudioGeneration(false);
+        setAudioConnection(false);
         disarmDefaultSoundActivation();
         statusEl.textContent = "sound unavailable: unsupported sample rate";
+      } else if (shouldGenerate) {
+        setAudioConnection(true);
       }
       updateSoundButton();
     }
@@ -607,6 +637,7 @@
       }
 
       audioError = null;
+      clearSoundStatus();
       updateSoundButton();
       try {
         if (!audioContext) {
@@ -622,13 +653,13 @@
             numberOfOutputs: 1,
             outputChannelCount: [2],
           });
-          audioNode.connect(audioContext.destination);
         } else {
           await resumeAudioContext();
         }
         syncAudioForSpeed();
-        if (statusEl.textContent.startsWith("sound unavailable:")) {
-          statusEl.textContent = vm ? "running" : "loading wasm\u2026";
+        if (!soundRequested) {
+          await suspendAudioContext();
+          return false;
         }
         return soundRequested && audioNode !== null && audioContext.state === "running";
       } catch (error) {
@@ -648,6 +679,7 @@
           }
           audioContext = null;
           audioNode = null;
+          audioConnected = false;
         }
         if (retryOnNextInteraction) armDefaultSoundActivation();
         else disarmDefaultSoundActivation();
@@ -698,6 +730,7 @@
         audioError = null;
         disarmDefaultSoundActivation();
         syncAudioForSpeed();
+        await suspendAudioContext();
         return;
       }
 

--- a/web/index.html
+++ b/web/index.html
@@ -394,6 +394,7 @@
     let soundRequested = true;
     let audioGenerating = false;
     let audioActivation = null;
+    let audioError = null;
     let debuggerController = null;
     const inputQueue = [];
 
@@ -522,7 +523,15 @@
       if (soundButton.disabled) {
         soundButton.setAttribute("aria-pressed", "false");
         soundButton.textContent = "Sound Unavailable";
-        soundButton.title = "Web Audio is not supported";
+        soundButton.title = audioError || "Web Audio is not supported";
+        return;
+      }
+      if (audioError) {
+        soundButton.setAttribute("aria-pressed", soundRequested ? "true" : "false");
+        soundButton.textContent = soundRequested ? "Sound Waiting" : "Retry Sound";
+        soundButton.title = soundRequested
+          ? `Sound will retry on the next interaction: ${audioError}`
+          : `Retry system-speaker and Mockingboard audio: ${audioError}`;
         return;
       }
       soundButton.setAttribute("aria-pressed", soundRequested ? "true" : "false");
@@ -555,30 +564,57 @@
       const shouldGenerate = soundRequested && speedMul === 1 && audioNode !== null;
       if (!setAudioGeneration(shouldGenerate)) {
         soundRequested = false;
+        audioError = "Unsupported audio sample rate";
         setAudioGeneration(false);
+        disarmDefaultSoundActivation();
         statusEl.textContent = "sound unavailable: unsupported sample rate";
       }
       updateSoundButton();
     }
 
+    function audioActivationTimeout() {
+      const error = new Error("Browser did not allow sound to start");
+      error.name = "NotAllowedError";
+      return error;
+    }
+
+    async function resumeAudioContext() {
+      let timeout = null;
+      try {
+        await Promise.race([
+          audioContext.resume(),
+          new Promise((_, reject) => {
+            timeout = setTimeout(() => reject(audioActivationTimeout()), 1000);
+          }),
+        ]);
+      } finally {
+        if (timeout !== null) clearTimeout(timeout);
+      }
+      if (audioContext.state !== "running") throw audioActivationTimeout();
+    }
+
     async function startSound() {
-      if (!soundRequested) return;
+      if (!soundRequested) return false;
       const AudioContextClass = window.AudioContext || window.webkitAudioContext;
       if (!AudioContextClass) {
         soundRequested = false;
+        audioError = "Web Audio is not supported";
         soundButton.disabled = true;
+        disarmDefaultSoundActivation();
         updateSoundButton();
         statusEl.textContent = "sound unavailable: Web Audio is not supported";
-        return;
+        return false;
       }
 
+      audioError = null;
+      updateSoundButton();
       try {
         if (!audioContext) {
           audioContext = new AudioContextClass({ latencyHint: "interactive" });
           if (!audioContext.audioWorklet) {
             throw new Error("AudioWorklet is not supported");
           }
-          await audioContext.resume();
+          await resumeAudioContext();
           await audioContext.audioWorklet.addModule(
             new URL("audio-worklet.js", document.baseURI));
           audioNode = new AudioWorkletNode(audioContext, "badger-audio", {
@@ -588,11 +624,21 @@
           });
           audioNode.connect(audioContext.destination);
         } else {
-          await audioContext.resume();
+          await resumeAudioContext();
         }
         syncAudioForSpeed();
+        if (statusEl.textContent.startsWith("sound unavailable:")) {
+          statusEl.textContent = vm ? "running" : "loading wasm\u2026";
+        }
+        return soundRequested && audioNode !== null && audioContext.state === "running";
       } catch (error) {
-        soundRequested = false;
+        const activationCancelled = !soundRequested;
+        const retryOnNextInteraction =
+          !activationCancelled && error && error.name === "NotAllowedError";
+        soundRequested = retryOnNextInteraction;
+        audioError = activationCancelled
+          ? null
+          : (error && error.message ? error.message : String(error));
         setAudioGeneration(false);
         if (audioContext) {
           try {
@@ -603,22 +649,25 @@
           audioContext = null;
           audioNode = null;
         }
-        soundButton.setAttribute("aria-pressed", "false");
-        soundButton.textContent = "Sound Unavailable";
-        soundButton.title = "Browser audio could not be started";
-        statusEl.textContent = "sound unavailable: " + error.message;
-        console.error(error);
+        if (retryOnNextInteraction) armDefaultSoundActivation();
+        else disarmDefaultSoundActivation();
+        updateSoundButton();
+        if (!activationCancelled) {
+          statusEl.textContent = "sound unavailable: " + audioError;
+          console.error(error);
+        }
+        return false;
       }
     }
 
     async function activateSound() {
-      if (!soundRequested) return;
+      if (!soundRequested) return false;
       if (!audioActivation) {
         audioActivation = startSound().finally(() => {
           audioActivation = null;
         });
       }
-      await audioActivation;
+      return await audioActivation;
     }
 
     function disarmDefaultSoundActivation() {
@@ -626,10 +675,16 @@
       document.removeEventListener("keydown", activateDefaultSound, true);
     }
 
-    function activateDefaultSound(event) {
-      if (soundButton.contains(event.target)) return;
-      disarmDefaultSoundActivation();
-      void activateSound();
+    function isDefaultSoundActivation(event) {
+      if (!event || event.isTrusted !== true) return false;
+      if (event.type === "keydown" && event.key === "Escape") return false;
+      const userActivation = window.navigator && window.navigator.userActivation;
+      return !userActivation || userActivation.isActive;
+    }
+
+    async function activateDefaultSound(event) {
+      if (soundButton.contains(event.target) || !isDefaultSoundActivation(event)) return;
+      if (await activateSound()) disarmDefaultSoundActivation();
     }
 
     function armDefaultSoundActivation() {
@@ -640,6 +695,7 @@
     async function toggleSound() {
       if (soundRequested) {
         soundRequested = false;
+        audioError = null;
         disarmDefaultSoundActivation();
         syncAudioForSpeed();
         return;
@@ -647,6 +703,7 @@
 
       disarmDefaultSoundActivation();
       soundRequested = true;
+      audioError = null;
       updateSoundButton();
       await activateSound();
     }

--- a/web/test_sound_default.cjs
+++ b/web/test_sound_default.cjs
@@ -67,6 +67,15 @@ assert.match(
   /if \(audioError\) \{[\s\S]*?soundButton\.textContent = soundRequested \? "Sound Waiting" : "Retry Sound";[\s\S]*?return;\s+\}/,
   "audio errors must survive unrelated button refreshes and remain retryable",
 );
+const startSoundSource = inlineScript.slice(
+  inlineScript.indexOf("async function startSound()"),
+  inlineScript.indexOf("async function activateSound()"),
+);
+assert(
+  startSoundSource.indexOf("clearSoundStatus();") <
+    startSoundSource.indexOf("syncAudioForSpeed();"),
+  "stale sound errors must clear before initialization so new failures remain visible",
+);
 
 class FakeElement {
   constructor(id) {
@@ -145,9 +154,12 @@ function mountPage(options = {}) {
   const metrics = {
     connections: 0,
     contexts: 0,
+    disconnections: 0,
     moduleLoads: 0,
     nodes: 0,
+    rendererActive: false,
     resumes: 0,
+    suspends: 0,
   };
 
   class FakeAudioContext {
@@ -188,6 +200,11 @@ function mountPage(options = {}) {
     async close() {
       this.state = "closed";
     }
+
+    async suspend() {
+      metrics.suspends++;
+      this.state = "suspended";
+    }
   }
 
   class FakeAudioWorkletNode {
@@ -198,6 +215,12 @@ function mountPage(options = {}) {
 
     connect() {
       metrics.connections++;
+      metrics.rendererActive = true;
+    }
+
+    disconnect() {
+      metrics.disconnections++;
+      metrics.rendererActive = false;
     }
   }
 
@@ -260,9 +283,12 @@ async function main() {
   assert.deepEqual(activated.metrics, {
     connections: 1,
     contexts: 1,
+    disconnections: 0,
     moduleLoads: 1,
     nodes: 1,
+    rendererActive: true,
     resumes: 1,
+    suspends: 0,
   });
   assert.equal(activated.document.listenerCount("click"), 0);
   assert.equal(activated.document.listenerCount("keydown"), 0);
@@ -285,8 +311,13 @@ async function main() {
   await activatedButton.dispatch("click");
   assert.equal(activatedButton.getAttribute("aria-pressed"), "false");
   assert.equal(activatedButton.textContent, "Enable Sound");
+  assert.equal(activated.metrics.disconnections, 1);
+  assert.equal(activated.metrics.rendererActive, false);
+  assert.equal(activated.metrics.suspends, 1);
   await activatedButton.dispatch("click");
   assert.equal(activated.metrics.contexts, 1, "re-enabling must reuse the audio context");
+  assert.equal(activated.metrics.connections, 2);
+  assert.equal(activated.metrics.rendererActive, true);
   assert.equal(activated.metrics.resumes, 2);
   assert.equal(activatedButton.getAttribute("aria-pressed"), "true");
   assert.equal(activatedButton.textContent, "Disable Sound");
@@ -312,6 +343,22 @@ async function main() {
   assert.equal(blocked.metrics.nodes, 1);
   assert.equal(blockedButton.textContent, "Disable Sound");
   assert.equal(blocked.document.listenerCount("click"), 0);
+
+  const cancelledStart = mountPage({ deferResume: true });
+  const cancelledStartButton = cancelledStart.document.getElementById("sound");
+  const cancelledStartActivation = cancelledStart.document.dispatch(
+    "click",
+    cancelledStart.document.getElementById("screen"),
+  );
+  await cancelledStartButton.dispatch("click");
+  cancelledStart.settleResume();
+  await cancelledStartActivation;
+  assert.equal(cancelledStart.metrics.nodes, 1);
+  assert.equal(cancelledStart.metrics.connections, 0);
+  assert.equal(cancelledStart.metrics.rendererActive, false);
+  assert.equal(cancelledStart.metrics.suspends, 1);
+  assert.equal(cancelledStartButton.getAttribute("aria-pressed"), "false");
+  assert.equal(cancelledStartButton.textContent, "Enable Sound");
 
   const cancelled = mountPage({ deferResume: true });
   const cancelledButton = cancelled.document.getElementById("sound");

--- a/web/test_sound_default.cjs
+++ b/web/test_sound_default.cjs
@@ -27,8 +27,13 @@ assert.match(
 );
 assert.match(
   inlineScript,
-  /function activateDefaultSound\(event\) \{\s+if \(soundButton\.contains\(event\.target\)\) return;\s+disarmDefaultSoundActivation\(\);\s+void activateSound\(\);\s+\}/,
-  "the first non-toggle interaction must activate default sound",
+  /if \(!event \|\| event\.isTrusted !== true\) return false;\s+if \(event\.type === "keydown" && event\.key === "Escape"\) return false;/,
+  "synthetic and non-activating key events must not consume default activation",
+);
+assert.match(
+  inlineScript,
+  /async function activateDefaultSound\(event\) \{\s+if \(soundButton\.contains\(event\.target\) \|\| !isDefaultSoundActivation\(event\)\) return;\s+if \(await activateSound\(\)\) disarmDefaultSoundActivation\(\);\s+\}/,
+  "default activation must disarm only after sound starts",
 );
 assert.match(
   inlineScript,
@@ -54,8 +59,13 @@ assert.match(
 );
 assert.match(
   inlineScript,
-  /if \(soundRequested\) \{\s+soundRequested = false;\s+disarmDefaultSoundActivation\(\);\s+syncAudioForSpeed\(\);/,
+  /if \(soundRequested\) \{\s+soundRequested = false;\s+audioError = null;\s+disarmDefaultSoundActivation\(\);\s+syncAudioForSpeed\(\);/,
   "the sound control must opt out before or after activation",
+);
+assert.match(
+  inlineScript,
+  /if \(audioError\) \{[\s\S]*?soundButton\.textContent = soundRequested \? "Sound Waiting" : "Retry Sound";[\s\S]*?return;\s+\}/,
+  "audio errors must survive unrelated button refreshes and remain retryable",
 );
 
 class FakeElement {
@@ -70,7 +80,7 @@ class FakeElement {
 
   addEventListener(type, listener) {
     const listeners = this.listeners.get(type) || [];
-    listeners.push(listener);
+    if (!listeners.includes(listener)) listeners.push(listener);
     this.listeners.set(type, listeners);
   }
 
@@ -79,9 +89,16 @@ class FakeElement {
     this.listeners.set(type, listeners.filter((candidate) => candidate !== listener));
   }
 
-  async dispatch(type, target = this) {
+  async dispatch(type, target = this, overrides = {}) {
+    const event = {
+      isTrusted: true,
+      key: "",
+      target,
+      type,
+      ...overrides,
+    };
     const results = [...(this.listeners.get(type) || [])]
-      .map((listener) => listener({ type, target }));
+      .map((listener) => listener(event));
     await Promise.all(results.filter((result) => result instanceof Promise));
   }
 
@@ -119,8 +136,12 @@ class FakeDocument extends FakeElement {
   }
 }
 
-function mountPage() {
+function mountPage(options = {}) {
   const document = new FakeDocument();
+  let deferredResume = null;
+  let deferredResumeUsed = false;
+  let moduleFailures = options.moduleFailures || 0;
+  let resumeFailures = options.resumeFailures || 0;
   const metrics = {
     connections: 0,
     contexts: 0,
@@ -132,10 +153,15 @@ function mountPage() {
   class FakeAudioContext {
     constructor() {
       metrics.contexts++;
+      this.state = "suspended";
       this.audioWorklet = {
         addModule: async (url) => {
           assert.equal(url.href, "https://example.test/audio-worklet.js");
           metrics.moduleLoads++;
+          if (moduleFailures > 0) {
+            moduleFailures--;
+            throw new Error("worklet load failed");
+          }
         },
       };
       this.destination = {};
@@ -144,9 +170,24 @@ function mountPage() {
 
     async resume() {
       metrics.resumes++;
+      if (options.deferResume && !deferredResumeUsed) {
+        deferredResumeUsed = true;
+        await new Promise((resolve, reject) => {
+          deferredResume = (error) => error ? reject(error) : resolve();
+        });
+      }
+      if (resumeFailures > 0) {
+        resumeFailures--;
+        const error = new Error("user activation required");
+        error.name = "NotAllowedError";
+        throw error;
+      }
+      this.state = "running";
     }
 
-    async close() {}
+    async close() {
+      this.state = "closed";
+    }
   }
 
   class FakeAudioWorkletNode {
@@ -168,19 +209,31 @@ function mountPage() {
     "BadgerGamepads",
     "createBadgerVM",
     "AudioWorkletNode",
+    "console",
     inlineScript,
   );
   executePage(
-    { AudioContext: FakeAudioContext },
+    {
+      AudioContext: FakeAudioContext,
+      navigator: { userActivation: { isActive: true } },
+    },
     document,
     { search: "" },
     { EmulationClock: class {} },
     { GamepadManager: class {} },
     () => new Promise(() => {}),
     FakeAudioWorkletNode,
+    { error() {} },
   );
 
-  return { document, metrics };
+  return {
+    document,
+    metrics,
+    settleResume(error = null) {
+      assert(deferredResume, "deferred resume must be pending");
+      deferredResume(error);
+    },
+  };
 }
 
 async function main() {
@@ -216,6 +269,19 @@ async function main() {
   assert.equal(activatedButton.getAttribute("aria-pressed"), "true");
   assert.equal(activatedButton.textContent, "Disable Sound");
 
+  const ignored = mountPage();
+  const ignoredScreen = ignored.document.getElementById("screen");
+  await ignored.document.dispatch("keydown", ignoredScreen, { key: "Escape" });
+  await ignored.document.dispatch("keydown", ignoredScreen, {
+    isTrusted: false,
+    key: "A",
+  });
+  assert.equal(ignored.metrics.contexts, 0);
+  assert.equal(ignored.document.listenerCount("click"), 1);
+  assert.equal(ignored.document.listenerCount("keydown"), 1);
+  await ignored.document.dispatch("click", ignoredScreen);
+  assert.equal(ignored.metrics.contexts, 1);
+
   await activatedButton.dispatch("click");
   assert.equal(activatedButton.getAttribute("aria-pressed"), "false");
   assert.equal(activatedButton.textContent, "Enable Sound");
@@ -233,6 +299,54 @@ async function main() {
   await new Promise(setImmediate);
   assert.equal(keyboardActivated.metrics.contexts, 1);
   assert.equal(keyboardActivated.metrics.nodes, 1);
+
+  const blocked = mountPage({ resumeFailures: 1 });
+  const blockedButton = blocked.document.getElementById("sound");
+  const blockedScreen = blocked.document.getElementById("screen");
+  await blocked.document.dispatch("click", blockedScreen);
+  assert.equal(blockedButton.getAttribute("aria-pressed"), "true");
+  assert.equal(blockedButton.textContent, "Sound Waiting");
+  assert.equal(blocked.document.listenerCount("click"), 1);
+  await blocked.document.dispatch("click", blockedScreen);
+  assert.equal(blocked.metrics.contexts, 2);
+  assert.equal(blocked.metrics.nodes, 1);
+  assert.equal(blockedButton.textContent, "Disable Sound");
+  assert.equal(blocked.document.listenerCount("click"), 0);
+
+  const cancelled = mountPage({ deferResume: true });
+  const cancelledButton = cancelled.document.getElementById("sound");
+  const cancelledActivation = cancelled.document.dispatch(
+    "click",
+    cancelled.document.getElementById("screen"),
+  );
+  await cancelledButton.dispatch("click");
+  const cancelledError = new Error("user activation required");
+  cancelledError.name = "NotAllowedError";
+  cancelled.settleResume(cancelledError);
+  await cancelledActivation;
+  assert.equal(cancelledButton.getAttribute("aria-pressed"), "false");
+  assert.equal(cancelledButton.textContent, "Enable Sound");
+  assert.equal(cancelled.document.listenerCount("click"), 0);
+  assert.doesNotMatch(cancelledButton.title, /retry/i);
+
+  const failed = mountPage({ moduleFailures: 1 });
+  const failedButton = failed.document.getElementById("sound");
+  await failed.document.dispatch(
+    "click",
+    failed.document.getElementById("screen"),
+  );
+  assert.equal(failedButton.getAttribute("aria-pressed"), "false");
+  assert.equal(failedButton.textContent, "Retry Sound");
+  assert.match(failedButton.title, /worklet load failed/);
+  await failedButton.dispatch("click");
+  assert.equal(failed.metrics.contexts, 2);
+  assert.equal(failed.metrics.nodes, 1);
+  assert.equal(failedButton.getAttribute("aria-pressed"), "true");
+  assert.equal(failedButton.textContent, "Disable Sound");
+  assert.equal(
+    failed.document.getElementById("status").textContent,
+    "loading wasm\u2026",
+  );
 
   console.log("PASS: browser sound defaults on and unlocks on first interaction");
 }

--- a/web/test_sound_default.cjs
+++ b/web/test_sound_default.cjs
@@ -1,0 +1,243 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const pageHtml = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
+const inlineScript = pageHtml.match(/<script>\s*([\s\S]*?)\s*<\/script>/)?.[1];
+
+assert(inlineScript, "page must include the emulator script");
+assert.doesNotThrow(
+  () => new Function(inlineScript),
+  "emulator script must remain valid JavaScript",
+);
+assert.match(
+  pageHtml,
+  /<button id="sound" type="button" aria-pressed="true"\s+title="[^"]+">Disable Sound<\/button>/,
+  "sound control must render enabled by default",
+);
+assert.match(
+  inlineScript,
+  /let soundRequested = true;/,
+  "runtime sound state must default to enabled",
+);
+assert.match(
+  inlineScript,
+  /const shouldGenerate = soundRequested && speedMul === 1 && audioNode !== null;/,
+  "PCM generation must wait until browser audio finishes unlocking",
+);
+assert.match(
+  inlineScript,
+  /function activateDefaultSound\(event\) \{\s+if \(soundButton\.contains\(event\.target\)\) return;\s+disarmDefaultSoundActivation\(\);\s+void activateSound\(\);\s+\}/,
+  "the first non-toggle interaction must activate default sound",
+);
+assert.match(
+  inlineScript,
+  /document\.addEventListener\("click", activateDefaultSound, true\);\s+document\.addEventListener\("keydown", activateDefaultSound, true\);/,
+  "pointer and keyboard gestures must unlock browser audio",
+);
+assert.match(
+  inlineScript,
+  /soundButton\.addEventListener\("click", toggleSound\);\s+updateSoundButton\(\);\s+armDefaultSoundActivation\(\);/,
+  "default activation must be armed after the sound control is wired",
+);
+const soundWiringIndex = inlineScript.indexOf(
+  'soundButton.addEventListener("click", toggleSound);',
+);
+assert(
+  soundWiringIndex < inlineScript.indexOf("createBadgerVM({"),
+  "sound controls must work while the emulator is loading",
+);
+assert.match(
+  inlineScript,
+  /if \(audioContext && !audioActivation && soundRequested\) syncAudioForSpeed\(\);/,
+  "boot must connect audio that unlocked before the VM was ready",
+);
+assert.match(
+  inlineScript,
+  /if \(soundRequested\) \{\s+soundRequested = false;\s+disarmDefaultSoundActivation\(\);\s+syncAudioForSpeed\(\);/,
+  "the sound control must opt out before or after activation",
+);
+
+class FakeElement {
+  constructor(id) {
+    this.id = id;
+    this.attributes = {};
+    this.disabled = false;
+    this.listeners = new Map();
+    this.textContent = "";
+    this.title = "";
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    this.listeners.set(type, listeners.filter((candidate) => candidate !== listener));
+  }
+
+  async dispatch(type, target = this) {
+    const results = [...(this.listeners.get(type) || [])]
+      .map((listener) => listener({ type, target }));
+    await Promise.all(results.filter((result) => result instanceof Promise));
+  }
+
+  listenerCount(type) {
+    return (this.listeners.get(type) || []).length;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+
+  getAttribute(name) {
+    return this.attributes[name];
+  }
+
+  contains(target) {
+    return target === this;
+  }
+
+  getContext() {
+    return {};
+  }
+}
+
+class FakeDocument extends FakeElement {
+  constructor() {
+    super("document");
+    this.baseURI = "https://example.test/";
+    this.elements = new Map();
+  }
+
+  getElementById(id) {
+    if (!this.elements.has(id)) this.elements.set(id, new FakeElement(id));
+    return this.elements.get(id);
+  }
+}
+
+function mountPage() {
+  const document = new FakeDocument();
+  const metrics = {
+    connections: 0,
+    contexts: 0,
+    moduleLoads: 0,
+    nodes: 0,
+    resumes: 0,
+  };
+
+  class FakeAudioContext {
+    constructor() {
+      metrics.contexts++;
+      this.audioWorklet = {
+        addModule: async (url) => {
+          assert.equal(url.href, "https://example.test/audio-worklet.js");
+          metrics.moduleLoads++;
+        },
+      };
+      this.destination = {};
+      this.sampleRate = 48000;
+    }
+
+    async resume() {
+      metrics.resumes++;
+    }
+
+    async close() {}
+  }
+
+  class FakeAudioWorkletNode {
+    constructor() {
+      metrics.nodes++;
+      this.port = { postMessage() {} };
+    }
+
+    connect() {
+      metrics.connections++;
+    }
+  }
+
+  const executePage = new Function(
+    "window",
+    "document",
+    "location",
+    "BadgerEmulationClock",
+    "BadgerGamepads",
+    "createBadgerVM",
+    "AudioWorkletNode",
+    inlineScript,
+  );
+  executePage(
+    { AudioContext: FakeAudioContext },
+    document,
+    { search: "" },
+    { EmulationClock: class {} },
+    { GamepadManager: class {} },
+    () => new Promise(() => {}),
+    FakeAudioWorkletNode,
+  );
+
+  return { document, metrics };
+}
+
+async function main() {
+  const optedOut = mountPage();
+  const optOutButton = optedOut.document.getElementById("sound");
+  assert.equal(optOutButton.getAttribute("aria-pressed"), "true");
+  assert.equal(optOutButton.textContent, "Disable Sound");
+  await optedOut.document.dispatch("click", optOutButton);
+  assert.equal(optedOut.metrics.contexts, 0, "the opt-out click must not start audio");
+  await optOutButton.dispatch("click");
+  assert.equal(optedOut.metrics.contexts, 0, "opting out must not create an audio context");
+  assert.equal(optOutButton.getAttribute("aria-pressed"), "false");
+  assert.equal(optOutButton.textContent, "Enable Sound");
+  assert.equal(optedOut.document.listenerCount("click"), 0);
+  assert.equal(optedOut.document.listenerCount("keydown"), 0);
+
+  const activated = mountPage();
+  const activatedButton = activated.document.getElementById("sound");
+  await activated.document.dispatch(
+    "click",
+    activated.document.getElementById("screen"),
+  );
+  await new Promise(setImmediate);
+  assert.deepEqual(activated.metrics, {
+    connections: 1,
+    contexts: 1,
+    moduleLoads: 1,
+    nodes: 1,
+    resumes: 1,
+  });
+  assert.equal(activated.document.listenerCount("click"), 0);
+  assert.equal(activated.document.listenerCount("keydown"), 0);
+  assert.equal(activatedButton.getAttribute("aria-pressed"), "true");
+  assert.equal(activatedButton.textContent, "Disable Sound");
+
+  await activatedButton.dispatch("click");
+  assert.equal(activatedButton.getAttribute("aria-pressed"), "false");
+  assert.equal(activatedButton.textContent, "Enable Sound");
+  await activatedButton.dispatch("click");
+  assert.equal(activated.metrics.contexts, 1, "re-enabling must reuse the audio context");
+  assert.equal(activated.metrics.resumes, 2);
+  assert.equal(activatedButton.getAttribute("aria-pressed"), "true");
+  assert.equal(activatedButton.textContent, "Disable Sound");
+
+  const keyboardActivated = mountPage();
+  await keyboardActivated.document.dispatch(
+    "keydown",
+    keyboardActivated.document.getElementById("screen"),
+  );
+  await new Promise(setImmediate);
+  assert.equal(keyboardActivated.metrics.contexts, 1);
+  assert.equal(keyboardActivated.metrics.nodes, 1);
+
+  console.log("PASS: browser sound defaults on and unlocks on first interaction");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- request browser sound by default and unlock Web Audio on the first trusted click or activating keypress
- keep the sound control as an immediate opt-out with retryable startup failures
- disconnect the AudioWorklet and suspend its context when disabled, then resume/reconnect on re-enable
- document the behavior and cover activation, cancellation, retry, and renderer lifecycle races

## Tests
- `web/test_sound_default.cjs`
- `web/test_audio_worklet.cjs`
- `web/test_virtual_keyboard.cjs`
- pre-push 65C02 assembler gate

## Second-model review
- Reviewed diff: `d10107b4455cc9a8360806ca98388ee2f6739f3f...ac742cfd6689a845a378306377b1d57a67c98d62`
- GPT Reviewer (`gpt-5.6-sol`): LGTM — 0 findings (final pass)
- Gemini Reviewer (`gemini-3.1-pro-preview`): LGTM — 0 findings (final pass)
- Resolved: 4 fixed, 1 overridden
  - Overridden: mobile touch events might bypass activation — false positive; the virtual keyboard uses `click` (`web/virtual-keyboard.js:267`) and no touch/pointer handler suppresses that click.