### PR TITLE
Fix debugger bank aliases

### DIFF
--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -485,11 +485,11 @@ void VM::DoSoftSwitches(uint16_t address, bool write)
 	}
 }
 
-uint8_t VM::PeekData(uint16_t address) const
+MemoryReadMapping VM::GetMemoryReadMapping(uint16_t address) const
 {
-	if (address >= MM_BASIC_START && address <= MM_BASIC_END)
+	if (address >= MM_BASIC_START && address <= MM_BASIC_END && _basicbank)
 	{
-		return _basicbank ? _basic[address - MM_BASIC_START] : _data[address];
+		return MemoryReadMapping::BasicROM;
 	}
 
 	if (address >= MM_ROM_START && address <= MM_ROM_END && _bank_read)
@@ -497,10 +497,29 @@ uint8_t VM::PeekData(uint16_t address) const
 		if (address < 0xE000)
 		{
 			return _bank_page1
-				? _bank1_d000[address - 0xD000]
-				: _bank2_d000[address - 0xD000];
+				? MemoryReadMapping::LanguageCardBank1
+				: MemoryReadMapping::LanguageCardBank2;
 		}
+		return MemoryReadMapping::LanguageCardHigh;
+	}
+
+	return MemoryReadMapping::Primary;
+}
+
+uint8_t VM::PeekData(uint16_t address) const
+{
+	switch (GetMemoryReadMapping(address))
+	{
+	case MemoryReadMapping::BasicROM:
+		return _basic[address - MM_BASIC_START];
+	case MemoryReadMapping::LanguageCardBank1:
+		return _bank1_d000[address - 0xD000];
+	case MemoryReadMapping::LanguageCardBank2:
+		return _bank2_d000[address - 0xD000];
+	case MemoryReadMapping::LanguageCardHigh:
 		return _bank_e000[address - 0xE000];
+	default:
+		break;
 	}
 
 	return _data[address];
@@ -508,9 +527,12 @@ uint8_t VM::PeekData(uint16_t address) const
 
 bool VM::IsROMVisible(uint16_t address) const
 {
-	return (address >= MM_BASIC_START && address <= MM_BASIC_END && _basicbank)
+	const MemoryReadMapping mapping = GetMemoryReadMapping(address);
+	return (address >= MM_BASIC_START && address <= MM_BASIC_END
+			&& mapping == MemoryReadMapping::BasicROM)
 		|| (address >= MM_DISKROM_START && address <= MM_DISKROM_END)
-		|| (address >= MM_ROM_START && address <= MM_ROM_END && !_bank_read);
+		|| (address >= MM_ROM_START && address <= MM_ROM_END
+			&& mapping == MemoryReadMapping::Primary);
 }
 
 uint8_t VM::ReadData(uint16_t address)

--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -106,6 +106,18 @@ bool VM::IRQAsserted() const
 	return _acia->IRQAsserted() || _mockingboard->IRQAsserted();
 }
 
+bool VM::WillExecuteCurrentInstruction() const
+{
+	if (_cpu->stopped || _nmiPending)
+		return false;
+
+	const bool irq = IRQAsserted();
+	if (irq && !_cpu->flags.bits.I)
+		return false;
+
+	return !_cpu->waitForInterrupt || irq;
+}
+
 void VM::UpdateVIA1NMI()
 {
 	const bool asserted = _via1->IRQAsserted();

--- a/emulator/Badger6502VMLib/vm.cpp
+++ b/emulator/Badger6502VMLib/vm.cpp
@@ -485,6 +485,34 @@ void VM::DoSoftSwitches(uint16_t address, bool write)
 	}
 }
 
+uint8_t VM::PeekData(uint16_t address) const
+{
+	if (address >= MM_BASIC_START && address <= MM_BASIC_END)
+	{
+		return _basicbank ? _basic[address - MM_BASIC_START] : _data[address];
+	}
+
+	if (address >= MM_ROM_START && address <= MM_ROM_END && _bank_read)
+	{
+		if (address < 0xE000)
+		{
+			return _bank_page1
+				? _bank1_d000[address - 0xD000]
+				: _bank2_d000[address - 0xD000];
+		}
+		return _bank_e000[address - 0xE000];
+	}
+
+	return _data[address];
+}
+
+bool VM::IsROMVisible(uint16_t address) const
+{
+	return (address >= MM_BASIC_START && address <= MM_BASIC_END && _basicbank)
+		|| (address >= MM_DISKROM_START && address <= MM_DISKROM_END)
+		|| (address >= MM_ROM_START && address <= MM_ROM_END && !_bank_read);
+}
+
 uint8_t VM::ReadData(uint16_t address)
 {
 	uint8_t result = 0;
@@ -554,39 +582,11 @@ uint8_t VM::ReadData(uint16_t address)
 	}
 	else if (address >= MM_ROM_START && address <= MM_ROM_END)
 	{
-		if (_bank_read) // read RAM
-		{
-			if (address >= 0xD000 && address < 0xE000)
-			{
-				if (_bank_page1)
-				{
-					return _bank1_d000[address - 0xD000];
-				}
-				else
-				{
-					return _bank2_d000[address - 0xD000];
-				}
-			}
-			else if (address >= 0xE000 && address <= 0xFFFF)
-			{
-				return _bank_e000[address - 0xE000];
-			}
-		}
-		else
-		{
-			return _data[address];
-		}
+		return PeekData(address);
 	}
 	else if (address >= MM_BASIC_START && address <= MM_BASIC_END)
 	{
-		if (_basicbank)
-		{
-			return _basic[address - MM_BASIC_START];
-		}
-		else
-		{
-			return _data[address];
-		}
+		return PeekData(address);
 	}
 	else
 	{

--- a/emulator/Badger6502VMLib/vm.h
+++ b/emulator/Badger6502VMLib/vm.h
@@ -199,6 +199,8 @@ public:
 	uint8_t * GetData();
 	uint8_t * GetRomDisk();
 	uint8_t * GetBasicRom();
+	uint8_t PeekData(uint16_t address) const;
+	bool IsROMVisible(uint16_t address) const;
 
 private:
 	void Init();

--- a/emulator/Badger6502VMLib/vm.h
+++ b/emulator/Badger6502VMLib/vm.h
@@ -134,6 +134,16 @@ enum
 	MM_ROM_END			= 0xFFFF
 };
 
+enum class MemoryReadMapping : uint8_t
+{
+	Primary = 0,
+	BasicROM,
+	LanguageCardBank1,
+	LanguageCardBank2,
+	LanguageCardHigh,
+	Count
+};
+
 struct	CPU;
 class	ACIA;
 class	VIA;
@@ -199,6 +209,7 @@ public:
 	uint8_t * GetData();
 	uint8_t * GetRomDisk();
 	uint8_t * GetBasicRom();
+	MemoryReadMapping GetMemoryReadMapping(uint16_t address) const;
 	uint8_t PeekData(uint16_t address) const;
 	bool IsROMVisible(uint16_t address) const;
 

--- a/emulator/Badger6502VMLib/vm.h
+++ b/emulator/Badger6502VMLib/vm.h
@@ -151,6 +151,7 @@ public:
 	uint8_t Step();
 	void TickDevices(uint32_t cycles);
 	bool IRQAsserted() const;
+	bool WillExecuteCurrentInstruction() const;
 	void SignalVIA1Pin(VIA::Pins pin);
 	bool SetGamepadState(uint8_t controller, uint16_t pressedButtons);
 	CPU* GetCPU();

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -70,7 +70,10 @@ bridge uses this to clock the SD card and advance the drive).
   the shared level-sensitive IRQ line before the instruction and ticks the onboard VIA plus
   both Mockingboard VIA/AY pairs for every returned CPU cycle, then advances the VM-owned
   PCM sample clock. Presentation hosts may then advance host-owned keyboard/disk plumbing.
-  The blocking `VM::Run()` is not used by the web build.
+  `VM::WillExecuteCurrentInstruction()` reports whether the next step will execute the
+  opcode at the current PC rather than tick a dormant `WAI`/`STP` or service NMI/IRQ; the
+  web debugger uses that boundary without changing execution. The blocking `VM::Run()` is
+  not used by the web build.
 - `reset()` loads PC from `$FFFC/$FFFD`. ROM load recipe (mirrored by every host): write the
   first `0x10000` bytes of `badger6502.bin` into `GetData()`, `seedBasicRom()` (copy
   `$9000..$BFFF`), `loadFont()`, then `reset()`.
@@ -140,7 +143,7 @@ left/right AY) + framebuffer + serial + register state → host (native window o
 
 | Item | Status | Notes |
 |------|--------|-------|
-| 65C02 CPU + full ISA/addressing | Shipped | Covered by `Badger6502VMTest` (MSTest). |
+| 65C02 CPU + full ISA/addressing | Shipped | Covered by `Badger6502VMTest` (MSTest); instruction readiness is exposed for exact host debugger stops. |
 | Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract. |
 | Text / lo-res / hi-res video | Shipped | `badgervmpal`; color/fringe logic shared with hosts. |
 | Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -74,6 +74,10 @@ bridge uses this to clock the SD card and advance the drive).
   opcode at the current PC rather than tick a dormant `WAI`/`STP` or service NMI/IRQ; the
   web debugger uses that boundary without changing execution. The blocking `VM::Run()` is
   not used by the web build.
+- `VM::PeekData()` mirrors the currently selected BASIC and language-card read banks without
+  invoking memory-mapped device reads or soft-switch side effects. `VM::IsROMVisible()`
+  reports whether an address currently resolves to the BASIC ROM, Disk II boot ROM, or
+  upper ROM; debugger hosts use both for bank-correct opcode inspection and source labels.
 - `reset()` loads PC from `$FFFC/$FFFD`. ROM load recipe (mirrored by every host): write the
   first `0x10000` bytes of `badger6502.bin` into `GetData()`, `seedBasicRom()` (copy
   `$9000..$BFFF`), `loadFont()`, then `reset()`.
@@ -144,7 +148,7 @@ left/right AY) + framebuffer + serial + register state → host (native window o
 | Item | Status | Notes |
 |------|--------|-------|
 | 65C02 CPU + full ISA/addressing | Shipped | Covered by `Badger6502VMTest` (MSTest); instruction readiness is exposed for exact host debugger stops. |
-| Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract. |
+| Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract, including side-effect-free mapped inspection and ROM-visibility queries. |
 | Text / lo-res / hi-res video | Shipped | `badgervmpal`; color/fringe logic shared with hosts. |
 | Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |
 | VIA1 + bit-banged SPI micro-SD | Shipped | `via` + `MockMicroSD`. |

--- a/specs/EMULATOR.md
+++ b/specs/EMULATOR.md
@@ -74,10 +74,12 @@ bridge uses this to clock the SD card and advance the drive).
   opcode at the current PC rather than tick a dormant `WAI`/`STP` or service NMI/IRQ; the
   web debugger uses that boundary without changing execution. The blocking `VM::Run()` is
   not used by the web build.
-- `VM::PeekData()` mirrors the currently selected BASIC and language-card read banks without
-  invoking memory-mapped device reads or soft-switch side effects. `VM::IsROMVisible()`
-  reports whether an address currently resolves to the BASIC ROM, Disk II boot ROM, or
-  upper ROM; debugger hosts use both for bank-correct opcode inspection and source labels.
+- `VM::GetMemoryReadMapping()` identifies the backing store currently selected at an address
+  (primary 64K image, BASIC ROM, language-card bank 1/2, or shared language-card high RAM).
+  `VM::PeekData()` follows that mapping without invoking memory-mapped device reads or
+  soft-switch side effects. `VM::IsROMVisible()` reports whether an address currently
+  resolves to the BASIC ROM, Disk II boot ROM, or upper ROM; debugger hosts use these
+  queries for bank-correct breakpoints, opcode inspection, highlighting, and source labels.
 - `reset()` loads PC from `$FFFC/$FFFD`. ROM load recipe (mirrored by every host): write the
   first `0x10000` bytes of `badger6502.bin` into `GetData()`, `seedBasicRom()` (copy
   `$9000..$BFFF`), `loadFont()`, then `reset()`.
@@ -148,7 +150,7 @@ left/right AY) + framebuffer + serial + register state → host (native window o
 | Item | Status | Notes |
 |------|--------|-------|
 | 65C02 CPU + full ISA/addressing | Shipped | Covered by `Badger6502VMTest` (MSTest); instruction readiness is exposed for exact host debugger stops. |
-| Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract, including side-effect-free mapped inspection and ROM-visibility queries. |
+| Memory map + soft switches | Shipped | `vm.h` `MM_*`; the shared contract, including stable read-mapping identity, side-effect-free mapped inspection, and ROM-visibility queries. |
 | Text / lo-res / hi-res video | Shipped | `badgervmpal`; color/fringe logic shared with hosts. |
 | Keyboard + ACIA serial | Shipped | `$C000`/`$C010`; `PS2Keyboard`, `acia`. |
 | VIA1 + bit-banged SPI micro-SD | Shipped | `via` + `MockMicroSD`. |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -83,10 +83,11 @@ client-side so GitHub Pages can host it as static files.
   Breakpoint checks stay inside `WebVM`'s native instruction loop so normal-speed and Max
   execution do not cross the JS/WASM boundary once per instruction. The checked-in ca65
   `badger6502.dbg` is staged as a lazy-loaded data asset; while execution is outside the
-  assembled image, `debugger.js` correlates a ROM PC to an exact symbol and/or source
-  filename/line when that metadata exists. The ROM source text is not shipped in this
-  repository, so the browser identifies its listing coordinate rather than displaying the
-  original ROM source line.
+  assembled image, `debugger.js` correlates a PC in a read-only, ROM-binary-backed ca65
+  segment to an exact symbol and/or source filename/line when that metadata exists. RAM,
+  zero-page, and device-address equates are not treated as ROM locations. The ROM source
+  text is not shipped in this repository, so the browser identifies its listing coordinate
+  rather than displaying the original ROM source line.
 - **SD image:** `make_sd_sparse.py` streams `emulator/Data/sd.zip` (2 GB, mostly-zero FAT32)
   into `data/sd.sparse` (~11.5 MB `SDSP` container), fetched lazily.
 - **Gallery (`gallery.html` + `gallery.json`):** a lightweight, WASM-free showcase page that
@@ -192,7 +193,9 @@ client-side so GitHub Pages can host it as static files.
   breakpoint. Continue first steps past a breakpoint at the current PC so it cannot
   immediately retrigger. A PC held dormant by `WAI`/`STP` is not breakpoint-eligible until
   the CPU can execute there, so continuing a waiting machine cannot loop on the same stop.
-  Step-over enters an absolute `JSR` once, then runs to its
+  A masked IRQ that releases `WAI` makes the held PC breakpoint-eligible before its
+  instruction executes; pending NMI and unmasked IRQ service takes precedence over a
+  breakpoint on the interrupted PC. Step-over enters an absolute `JSR` once, then runs to its
   three-byte fall-through address using a temporary breakpoint; every other opcode behaves
   as step-into. Resetting or loading a program clears transient stop state but does not
   silently discard user breakpoints.
@@ -249,9 +252,9 @@ Boot Disk/Mount SD →
 insertDisk()/loadSD() → C600G / EC5CG`.
 
 Debugger: `asm6502 listing metadata → source/address rows → user breakpoint set → WebVM
-instruction-loop check → cooperative pause before PC → registers + raw peek memory + source
-row highlight`; outside the assembled image, `badger6502.dbg → debugger.js ca65 parser →
-ROM symbol/file:line`.
+instruction-readiness check → cooperative pause before executable PC → registers + raw peek
+memory + source row highlight`; outside the assembled image, `badger6502.dbg → debugger.js
+ROM-backed ca65-segment filter → ROM symbol/file:line`.
 
 Gallery: `gallery.html → fetch gallery.json → render cards → click Run & Remix →
 index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -27,8 +27,9 @@ client-side so GitHub Pages can host it as static files.
 - **Bridge API (embind, `web_bridge.cpp`):** `loadData(addr, bytes)`, `seedBasicRom()`,
   `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
   `runCycles(cycleBudget)`, `step()`, instruction-address breakpoint add/remove/clear/query
-  methods, `setPC`, raw `poke/peek`, bank-aware side-effect-free `peekMapped`, `romVisible`,
-  `keyDown(code)`, `drainOutput()` (serial),
+  methods plus mapping-qualified breakpoint insertion, `setPC`, raw `poke/peek`, bank-aware
+  side-effect-free `peekMapped`, `memoryMapping`, `romVisible`, `keyDown(code)`,
+  `drainOutput()` (serial),
   `setGamepadState(index, pressedMask)`,
   `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM:
   centered system speaker summed with hard-panned Mockingboard AY channels),
@@ -82,7 +83,10 @@ client-side so GitHub Pages can host it as static files.
   `JSR`, add an arbitrary hexadecimal PC breakpoint, inspect raw memory without triggering
   device side effects, and display the live register set already exposed by the bridge.
   Step-over decodes the opcode through the VM's current BASIC/language-card read mapping,
-  without invoking a bus read.
+  without invoking a bus read. Source rows capture the primary-image mapping selected after
+  program load; their breakpoints and current-row highlighting apply only while that same
+  backing store is visible. Temporary step-over return breakpoints likewise retain the
+  caller's mapping, while manually entered address breakpoints remain unconditional.
   Breakpoint checks stay inside `WebVM`'s native instruction loop so normal-speed and Max
   execution do not cross the JS/WASM boundary once per instruction. The checked-in ca65
   `badger6502.dbg` is staged as a lazy-loaded data asset; while execution is outside the
@@ -201,8 +205,12 @@ client-side so GitHub Pages can host it as static files.
   instruction executes; pending NMI and unmasked IRQ service takes precedence over a
   breakpoint on the interrupted PC. Step-over enters an absolute `JSR` once, then runs to its
   three-byte fall-through address using a temporary breakpoint; opcode recognition follows
-  the current bank mapping. Every other opcode behaves as step-into. Resetting or loading a
-  program clears transient stop state but does not silently discard user breakpoints.
+  the current bank mapping, and the temporary stop cannot trigger in an aliased bank. Every
+  other opcode behaves as step-into. Source breakpoints cannot trigger against BASIC ROM or
+  language-card RAM aliased over the assembled image. Resetting or loading a program clears
+  transient stop state but does not silently discard user breakpoints. A reset that re-seeds
+  the primary image unbinds source-line stops from the replaced bytes while retaining the
+  selected lines; loading the next assembled program binds those selections again.
 - Assets are relative so the site works under `/<repo>/` on Pages; the mandatory first-load
   payload is ~1.26 MB, with `disk.woz`/`sd.sparse` fetched only on demand.
 - **Share / Remix loop.** The editor's **Share** button copies a self-contained deep link
@@ -255,10 +263,12 @@ virtual-keyboard button→shared input queue→strobe-clear frame→keyDown()→
 Boot Disk/Mount SD →
 insertDisk()/loadSD() → C600G / EC5CG`.
 
-Debugger: `asm6502 listing metadata → source/address rows → user breakpoint set → WebVM
-instruction-readiness check → cooperative pause before executable PC → registers + raw peek
-memory + source row highlight`; outside the assembled image, `badger6502.dbg → debugger.js
-ROM-backed ca65-segment filter → ROM symbol/file:line`.
+Debugger: `asm6502 listing metadata → source/address rows + loaded read-mapping identity →
+user source breakpoint set → WebVM instruction-readiness + mapping check → cooperative pause
+before matching executable PC → registers + raw peek memory + mapping-qualified source row
+highlight`; manual PC breakpoints bypass the mapping qualifier. Outside the assembled image,
+`badger6502.dbg → debugger.js ROM-backed ca65-segment + current-ROM-visibility filter → ROM
+symbol/file:line`.
 
 Gallery: `gallery.html → fetch gallery.json → render cards → click Run & Remix →
 index.html?src=programs/<name>.s → Share/Remix loader assembles + runs`.
@@ -295,7 +305,7 @@ on the emulator whether it succeeds, is blocked, or 404s.
 | USB/Bluetooth gamepads | Shipped | Two stable player slots through the standard Gamepad API and shared SNES/VIA peripheral; covered by browser-mapping, serial-protocol, and ROM-table tests. |
 | Disk II WOZ boot + micro-SD DOS shell | Shipped | **Boot Disk** / **Mount SD** buttons. |
 | In-browser assembler (Assemble & Run) | Shipped | dual-use `asm6502.mjs`; ~11 samples; `?src=`. Sample sources fetched with `cache:"no-cache"` (revalidate) so a new deploy isn't masked by the browser cache. |
-| Source debugger | Shipped | Browser-assembled source listing with instruction breakpoints, pause/continue, step into/over, register and raw-memory inspection, plus lazy ca65 ROM symbol/file:line correlation; covered by `test_debugger.cjs`. |
+| Source debugger | Shipped | Browser-assembled source listing with bank-qualified instruction breakpoints/highlighting, pause/continue, bank-aware step into/over, register and raw-memory inspection, plus lazy ca65 ROM symbol/file:line correlation; covered by `test_debugger.cjs`. |
 | Program downloads (.PRG / .woz) | Shipped | **Download .PRG** (raw bytes) + **Download .woz** (bootable WOZ2 via `wozgen.mjs`, a port of `dsk2woz2`, with a multi-track boot loader); verified by `web/test_woz_download.cjs`. |
 | Share / Remix deep links | Shipped | **Share** button; `?src=programs/<name>.s` for unmodified samples, inline base64url `?code=` otherwise, both carrying `&org=` when the source has no `.org`; remix banner on shared links. |
 | Community Gallery | Shipped | `gallery.html` renders the curated `gallery.json`; one-click **Run & Remix** via `?src=`/`?code=`; PR-based submissions credited by author. |

--- a/specs/WEB-CLIENT.md
+++ b/specs/WEB-CLIENT.md
@@ -27,7 +27,8 @@ client-side so GitHub Pages can host it as static files.
 - **Bridge API (embind, `web_bridge.cpp`):** `loadData(addr, bytes)`, `seedBasicRom()`,
   `loadFont(bytes)`, `loadSD(bytes)`, `insertDisk(drive, bytes)`, `reset()`, `run(maxSteps)`,
   `runCycles(cycleBudget)`, `step()`, instruction-address breakpoint add/remove/clear/query
-  methods, `setPC`, `poke/peek`, `keyDown(code)`, `drainOutput()` (serial),
+  methods, `setPC`, raw `poke/peek`, bank-aware side-effect-free `peekMapped`, `romVisible`,
+  `keyDown(code)`, `drainOutput()` (serial),
   `setGamepadState(index, pressedMask)`,
   `enableAudio(sampleRate)`, `disableAudio()`, `drainAudio()` (interleaved Float32 stereo PCM:
   centered system speaker summed with hard-panned Mockingboard AY channels),
@@ -80,14 +81,17 @@ client-side so GitHub Pages can host it as static files.
   breakpoints. The debugger can pause/continue, step one instruction, step over an absolute
   `JSR`, add an arbitrary hexadecimal PC breakpoint, inspect raw memory without triggering
   device side effects, and display the live register set already exposed by the bridge.
+  Step-over decodes the opcode through the VM's current BASIC/language-card read mapping,
+  without invoking a bus read.
   Breakpoint checks stay inside `WebVM`'s native instruction loop so normal-speed and Max
   execution do not cross the JS/WASM boundary once per instruction. The checked-in ca65
   `badger6502.dbg` is staged as a lazy-loaded data asset; while execution is outside the
   assembled image, `debugger.js` correlates a PC in a read-only, ROM-binary-backed ca65
-  segment to an exact symbol and/or source filename/line when that metadata exists. RAM,
-  zero-page, and device-address equates are not treated as ROM locations. The ROM source
-  text is not shipped in this repository, so the browser identifies its listing coordinate
-  rather than displaying the original ROM source line.
+  segment to an exact symbol and/or source filename/line only while the VM reports that ROM
+  visible at the current address. RAM, zero-page, banked RAM, and device-address equates are
+  not treated as ROM locations. The ROM source text is not shipped in this repository, so
+  the browser identifies its listing coordinate rather than displaying the original ROM
+  source line.
 - **SD image:** `make_sd_sparse.py` streams `emulator/Data/sd.zip` (2 GB, mostly-zero FAT32)
   into `data/sd.sparse` (~11.5 MB `SDSP` container), fetched lazily.
 - **Gallery (`gallery.html` + `gallery.json`):** a lightweight, WASM-free showcase page that
@@ -196,9 +200,9 @@ client-side so GitHub Pages can host it as static files.
   A masked IRQ that releases `WAI` makes the held PC breakpoint-eligible before its
   instruction executes; pending NMI and unmasked IRQ service takes precedence over a
   breakpoint on the interrupted PC. Step-over enters an absolute `JSR` once, then runs to its
-  three-byte fall-through address using a temporary breakpoint; every other opcode behaves
-  as step-into. Resetting or loading a program clears transient stop state but does not
-  silently discard user breakpoints.
+  three-byte fall-through address using a temporary breakpoint; opcode recognition follows
+  the current bank mapping. Every other opcode behaves as step-into. Resetting or loading a
+  program clears transient stop state but does not silently discard user breakpoints.
 - Assets are relative so the site works under `/<repo>/` on Pages; the mandatory first-load
   payload is ~1.26 MB, with `disk.woz`/`sd.sparse` fetched only on demand.
 - **Share / Remix loop.** The editor's **Share** button copies a self-contained deep link

--- a/status/SYSTEM-STATUS.md
+++ b/status/SYSTEM-STATUS.md
@@ -89,9 +89,10 @@ secrets. Nothing to configure and nothing to commit. (The only "secret" is the s
   `asm6502.mjs` and runs it like `BRUN`; ships ~11 sample programs; deep-linkable via `?src=`.
   Exports the assembled program as a raw **.PRG** or a bootable **.woz** disk image
   (`wozgen.mjs`, a JS port of `dsk2woz2` with a multi-track boot loader) that boots via `C600G`.
-- **Browser debugger:** source-correlated instruction breakpoints for assembled programs,
-  pause/continue, step into/over, live registers, raw-memory inspection, arbitrary PC
-  breakpoints, and lazy ROM symbol/source-file:line correlation from `badger6502.dbg`.
+- **Browser debugger:** bank-qualified, source-correlated instruction breakpoints and
+  highlighting for assembled programs, pause/continue, bank-aware step into/over, live
+  registers, raw-memory inspection, unconditional arbitrary-PC breakpoints, and lazy ROM
+  symbol/source-file:line correlation from `badger6502.dbg`.
 - **Disk gap:** DOS 3.3 / Quick-DOS and games that chain through an Applesoft auto-run
   greeting don't run — this clone's `$E000` BASIC is generic Microsoft BASIC, not Applesoft.
   Self-booting machine-code disks work.

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -13,7 +13,17 @@
       line: record.line,
       kind: record.kind,
       source: sourceLines[record.line - 1] || "",
+      mapping: null,
     }));
+  }
+
+  function bindSourceMappings(rows, mappingForAddress) {
+    for (const row of rows) row.mapping = mappingForAddress(row.address);
+    return rows;
+  }
+
+  function isSourceRowActive(row, mapping) {
+    return Boolean(row) && row.mapping != null && row.mapping === mapping;
   }
 
   function stepOverTarget(address, opcode) {
@@ -167,5 +177,12 @@
     return { lookup };
   }
 
-  return { buildSourceListing, lookupRomLocation, parseCa65Debug, stepOverTarget };
+  return {
+    bindSourceMappings,
+    buildSourceListing,
+    isSourceRowActive,
+    lookupRomLocation,
+    parseCa65Debug,
+    stepOverTarget,
+  };
 });

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -64,7 +64,11 @@
       if (tag === "file") {
         files.set(decimal(fields.id), fields.name);
       } else if (tag === "seg") {
-        segments.set(decimal(fields.id), { start: hexadecimal(fields.start) });
+        segments.set(decimal(fields.id), {
+          start: hexadecimal(fields.start),
+          size: hexadecimal(fields.size) || 0,
+          romBacked: fields.type === "ro" && Boolean(fields.oname),
+        });
       } else if (tag === "span") {
         spans.set(decimal(fields.id), {
           segment: decimal(fields.seg),
@@ -90,6 +94,15 @@
       }
     }
 
+    const romAddresses = new Uint8Array(0x10000);
+    for (const segment of segments.values()) {
+      if (!segment.romBacked || segment.start == null || segment.size <= 0) continue;
+      const end = Math.min(segment.start + segment.size, 0x10000);
+      for (let address = Math.max(segment.start, 0); address < end; address++) {
+        romAddresses[address] = 1;
+      }
+    }
+
     const locations = new Array(0x10000);
     for (const line of lines.values()) {
       const file = files.get(line.file) || null;
@@ -97,12 +110,12 @@
       for (const spanId of line.spans) {
         const span = spans.get(spanId);
         const segment = span && segments.get(span.segment);
-        if (!span || !segment || segment.start == null) continue;
+        if (!span || !segment || !segment.romBacked || segment.start == null) continue;
         const start = segment.start + span.start;
         const location = { file, line: line.line };
         for (let offset = 0; offset < span.size; offset++) {
           const address = start + offset;
-          if (address < 0 || address > 0xFFFF) continue;
+          if (address < 0 || address > 0xFFFF || !romAddresses[address]) continue;
           const current = locations[address];
           if (!current || priority > current.priority) {
             locations[address] = { ...location, priority };
@@ -113,7 +126,8 @@
 
     const symbols = new Array(0x10000);
     for (const raw of rawSymbols) {
-      if (raw.address == null || raw.address < 0 || raw.address > 0xFFFF) continue;
+      if (raw.address == null || raw.address < 0 || raw.address > 0xFFFF
+          || !romAddresses[raw.address]) continue;
       const definition = raw.def == null ? null : lines.get(raw.def);
       const symbol = {
         address: raw.address,
@@ -127,7 +141,8 @@
     }
 
     function lookup(address) {
-      if (!Number.isInteger(address) || address < 0 || address > 0xFFFF) return null;
+      if (!Number.isInteger(address) || address < 0 || address > 0xFFFF
+          || !romAddresses[address]) return null;
       const location = locations[address];
       const symbol = symbols[address];
       return {

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -16,6 +16,14 @@
     }));
   }
 
+  function stepOverTarget(address, opcode) {
+    return opcode === 0x20 ? (address + 3) & 0xFFFF : null;
+  }
+
+  function lookupRomLocation(debugMap, address, romVisible) {
+    return debugMap && romVisible ? debugMap.lookup(address) : null;
+  }
+
   function parsePairs(text) {
     const pairs = Object.create(null);
     const pattern = /([A-Za-z][A-Za-z0-9_]*)=("(?:[^"\\]|\\.)*"|[^,]*)/g;
@@ -159,5 +167,5 @@
     return { lookup };
   }
 
-  return { buildSourceListing, parseCa65Debug };
+  return { buildSourceListing, lookupRomLocation, parseCa65Debug, stepOverTarget };
 });

--- a/web/index.html
+++ b/web/index.html
@@ -932,7 +932,8 @@
       }
 
       function formatRomLocation(address) {
-        const info = romDebug && romDebug.lookup(address);
+        const info = BadgerDebugger.lookupRomLocation(
+          romDebug, address, vm.romVisible(address));
         if (!info) return `$${hex(address, 4)} (outside assembled source)`;
         const parts = [`$${hex(address, 4)}`];
         if (info.symbol) parts.push(info.symbol.name);
@@ -997,12 +998,13 @@
       overBtn.addEventListener("click", () => {
         removeTemporaryBreakpoint();
         const address = vm.pc() & 0xFFFF;
-        if (vm.peek(address) !== 0x20) {
+        const returnAddress = BadgerDebugger.stepOverTarget(
+          address, vm.peekMapped(address));
+        if (returnAddress == null) {
           vm.step();
           setPaused(true, "step");
           return;
         }
-        const returnAddress = (address + 3) & 0xFFFF;
         vm.step();
         temporaryBreakpoint = returnAddress;
         syncBreakpoints();

--- a/web/index.html
+++ b/web/index.html
@@ -772,13 +772,14 @@
 
       const manualBreakpoints = new Set();
       const sourceBreakpointLines = new Set();
-      const sourceBreakpoints = new Set();
+      const sourceBreakpoints = new Map();
       let rows = [];
       let rowElements = new Map();
       let paused = false;
       let suspended = false;
       let temporaryBreakpoint = null;
       let currentAddress = -1;
+      let currentMapping = -1;
       let memoryDirty = true;
       let romDebug = null;
       let romDebugLoading = null;
@@ -791,14 +792,15 @@
       function rebuildSourceBreakpoints() {
         sourceBreakpoints.clear();
         for (const row of rows) {
-          if (row.kind === "instruction" && sourceBreakpointLines.has(row.line)) {
-            sourceBreakpoints.add(row.address);
+          if (row.kind === "instruction" && row.mapping != null &&
+              sourceBreakpointLines.has(row.line)) {
+            sourceBreakpoints.set(row.address, row.mapping);
           }
         }
       }
 
       function allBreakpointAddresses() {
-        return new Set([...manualBreakpoints, ...sourceBreakpoints]);
+        return new Set([...manualBreakpoints, ...sourceBreakpoints.keys()]);
       }
 
       function renderBreakpointSummary() {
@@ -822,8 +824,14 @@
         vm.clearBreakpoints();
         rebuildSourceBreakpoints();
         if (!suspended) {
-          for (const address of allBreakpointAddresses()) vm.addBreakpoint(address);
-          if (temporaryBreakpoint != null) vm.addBreakpoint(temporaryBreakpoint);
+          for (const address of manualBreakpoints) vm.addBreakpoint(address);
+          for (const [address, mapping] of sourceBreakpoints) {
+            vm.addMappedBreakpoint(address, mapping);
+          }
+          if (temporaryBreakpoint != null) {
+            vm.addMappedBreakpoint(
+              temporaryBreakpoint.address, temporaryBreakpoint.mapping);
+          }
         }
         refreshBreakpointRows();
         renderBreakpointSummary();
@@ -946,12 +954,14 @@
 
       function refresh(force = false) {
         const address = vm.pc() & 0xFFFF;
-        if (force || address !== currentAddress) {
+        const mapping = vm.memoryMapping(address);
+        if (force || address !== currentAddress || mapping !== currentMapping) {
           const previous = rowElements.get(currentAddress);
           if (previous) previous.element.classList.remove("current");
           currentAddress = address;
+          currentMapping = mapping;
           const current = rowElements.get(address);
-          if (current) {
+          if (current && BadgerDebugger.isSourceRowActive(current.row, mapping)) {
             current.element.classList.add("current");
             locationEl.textContent =
               `$${hex(address, 4)}  assembled source line ${current.row.line}: ${current.row.source.trim()}`;
@@ -1005,8 +1015,9 @@
           setPaused(true, "step");
           return;
         }
+        const returnMapping = vm.memoryMapping(returnAddress);
         vm.step();
-        temporaryBreakpoint = returnAddress;
+        temporaryBreakpoint = { address: returnAddress, mapping: returnMapping };
         syncBreakpoints();
         setPaused(false, `step over to $${hex(returnAddress, 4)}`);
       });
@@ -1055,13 +1066,20 @@
         isPaused: () => paused,
         onBreakpoint() {
           const address = vm.pc() & 0xFFFF;
-          if (temporaryBreakpoint === address) removeTemporaryBreakpoint();
+          if (temporaryBreakpoint != null &&
+              temporaryBreakpoint.address === address &&
+              temporaryBreakpoint.mapping === vm.memoryMapping(address)) {
+            removeTemporaryBreakpoint();
+          }
           detailsEl.open = true;
           setPaused(true, `breakpoint $${hex(address, 4)}`);
         },
         onMachineReset() {
           temporaryBreakpoint = null;
-          if (!suspended) syncBreakpoints();
+          if (!suspended) {
+            BadgerDebugger.bindSourceMappings(rows, () => null);
+            syncBreakpoints();
+          }
           setPaused(false, "running");
         },
         beginProgramLoad() {
@@ -1071,6 +1089,8 @@
           setPaused(false, "loading");
         },
         endProgramLoad() {
+          BadgerDebugger.bindSourceMappings(
+            rows, (address) => vm.memoryMapping(address));
           suspended = false;
           syncBreakpoints();
           setPaused(false, "running");

--- a/web/test_debugger.cjs
+++ b/web/test_debugger.cjs
@@ -38,6 +38,9 @@ function check(name, condition, detail = "") {
   check("ROM debug resolves COUT source coordinate",
     cout && cout.symbol && cout.symbol.file === "apple2rom.s" && cout.symbol.line === 1058,
     JSON.stringify(cout));
+  check("ROM debug excludes RAM symbols", romDebug.lookup(0x0800) === null);
+  check("ROM debug excludes zero-page source", romDebug.lookup(0x0036) === null);
+  check("ROM debug excludes device equates", romDebug.lookup(0xC100) === null);
 
   const Module = await createBadgerVM();
   const vm = new Module.WebVM();
@@ -75,8 +78,12 @@ function check(name, condition, detail = "") {
   check("clear removes all breakpoints",
     !vm.hasBreakpoint(0x0802) && !vm.hasBreakpoint(0x0808) && !vm.breakpointHit());
 
+  vm.reset();
   vm.poke(0x0900, 0xCB); // WAI
-  vm.poke(0x0901, 0xEA); // NOP after the interrupt wakes the CPU
+  vm.poke(0x0901, 0xEE); // INC $2001 after the interrupt wakes the CPU
+  vm.poke(0x0902, 0x01);
+  vm.poke(0x0903, 0x20);
+  vm.poke(0x2001, 0);
   vm.setPC(0x0900);
   vm.step();
   vm.addBreakpoint(0x0901);
@@ -84,6 +91,19 @@ function check(name, condition, detail = "") {
   check("dormant WAI PC does not retrigger breakpoint",
     waitCycles >= 20 && vm.waiting() && vm.pc() === 0x0901 && !vm.breakpointHit(),
     `cycles=${waitCycles} pc=${vm.pc().toString(16)}`);
+
+  vm.writeBus(0xC40E, 0xC0); // Enable Mockingboard VIA Timer 1 IRQ.
+  vm.writeBus(0xC404, 1);
+  vm.writeBus(0xC405, 0);
+  const wakeCycles = vm.runCycles(20);
+  check("masked IRQ wakes WAI into breakpoint before instruction",
+    wakeCycles < 20 && vm.waiting() && vm.breakpointHit()
+      && vm.pc() === 0x0901 && vm.peek(0x2001) === 0,
+    `cycles=${wakeCycles} pc=${vm.pc().toString(16)} value=${vm.peek(0x2001)}`);
+
+  vm.step();
+  check("step executes instruction after masked-IRQ breakpoint",
+    !vm.waiting() && !vm.breakpointHit() && vm.pc() === 0x0904 && vm.peek(0x2001) === 1);
 
   vm.delete();
   console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILED`);

--- a/web/test_debugger.cjs
+++ b/web/test_debugger.cjs
@@ -2,7 +2,9 @@ const fs = require("fs");
 const path = require("path");
 const createBadgerVM = require("./badger6502.js");
 const {
+  bindSourceMappings,
   buildSourceListing,
+  isSourceRowActive,
   lookupRomLocation,
   parseCa65Debug,
   stepOverTarget,
@@ -32,6 +34,8 @@ function check(name, condition, detail = "") {
     listing[1].address === 0x0802 && listing[1].line === 3 && listing[1].source.includes("jsr sub"));
   check("source listing marks executable rows",
     listing.every((row) => row.kind === "instruction"));
+  check("source listing starts unbound",
+    listing.every((row) => row.mapping === null));
 
   const debugText = fs.readFileSync(
     path.join(__dirname, "..", "emulator", "Data", "badger6502.dbg"), "utf8");
@@ -49,6 +53,12 @@ function check(name, condition, detail = "") {
 
   const Module = await createBadgerVM();
   const vm = new Module.WebVM();
+  bindSourceMappings(listing, (address) => vm.memoryMapping(address));
+  check("source listing binds loaded memory mapping",
+    isSourceRowActive(listing[0], vm.memoryMapping(listing[0].address)));
+  bindSourceMappings(listing, () => null);
+  check("source listing unbinds when its image is replaced",
+    !isSourceRowActive(listing[0], vm.memoryMapping(listing[0].address)));
 
   vm.poke(0x9000, 0x20);
   vm.seedBasicRom();
@@ -62,10 +72,37 @@ function check(name, condition, detail = "") {
     vm.romVisible(0x9000) && lookupRomLocation(romDebug, 0x9000, vm.romVisible(0x9000)));
 
   vm.writeBus(0xC007, 0);
+  const basicProgramMapping = vm.memoryMapping(0x9000);
   check("mapped peek sees BASIC RAM opcode",
     vm.peekMapped(0x9000) === 0xEA && !vm.romVisible(0x9000));
   check("ROM correlation hides banked BASIC RAM",
     lookupRomLocation(romDebug, 0x9000, vm.romVisible(0x9000)) === null);
+
+  vm.clearBreakpoints();
+  check("rejects invalid mapped breakpoint",
+    !vm.addMappedBreakpoint(0x9000, -1));
+  check("adds mapping-qualified breakpoint",
+    vm.addMappedBreakpoint(0x9000, basicProgramMapping));
+  vm.writeBus(0xC006, 0);
+  vm.setPC(0x9000);
+  const aliasedBasicCycles = vm.run(1);
+  check("source breakpoint ignores aliased BASIC ROM",
+    aliasedBasicCycles > 0 && !vm.breakpointHit());
+  check("source highlighting ignores aliased BASIC ROM",
+    !isSourceRowActive({ mapping: basicProgramMapping }, vm.memoryMapping(0x9000)));
+  vm.addBreakpoint(0x9000);
+  vm.setPC(0x9000);
+  const manualBasicCycles = vm.run(1);
+  check("manual breakpoint remains unconditional over source qualifier",
+    manualBasicCycles === 0 && vm.breakpointHit());
+  vm.removeBreakpoint(0x9000);
+  vm.addMappedBreakpoint(0x9000, basicProgramMapping);
+  vm.writeBus(0xC007, 0);
+  vm.setPC(0x9000);
+  const primaryBasicCycles = vm.run(1);
+  check("source breakpoint returns with BASIC RAM",
+    primaryBasicCycles === 0 && vm.breakpointHit());
+  vm.clearBreakpoints();
 
   vm.poke(0xD000, 0xEA);
   vm.writeBus(0xC083, 0);
@@ -80,10 +117,24 @@ function check(name, condition, detail = "") {
       && lookupRomLocation(romDebug, 0xD000, vm.romVisible(0xD000)) === null);
 
   vm.writeBus(0xC082, 0);
+  const upperProgramMapping = vm.memoryMapping(0xD000);
   check("mapped peek restores upper ROM opcode",
     vm.peekMapped(0xD000) === 0xEA && vm.romVisible(0xD000));
   check("ROM correlation follows visible upper ROM",
     lookupRomLocation(romDebug, 0xD000, vm.romVisible(0xD000)) !== null);
+
+  vm.addMappedBreakpoint(0xD000, upperProgramMapping);
+  vm.writeBus(0xC080, 0);
+  vm.setPC(0xD000);
+  const aliasedUpperCycles = vm.run(1);
+  check("source breakpoint ignores aliased language-card RAM",
+    aliasedUpperCycles > 0 && !vm.breakpointHit());
+  vm.writeBus(0xC082, 0);
+  vm.setPC(0xD000);
+  const primaryUpperCycles = vm.run(1);
+  check("source breakpoint returns with upper image",
+    primaryUpperCycles === 0 && vm.breakpointHit());
+  vm.clearBreakpoints();
 
   vm.loadData(assembled.org, assembled.bytes);
   vm.poke(0xFFFC, 0x00);

--- a/web/test_debugger.cjs
+++ b/web/test_debugger.cjs
@@ -1,7 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 const createBadgerVM = require("./badger6502.js");
-const { buildSourceListing, parseCa65Debug } = require("./debugger.js");
+const {
+  buildSourceListing,
+  lookupRomLocation,
+  parseCa65Debug,
+  stepOverTarget,
+} = require("./debugger.js");
 
 let failures = 0;
 function check(name, condition, detail = "") {
@@ -44,6 +49,42 @@ function check(name, condition, detail = "") {
 
   const Module = await createBadgerVM();
   const vm = new Module.WebVM();
+
+  vm.poke(0x9000, 0x20);
+  vm.seedBasicRom();
+  vm.poke(0x9000, 0xEA);
+  vm.writeBus(0xC006, 0);
+  check("mapped peek sees BASIC ROM opcode",
+    vm.peek(0x9000) === 0xEA && vm.peekMapped(0x9000) === 0x20);
+  check("step-over recognizes BASIC ROM JSR",
+    stepOverTarget(0x9000, vm.peekMapped(0x9000)) === 0x9003);
+  check("ROM correlation follows visible BASIC bank",
+    vm.romVisible(0x9000) && lookupRomLocation(romDebug, 0x9000, vm.romVisible(0x9000)));
+
+  vm.writeBus(0xC007, 0);
+  check("mapped peek sees BASIC RAM opcode",
+    vm.peekMapped(0x9000) === 0xEA && !vm.romVisible(0x9000));
+  check("ROM correlation hides banked BASIC RAM",
+    lookupRomLocation(romDebug, 0x9000, vm.romVisible(0x9000)) === null);
+
+  vm.poke(0xD000, 0xEA);
+  vm.writeBus(0xC083, 0);
+  vm.writeBus(0xC083, 0);
+  vm.writeBus(0xD000, 0x20);
+  check("mapped peek sees language-card RAM opcode",
+    vm.peek(0xD000) === 0xEA && vm.peekMapped(0xD000) === 0x20);
+  check("step-over recognizes language-card RAM JSR",
+    stepOverTarget(0xD000, vm.peekMapped(0xD000)) === 0xD003);
+  check("ROM correlation hides language-card RAM",
+    !vm.romVisible(0xD000)
+      && lookupRomLocation(romDebug, 0xD000, vm.romVisible(0xD000)) === null);
+
+  vm.writeBus(0xC082, 0);
+  check("mapped peek restores upper ROM opcode",
+    vm.peekMapped(0xD000) === 0xEA && vm.romVisible(0xD000));
+  check("ROM correlation follows visible upper ROM",
+    lookupRomLocation(romDebug, 0xD000, vm.romVisible(0xD000)) !== null);
+
   vm.loadData(assembled.org, assembled.bytes);
   vm.poke(0xFFFC, 0x00);
   vm.poke(0xFFFD, 0x08);

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -286,7 +286,19 @@ public:
     bool addBreakpoint(int addr)
     {
         if (addr < 0 || addr > 0xFFFF) return false;
-        _breakpoints[(size_t)addr] = 1;
+        _breakpoints[(size_t)addr] |= BREAKPOINT_UNCONDITIONAL;
+        return true;
+    }
+
+    bool addMappedBreakpoint(int addr, int mapping)
+    {
+        if (addr < 0 || addr > 0xFFFF
+            || mapping < 0 || mapping >= (int)MemoryReadMapping::Count)
+        {
+            return false;
+        }
+        _breakpoints[(size_t)addr] |=
+            (uint8_t)(1u << ((unsigned int)mapping + 1u));
         return true;
     }
 
@@ -367,6 +379,11 @@ public:
     void poke(int addr, int value) { _vm->GetData()[addr & 0xFFFF] = (uint8_t)(value & 0xFF); }
     int  peek(int addr)            { return _vm->GetData()[addr & 0xFFFF]; }
     int  peekMapped(int addr)      { return _vm->PeekData((uint16_t)(addr & 0xFFFF)); }
+    int  memoryMapping(int addr)
+    {
+        if (addr < 0 || addr > 0xFFFF) return -1;
+        return (int)_vm->GetMemoryReadMapping((uint16_t)addr);
+    }
     bool romVisible(int addr)
     {
         return addr >= 0 && addr <= 0xFFFF && _vm->IsROMVisible((uint16_t)addr);
@@ -463,8 +480,13 @@ private:
     bool breakpointAtPC()
     {
         CPU* cpu = _vm->GetCPU();
-        if (_breakpoints[(size_t)cpu->PC] == 0) return false;
-        return _vm->WillExecuteCurrentInstruction();
+        const uint8_t configured = _breakpoints[(size_t)cpu->PC];
+        if (configured == 0 || !_vm->WillExecuteCurrentInstruction()) return false;
+        if (configured & BREAKPOINT_UNCONDITIONAL) return true;
+
+        const unsigned int mapping =
+            (unsigned int)_vm->GetMemoryReadMapping(cpu->PC);
+        return (configured & (uint8_t)(1u << (mapping + 1u))) != 0;
     }
 
     int stepOnce()
@@ -626,6 +648,7 @@ private:
 
     uint64_t _cycles        = 0;
     uint64_t _lastDiskCycle = 0;
+    static constexpr uint8_t BREAKPOINT_UNCONDITIONAL = 0x01;
     std::array<uint8_t, 0x10000> _breakpoints = {};
     bool _breakpointHit = false;
 
@@ -649,6 +672,7 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("runCycles",    &WebVM::runCycles)
         .function("step",         &WebVM::step)
         .function("addBreakpoint", &WebVM::addBreakpoint)
+        .function("addMappedBreakpoint", &WebVM::addMappedBreakpoint)
         .function("removeBreakpoint", &WebVM::removeBreakpoint)
         .function("clearBreakpoints", &WebVM::clearBreakpoints)
         .function("hasBreakpoint", &WebVM::hasBreakpoint)
@@ -663,6 +687,7 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("poke",         &WebVM::poke)
         .function("peek",         &WebVM::peek)
         .function("peekMapped",   &WebVM::peekMapped)
+        .function("memoryMapping", &WebVM::memoryMapping)
         .function("romVisible",   &WebVM::romVisible)
         .function("readBus",      &WebVM::readBus)
         .function("writeBus",     &WebVM::writeBus)

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -458,8 +458,8 @@ private:
     bool breakpointAtPC()
     {
         CPU* cpu = _vm->GetCPU();
-        if (cpu->waitForInterrupt || cpu->stopped) return false;
-        return _breakpoints[(size_t)cpu->PC] != 0;
+        if (_breakpoints[(size_t)cpu->PC] == 0) return false;
+        return _vm->WillExecuteCurrentInstruction();
     }
 
     int stepOnce()

--- a/web/web_bridge.cpp
+++ b/web/web_bridge.cpp
@@ -366,6 +366,11 @@ public:
 
     void poke(int addr, int value) { _vm->GetData()[addr & 0xFFFF] = (uint8_t)(value & 0xFF); }
     int  peek(int addr)            { return _vm->GetData()[addr & 0xFFFF]; }
+    int  peekMapped(int addr)      { return _vm->PeekData((uint16_t)(addr & 0xFFFF)); }
+    bool romVisible(int addr)
+    {
+        return addr >= 0 && addr <= 0xFFFF && _vm->IsROMVisible((uint16_t)addr);
+    }
 
     // Bus-level access that runs through the full memory map (soft switches,
     // ACIA/VIA, Disk II, language-card banking). Use this to drive
@@ -657,6 +662,8 @@ EMSCRIPTEN_BINDINGS(badger6502)
         .function("setGamepadState", &WebVM::setGamepadState)
         .function("poke",         &WebVM::poke)
         .function("peek",         &WebVM::peek)
+        .function("peekMapped",   &WebVM::peekMapped)
+        .function("romVisible",   &WebVM::romVisible)
         .function("readBus",      &WebVM::readBus)
         .function("writeBus",     &WebVM::writeBus)
         .function("setPC",        &WebVM::setPC)


### PR DESCRIPTION
## Summary
- honor source breakpoints when a masked IRQ releases `WAI`, without retriggering dormant wait PCs
- restrict ca65 correlation to visible ROM-backed segments and decode Step Over through the active BASIC/language-card bank
- qualify source highlighting, source breakpoints, and temporary Step Over stops by the loaded memory mapping while keeping manual PC breakpoints unconditional
- unbind source stops when Reset replaces the loaded image, retaining line selections for the next program load

## Validation
- WebAssembly build (`web/build.ps1`)
- native `Badger6502VMTest`: 199 passed
- assembler, debugger, boot, and Mockingboard browser gates
- pre-push assembler and boot gates

## Second-model review
- Reviewed diff: `d10107b4455cc9a8360806ca98388ee2f6739f3f...8d576fcf8b2d2d6d340c1841d413ae10aa361716`
- GPT Reviewer (`gpt-5.6-sol`): LGTM — 0 findings
- Gemini Reviewer (`gemini-3.1-pro-preview`): LGTM — 0 findings
- Resolved: 0 fixed, 0 overridden